### PR TITLE
fix: properly type remember username hook

### DIFF
--- a/src/hooks/useRememberUsername.ts
+++ b/src/hooks/useRememberUsername.ts
@@ -1,24 +1,46 @@
 import { useEffect } from 'react';
-import type { UseFormSetValue, UseFormWatch } from 'react-hook-form';
+import type {
+  Path,
+  PathValue,
+  UseFormSetValue,
+  UseFormWatch,
+} from 'react-hook-form';
 
-export function useRememberUsername(
-  watch: UseFormWatch<any>,
-  setValue: UseFormSetValue<any>
+/**
+ * Hook to persist the username when the "remember me" option is enabled.
+ *
+ * @param watch    React Hook Form's watch function
+ * @param setValue React Hook Form's setValue function
+ */
+interface RememberUsernameFields {
+  username: string;
+  rememberMe?: boolean;
+}
+
+export function useRememberUsername<T extends RememberUsernameFields>(
+  watch: UseFormWatch<T>,
+  setValue: UseFormSetValue<T>,
 ) {
-  const rememberMe = watch('rememberMe');
-  const username = watch('username');
+  const rememberMe = watch('rememberMe' as Path<T>);
+  const username = watch('username' as Path<T>);
 
   useEffect(() => {
     const savedUsername = localStorage.getItem('savedUsername');
     if (savedUsername) {
-      setValue('username', savedUsername);
-      setValue('rememberMe', true);
+      setValue(
+        'username' as Path<T>,
+        savedUsername as PathValue<T, Path<T>>,
+      );
+      setValue(
+        'rememberMe' as Path<T>,
+        true as PathValue<T, Path<T>>,
+      );
     }
   }, [setValue]);
 
   useEffect(() => {
     if (rememberMe && username) {
-      localStorage.setItem('savedUsername', username);
+      localStorage.setItem('savedUsername', username as string);
     } else {
       localStorage.removeItem('savedUsername');
     }


### PR DESCRIPTION
## Summary
- ensure generic typing for `useRememberUsername` using React Hook Form paths
- persist username with strictly typed `watch` and `setValue`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c52101c8ec832a9f1eedd17740095e