### PR TITLE
Bypass login for development

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {
@@ -30,8 +31,9 @@ interface AuthProviderProps {
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const [username, setUsername] = useState<string | null>(null);
+  // Temporary bypass authentication for development purposes
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(true);
+  const [username, setUsername] = useState<string | null>('Developer');
 
   useEffect(() => {
     // Check if user is already logged in on app initialization

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,6 +10,7 @@ const ThemeContext = createContext<ThemeContextType>({
     toggleTheme: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => useContext(ThemeContext);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import { Navigate } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthContext';
-
 interface ProtectedRouteProps {
   children: React.ReactElement;
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
-  const { isAuthenticated } = useAuth();
-
-  return isAuthenticated ? children : <Navigate to="/login" replace />;
+  // Authentication temporarily disabled for development
+  return children;
 };
 
 export default ProtectedRoute;

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,6 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import MainLayout from '../components/MainLayout.tsx';
-import AuthPage from '../pages/AuthPage.tsx';
 import Dashboard from '../pages/Dashboard.tsx';
 import ProtectedRoute from '../routes/ProtectedRoute.tsx';
 
@@ -11,7 +10,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/login',
-    element: <AuthPage />,
+    element: <Navigate to="/dashboard" replace />,
   },
   {
     path: '/',


### PR DESCRIPTION
## Summary
- Default user context to a logged-in "Developer" and skip auth checks
- Disable ProtectedRoute and redirect `/login` to `/dashboard`
- Silence react-refresh lint warnings for context hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c43b6e1048832a934014994c587dbd