### PR TITLE
feat: support mock login via env flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 soho/node_modules/
 dist/
+.env

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -14,6 +14,14 @@ const loginApi = async ({
   username,
   password,
 }: LoginPayload): Promise<LoginResponse> => {
+  if (import.meta.env.VITE_MOCK_LOGIN === 'true') {
+    // Temporary offline login; remove or disable when real server access is restored.
+    if (username === 'demo' && password === 'demo') {
+      return Promise.resolve({ token: 'mock-token' });
+    }
+    return Promise.reject(new Error('Invalid credentials'));
+  }
+
   const { data } = await axiosInstance.post('/auth-token/', {
     username,
     password,


### PR DESCRIPTION
## Summary
- add .env to gitignore for local flags
- allow `useLogin` to return mock token when `VITE_MOCK_LOGIN` is true, bypassing network calls

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68c4356a6cf4832a8feb5e926b52b6e0