### PR TITLE
Add dashboard layout with navigation drawer and search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "^5.2.1",
+        "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.1",
         "@tailwindcss/vite": "^4.1.12",
         "@tanstack/react-query": "^5.85.5",
@@ -1215,26 +1216,52 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.1.tgz",
-      "integrity": "sha512-+mIK1Z0BhOaQ0vCgOkT1mSrIpEHLo338h4/duuL4TBLXPvUMit732mnwJY3W40Avy30HdeSfwUAAGRkKmwRaEQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.2.tgz",
+      "integrity": "sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
-    "node_modules/@mui/material": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.1.tgz",
-      "integrity": "sha512-Xf6Shbo03YmcBedZMwSpEFOwpYDtU7tC+rhAHTrA9FHk0FpsDqiQ9jUa1j/9s3HLs7KWb5mDcGnlwdh9Q9KAag==",
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.2.tgz",
+      "integrity": "sha512-TZWazBjWXBjR6iGcNkbKklnwodcwj0SrChCNHc9BhD9rBgET22J1eFhHsEmvSvru9+opDy3umqAimQjokhfJlQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/core-downloads-tracker": "^7.3.1",
-        "@mui/system": "^7.3.1",
-        "@mui/types": "^7.4.5",
-        "@mui/utils": "^7.3.1",
+        "@babel/runtime": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.2.tgz",
+      "integrity": "sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3",
+        "@mui/core-downloads-tracker": "^7.3.2",
+        "@mui/system": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -1253,7 +1280,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.1",
+        "@mui/material-pigment-css": "^7.3.2",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1274,13 +1301,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.1.tgz",
-      "integrity": "sha512-WU3YLkKXii/x8ZEKnrLKsPwplCVE11yZxUvlaaZSIzCcI3x2OdFC8eMlNy74hVeUsYQvzzX1Es/k4ARPlFvpPQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.2.tgz",
+      "integrity": "sha512-ha7mFoOyZGJr75xeiO9lugS3joRROjc8tG1u4P50dH0KR7bwhHznVMcYg7MouochUy0OxooJm/OOSpJ7gKcMvg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/utils": "^7.3.1",
+        "@babel/runtime": "^7.28.3",
+        "@mui/utils": "^7.3.2",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1301,12 +1328,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.1.tgz",
-      "integrity": "sha512-Nqo6OHjvJpXJ1+9TekTE//+8RybgPQUKwns2Lh0sq+8rJOUSUKS3KALv4InSOdHhIM9Mdi8/L7LTF1/Ky6D6TQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.2.tgz",
+      "integrity": "sha512-PkJzW+mTaek4e0nPYZ6qLnW5RGa0KN+eRTf5FA2nc7cFZTeM+qebmGibaTLrgQBy3UpcpemaqfzToBNkzuxqew==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
+        "@babel/runtime": "^7.28.3",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1335,16 +1362,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.1.tgz",
-      "integrity": "sha512-mIidecvcNVpNJMdPDmCeoSL5zshKBbYPcphjuh6ZMjhybhqhZ4mX6k9zmIWh6XOXcqRQMg5KrcjnO0QstrNj3w==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.2.tgz",
+      "integrity": "sha512-9d8JEvZW+H6cVkaZ+FK56R53vkJe3HsTpcjMUtH8v1xK6Y1TjzHdZ7Jck02mGXJsE6MQGWVs3ogRHTQmS9Q/rA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/private-theming": "^7.3.1",
-        "@mui/styled-engine": "^7.3.1",
-        "@mui/types": "^7.4.5",
-        "@mui/utils": "^7.3.1",
+        "@babel/runtime": "^7.28.3",
+        "@mui/private-theming": "^7.3.2",
+        "@mui/styled-engine": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1375,12 +1402,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.5.tgz",
-      "integrity": "sha512-ZPwlAOE3e8C0piCKbaabwrqZbW4QvWz0uapVPWya7fYj6PeDkl5sSJmomT7wjOcZGPB48G/a6Ubidqreptxz4g==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
+      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2"
+        "@babel/runtime": "^7.28.3"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1392,13 +1419,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.1.tgz",
-      "integrity": "sha512-/31y4wZqVWa0jzMnzo6JPjxwP6xXy4P3+iLbosFg/mJQowL1KIou0LC+lquWW60FKVbKz5ZUWBg2H3jausa0pw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.2",
-        "@mui/types": "^7.4.5",
+        "@babel/runtime": "^7.28.3",
+        "@mui/types": "^7.4.6",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@hookform/resolvers": "^5.2.1",
+    "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.1",
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.85.5",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^22.8.6",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -48,7 +50,6 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2",
-    "@types/node": "^22.8.6"
+    "vite": "^7.1.2"
   }
 }

--- a/soho/src/contexts/ThemeContext.tsx
+++ b/soho/src/contexts/ThemeContext.tsx
@@ -10,6 +10,7 @@ const ThemeContext = createContext<ThemeContextType>({
     toggleTheme: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => useContext(ThemeContext);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -31,3 +32,4 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         </ThemeContext.Provider>
     );
 };
+

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,27 +1,155 @@
-import { AppBar, Box, Button, Toolbar, Typography } from '@mui/material';
 import React from 'react';
 import { Outlet } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+
+import {
+  AppBar,
+  Box,
+  Button,
+  CssBaseline,
+  Drawer,
+  IconButton,
+  InputBase,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+  Typography,
+} from '@mui/material';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import LogoutIcon from '@mui/icons-material/Logout';
+import MenuIcon from '@mui/icons-material/Menu';
+import PeopleIcon from '@mui/icons-material/People';
+import SearchIcon from '@mui/icons-material/Search';
+import SettingsIcon from '@mui/icons-material/Settings';
+
+const drawerWidth = 240;
 
 const MainLayout: React.FC = () => {
   const { logout, username } = useAuth();
+  const navigate = useNavigate();
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const drawer = (
+    <div>
+      <Toolbar />
+      <List>
+        <ListItem disablePadding>
+          <ListItemButton onClick={() => navigate('/dashboard')}>
+            <ListItemIcon>
+              <DashboardIcon />
+            </ListItemIcon>
+            <ListItemText primary="Dashboard" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton onClick={() => navigate('/users')}>
+            <ListItemIcon>
+              <PeopleIcon />
+            </ListItemIcon>
+            <ListItemText primary="Users" />
+          </ListItemButton>
+        </ListItem>
+        <ListItem disablePadding>
+          <ListItemButton onClick={() => navigate('/settings')}>
+            <ListItemIcon>
+              <SettingsIcon />
+            </ListItemIcon>
+            <ListItemText primary="Settings" />
+          </ListItemButton>
+        </ListItem>
+      </List>
+    </div>
+  );
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <AppBar position="static">
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
+      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
         <Toolbar>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            sx={{ mr: 2, display: { sm: 'none' } }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
             Soho Dashboard
           </Typography>
-          <Typography variant="body1" sx={{ marginRight: 2 }}>
+          <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'center' }}>
+            <Box
+              sx={{
+                position: 'relative',
+                borderRadius: 1,
+                backgroundColor: 'rgba(255,255,255,0.15)',
+                '&:hover': { backgroundColor: 'rgba(255,255,255,0.25)' },
+                width: '100%',
+                maxWidth: 300,
+              }}
+            >
+              <Box
+                sx={{
+                  padding: '0 16px',
+                  height: '100%',
+                  position: 'absolute',
+                  pointerEvents: 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                }}
+              >
+                <SearchIcon />
+              </Box>
+              <InputBase
+                placeholder="Search…"
+                sx={{ color: 'inherit', pl: 4, width: '100%' }}
+                inputProps={{ 'aria-label': 'search' }}
+              />
+            </Box>
+          </Box>
+          <Typography variant="body1" sx={{ mr: 2 }}>
             Welcome, {username}
           </Typography>
-          <Button color="inherit" onClick={logout}>
+          <Button color="inherit" startIcon={<LogoutIcon />} onClick={logout}>
             Logout
           </Button>
         </Toolbar>
       </AppBar>
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Box component="nav" sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }} aria-label="navigation items">
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={handleDrawerToggle}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            display: { xs: 'block', sm: 'none' },
+            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+          }}
+        >
+          {drawer}
+        </Drawer>
+        <Drawer
+          variant="permanent"
+          sx={{
+            display: { xs: 'none', sm: 'block' },
+            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+          }}
+          open
+        >
+          {drawer}
+        </Drawer>
+      </Box>
+      <Box component="main" sx={{ flexGrow: 1, p: 3, width: { sm: `calc(100% - ${drawerWidth}px)` } }}>
+        <Toolbar />
         <Outlet />
       </Box>
     </Box>
@@ -29,3 +157,4 @@ const MainLayout: React.FC = () => {
 };
 
 export default MainLayout;
+

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
   useMemo,
 } from 'react';
+import axiosInstance from '../lib/axiosInstance';
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -17,6 +18,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {
@@ -51,11 +53,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUsername(username);
   }, []);
 
-  const logout = useCallback(() => {
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('username');
-    setIsAuthenticated(false);
-    setUsername(null);
+  const logout = useCallback(async () => {
+    try {
+      await axiosInstance.post('/logout/');
+    } catch (error) {
+      console.error('Logout failed', error);
+    } finally {
+      localStorage.removeItem('authToken');
+      localStorage.removeItem('username');
+      setIsAuthenticated(false);
+      setUsername(null);
+    }
   }, []);
 
   const value = useMemo(

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,6 +10,7 @@ const ThemeContext = createContext<ThemeContextType>({
     toggleTheme: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => useContext(ThemeContext);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,9 @@
+import { Typography } from '@mui/material';
+import React from 'react';
+
+const Settings: React.FC = () => {
+  return <Typography variant="h4">Settings</Typography>;
+};
+
+export default Settings;
+

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,0 +1,9 @@
+import { Typography } from '@mui/material';
+import React from 'react';
+
+const Users: React.FC = () => {
+  return <Typography variant="h4">Users</Typography>;
+};
+
+export default Users;
+

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -2,6 +2,8 @@ import { createBrowserRouter, Navigate } from 'react-router-dom';
 import MainLayout from '../components/MainLayout.tsx';
 import AuthPage from '../pages/AuthPage.tsx';
 import Dashboard from '../pages/Dashboard.tsx';
+import Settings from '../pages/Settings.tsx';
+import Users from '../pages/Users.tsx';
 import ProtectedRoute from '../routes/ProtectedRoute.tsx';
 
 const router = createBrowserRouter([
@@ -24,6 +26,14 @@ const router = createBrowserRouter([
       {
         path: 'dashboard',
         element: <Dashboard />,
+      },
+      {
+        path: 'users',
+        element: <Users />,
+      },
+      {
+        path: 'settings',
+        element: <Settings />,
       },
 
       // Add more protected routes here as needed


### PR DESCRIPTION
## Summary
- add responsive navbar and drawer with search bar and links
- implement API-backed logout and new user/settings routes
- add Users and Settings placeholder pages

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c1f83aaaa4832ab3555ee189bb2bba