### PR TITLE
refactor: remove password persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # soho_ui_react
 
+## Authentication
 
+This project uses token-based authentication. User passwords are **never** stored in
+browser storage. When the "remember me" option is enabled, only non-sensitive
+information such as the username may be stored locally.
 
 ## Getting started
 

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -48,27 +48,22 @@ export default function LoginPage() {
 
   const rememberMe = watch('rememberMe');
   const username = watch('username');
-  const password = watch('password');
 
   useEffect(() => {
     const savedUsername = localStorage.getItem('savedUsername');
-    const savedPassword = sessionStorage.getItem('savedPassword');
-    if (savedUsername) setValue('username', savedUsername);
-    if (savedPassword) setValue('password', savedPassword);
-    if (savedUsername || savedPassword) {
+    if (savedUsername) {
+      setValue('username', savedUsername);
       setValue('rememberMe', true);
     }
   }, [setValue]);
 
   useEffect(() => {
-    if (rememberMe) {
-      if (username) localStorage.setItem('savedUsername', username);
-      if (password) sessionStorage.setItem('savedPassword', password);
+    if (rememberMe && username) {
+      localStorage.setItem('savedUsername', username);
     } else {
       localStorage.removeItem('savedUsername');
-      sessionStorage.removeItem('savedPassword');
     }
-  }, [rememberMe, username, password]);
+  }, [rememberMe, username]);
 
   const onSubmit = (data: LoginFormData) => {
     login(


### PR DESCRIPTION
## Summary
- avoid storing passwords in sessionStorage; only keep username when remembering credentials
- document token-based authentication and username-only storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b68b9a34a0832aa6dd3f2cab198950