### PR TITLE
Memoize auth context value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+soho/node_modules/
+dist/

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,6 +4,8 @@ import React, {
   useContext,
   useEffect,
   useState,
+  useCallback,
+  useMemo,
 } from 'react';
 
 interface AuthContextType {
@@ -42,24 +44,27 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   }, []);
 
-  const loginAction = (token: string, username: string) => {
+  const loginAction = useCallback((token: string, username: string) => {
     localStorage.setItem('authToken', token);
     sessionStorage.setItem('username', username);
     setIsAuthenticated(true);
     setUsername(username);
-  };
+  }, []);
 
-  const logout = () => {
+  const logout = useCallback(() => {
     localStorage.removeItem('authToken');
     sessionStorage.removeItem('username');
     setIsAuthenticated(false);
     setUsername(null);
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({ isAuthenticated, loginAction, logout, username }),
+    [isAuthenticated, loginAction, logout, username],
+  );
 
   return (
-    <AuthContext.Provider
-      value={{ isAuthenticated, loginAction, logout, username }}
-    >
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- memoize auth context provider value to avoid unnecessary re-renders
- stabilize login and logout functions with `useCallback`
- add gitignore for node_modules and build output

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components in ThemeContext.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b68b9b8ab0832a9f6f294925da9d0d