### PR TITLE
chore: update font paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^22.8.6",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -2119,6 +2120,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -5068,6 +5079,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "@types/node": "^22.8.6"
   }
 }

--- a/soho/package-lock.json
+++ b/soho/package-lock.json
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^22.8.6",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -2119,6 +2120,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -5068,6 +5079,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/soho/package.json
+++ b/soho/package.json
@@ -48,6 +48,7 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "@types/node": "^22.8.6"
   }
 }

--- a/soho/src/index.css
+++ b/soho/src/index.css
@@ -1,12 +1,12 @@
 @import "tailwindcss";
 @import 'vazirmatn/Vazirmatn-font-face.css';
-@import "../public/fonts/Vazir/font-face-UI.css";
+@import "/fonts/Vazir/font-face-UI.css";
 
 @font-face {
     font-family: 'Didot';
     font-weight: 100 900;
     font-display: swap;
-    src: url(../public/fonts/GFSDidot-Regular.ttf) format('truetype');
+    src: url("/fonts/GFSDidot-Regular.ttf") format('truetype');
 }
 
 :root {

--- a/soho/vite.config.ts
+++ b/soho/vite.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '/fonts': path.resolve(__dirname, 'public/fonts'),
+    },
+  },
 })

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,12 @@
 @import "tailwindcss";
 @import 'vazirmatn/Vazirmatn-font-face.css';
-@import "../public/fonts/Vazir/font-face-UI.css";
+@import "/fonts/Vazir/font-face-UI.css";
 
 @font-face {
     font-family: 'Didot';
     font-weight: 100 900;
     font-display: swap;
-    src: url(../public/fonts/GFSDidot-Regular.ttf) format('truetype');
+    src: url("/fonts/GFSDidot-Regular.ttf") format('truetype');
 }
 
 :root {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '/fonts': path.resolve(__dirname, 'public/fonts'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- reference fonts with root-relative paths
- alias `/fonts` to the public directory

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npm run build`
- `npm run build` in soho
- `curl -I http://localhost:5174/fonts/GFSDidot-Regular.ttf`
- `curl -I http://localhost:4173/fonts/GFSDidot-Regular.ttf`


------
https://chatgpt.com/codex/tasks/task_b_68b6963133fc832aac1d4d8759a7327c