### PR TITLE
feat: add navigation drawer with search and logout

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,27 +1,86 @@
-import { AppBar, Box, Button, Toolbar, Typography } from '@mui/material';
-import React from 'react';
+import {
+  AppBar,
+  Box,
+  Button,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  TextField,
+  Toolbar,
+  Typography,
+} from '@mui/material';
+import React, { useState } from 'react';
 import { Outlet } from 'react-router';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+
+const drawerWidth = 240;
 
 const MainLayout: React.FC = () => {
   const { logout, username } = useAuth();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const navItems = [
+    { text: 'Dashboard', path: '/dashboard' },
+    { text: 'Users', path: '/users' },
+    { text: 'Settings', path: '/settings' },
+  ];
+
+  const handleLogout = async () => {
+    await logout();
+  };
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <AppBar position="static">
+    <Box sx={{ display: 'flex' }}>
+      <AppBar
+        position="fixed"
+        sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+      >
         <Toolbar>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             Soho Dashboard
           </Typography>
-          <Typography variant="body1" sx={{ marginRight: 2 }}>
+          <TextField
+            size="small"
+            placeholder="Search..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            sx={{ backgroundColor: 'white', borderRadius: 1, mr: 2 }}
+          />
+          <Typography variant="body1" sx={{ mr: 2 }}>
             Welcome, {username}
           </Typography>
-          <Button color="inherit" onClick={logout}>
+          <Button color="inherit" onClick={handleLogout}>
             Logout
           </Button>
         </Toolbar>
       </AppBar>
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        <Toolbar />
+        <List>
+          {navItems.map((item) => (
+            <ListItem key={item.text} disablePadding>
+              <ListItemButton component={Link} to={item.path}>
+                <ListItemText primary={item.text} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <Toolbar />
         <Outlet />
       </Box>
     </Box>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,7 +11,7 @@ import React, {
 interface AuthContextType {
   isAuthenticated: boolean;
   loginAction: (token: string, username: string) => void;
-  logout: () => void;
+  logout: () => Promise<void>;
   username: string | null;
 }
 
@@ -53,7 +53,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setUsername(username);
   }, []);
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    try {
+      await fetch('/api/logout', { method: 'POST', credentials: 'include' });
+    } catch {
+      // Ignore network errors for logout
+    }
     localStorage.removeItem('authToken');
     localStorage.removeItem('username');
     setIsAuthenticated(false);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,6 @@
+const Settings = () => {
+  return <div>Settings</div>;
+};
+
+export default Settings;
+

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,0 +1,6 @@
+const Users = () => {
+  return <div>Users</div>;
+};
+
+export default Users;
+

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,6 +1,8 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import MainLayout from '../components/MainLayout.tsx';
 import Dashboard from '../pages/Dashboard.tsx';
+import Settings from '../pages/Settings.tsx';
+import Users from '../pages/Users.tsx';
 import ProtectedRoute from '../routes/ProtectedRoute.tsx';
 
 const router = createBrowserRouter([
@@ -20,12 +22,9 @@ const router = createBrowserRouter([
       </ProtectedRoute>
     ),
     children: [
-      {
-        path: 'dashboard',
-        element: <Dashboard />,
-      },
-
-      // Add more protected routes here as needed
+      { path: 'dashboard', element: <Dashboard /> },
+      { path: 'users', element: <Users /> },
+      { path: 'settings', element: <Settings /> },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- add permanent navigation drawer with links to dashboard, users, and settings
- include search bar and logout in the top app bar
- add users and settings pages and route them
- send logout request to server via AuthContext

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c43dd4f350832a9824837f6b19d6a6