### PR TITLE
refactor: remove unused mutation handlers in login hook

### DIFF
--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -24,7 +24,5 @@ const loginApi = async ({
 export const useLogin = () => {
   return useMutation<LoginResponse, Error, LoginPayload>({
     mutationFn: loginApi,
-    onSuccess: () => {},
-    onError: () => {},
   });
 };


### PR DESCRIPTION
## Summary
- remove no-op onSuccess/onError handlers from `useLogin`

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint src/hooks/useLogin.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b695a2ff08832a963d4bf62acdc03f