### PR TITLE
refactor: add typed generics to remember username hook

### DIFF
--- a/src/hooks/useRememberUsername.ts
+++ b/src/hooks/useRememberUsername.ts
@@ -1,9 +1,17 @@
 import { useEffect } from 'react';
 import type { UseFormSetValue, UseFormWatch } from 'react-hook-form';
 
-export function useRememberUsername(
-  watch: UseFormWatch<any>,
-  setValue: UseFormSetValue<any>
+/**
+ * Hook to persist the username when the "remember me" option is enabled.
+ *
+ * @param watch    React Hook Form's watch function
+ * @param setValue React Hook Form's setValue function
+ */
+export function useRememberUsername<
+  T extends { username: string; rememberMe?: boolean }
+>(
+  watch: UseFormWatch<T>,
+  setValue: UseFormSetValue<T>
 ) {
   const rememberMe = watch('rememberMe');
   const username = watch('username');


### PR DESCRIPTION
## Summary
- add type-safe generics to `useRememberUsername` hook
- document parameters and behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c52101c8ec832a9f1eedd17740095e