### PR TITLE
Persist username in local storage

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -36,7 +36,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   useEffect(() => {
     // Check if user is already logged in on app initialization
     const token = localStorage.getItem('authToken');
-    const savedUsername = sessionStorage.getItem('username');
+    const savedUsername = localStorage.getItem('username');
 
     if (token) {
       setIsAuthenticated(true);
@@ -46,14 +46,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const loginAction = useCallback((token: string, username: string) => {
     localStorage.setItem('authToken', token);
-    sessionStorage.setItem('username', username);
+    localStorage.setItem('username', username);
     setIsAuthenticated(true);
     setUsername(username);
   }, []);
 
   const logout = useCallback(() => {
     localStorage.removeItem('authToken');
-    sessionStorage.removeItem('username');
+    localStorage.removeItem('username');
     setIsAuthenticated(false);
     setUsername(null);
   }, []);


### PR DESCRIPTION
## Summary
- Read stored username from localStorage on initialization instead of sessionStorage
- Save username in localStorage during login and clear it on logout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-refresh/only-export-components)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b694a65954832ab16085b71df1ecb8