### PR TITLE
Add React Query hooks for dashboard metrics

### DIFF
--- a/src/components/Cpu.tsx
+++ b/src/components/Cpu.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useCpu } from '../hooks/useCpu';
+
+const Cpu = () => {
+  const { data, isLoading, error } = useCpu();
+
+  if (isLoading) return <Typography>Loading CPU...</Typography>;
+  if (error) return <Typography>Error: {error.message}</Typography>;
+
+  return (
+    <Box sx={{ p: 2, bgcolor: 'var(--color-card-bg)', mb: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1, color: 'var(--color-primary)' }}>
+        CPU
+      </Typography>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </Box>
+  );
+};
+
+export default Cpu;

--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useDisk } from '../hooks/useDisk';
+
+const Disk = () => {
+  const { data, isLoading, error } = useDisk();
+
+  if (isLoading) return <Typography>Loading Disk...</Typography>;
+  if (error) return <Typography>Error: {error.message}</Typography>;
+
+  return (
+    <Box sx={{ p: 2, bgcolor: 'var(--color-card-bg)', mb: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1, color: 'var(--color-primary)' }}>
+        Disk
+      </Typography>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </Box>
+  );
+};
+
+export default Disk;

--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useMemory } from '../hooks/useMemory';
+
+const Memory = () => {
+  const { data, isLoading, error } = useMemory();
+
+  if (isLoading) return <Typography>Loading Memory...</Typography>;
+  if (error) return <Typography>Error: {error.message}</Typography>;
+
+  return (
+    <Box sx={{ p: 2, bgcolor: 'var(--color-card-bg)', mb: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1, color: 'var(--color-primary)' }}>
+        Memory
+      </Typography>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </Box>
+  );
+};
+
+export default Memory;

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material';
+import { useNetwork } from '../hooks/useNetwork';
+
+const Network = () => {
+  const { data, isLoading, error } = useNetwork();
+
+  if (isLoading) return <Typography>Loading Network...</Typography>;
+  if (error) return <Typography>Error: {error.message}</Typography>;
+
+  return (
+    <Box sx={{ p: 2, bgcolor: 'var(--color-card-bg)', mb: 2 }}>
+      <Typography variant="h6" sx={{ mb: 1, color: 'var(--color-primary)' }}>
+        Network
+      </Typography>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </Box>
+  );
+};
+
+export default Network;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,6 +10,7 @@ const ThemeContext = createContext<ThemeContextType>({
     toggleTheme: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => useContext(ThemeContext);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/hooks/useCpu.ts
+++ b/src/hooks/useCpu.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '../lib/axiosInstance';
+
+const fetchCpu = async () => {
+  const { data } = await axiosInstance.get('/cpu');
+  return data;
+};
+
+export const useCpu = () => {
+  return useQuery<unknown, Error>({
+    queryKey: ['cpu'],
+    queryFn: fetchCpu,
+  });
+};

--- a/src/hooks/useDisk.ts
+++ b/src/hooks/useDisk.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '../lib/axiosInstance';
+
+const fetchDisk = async () => {
+  const { data } = await axiosInstance.get('/disk');
+  return data;
+};
+
+export const useDisk = () => {
+  return useQuery<unknown, Error>({
+    queryKey: ['disk'],
+    queryFn: fetchDisk,
+  });
+};

--- a/src/hooks/useMemory.ts
+++ b/src/hooks/useMemory.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '../lib/axiosInstance';
+
+const fetchMemory = async () => {
+  const { data } = await axiosInstance.get('/memory');
+  return data;
+};
+
+export const useMemory = () => {
+  return useQuery<unknown, Error>({
+    queryKey: ['memory'],
+    queryFn: fetchMemory,
+  });
+};

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '../lib/axiosInstance';
+
+const fetchNetwork = async () => {
+  const { data } = await axiosInstance.get('/network');
+  return data;
+};
+
+export const useNetwork = () => {
+  return useQuery<unknown, Error>({
+    queryKey: ['network'],
+    queryFn: fetchNetwork,
+  });
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,154 +1,16 @@
-import { Box, Grid, Paper, Typography } from '@mui/material';
-import { BarChart } from '@mui/x-charts/BarChart';
-import { Gauge, gaugeClasses } from '@mui/x-charts/Gauge';
-import { LineChart } from '@mui/x-charts/LineChart';
-import { PieChart } from '@mui/x-charts/PieChart';
-import { ScatterChart } from '@mui/x-charts/ScatterChart';
-import { useEffect, useState } from 'react';
+import { Box } from '@mui/material';
+import Cpu from '../components/Cpu';
+import Disk from '../components/Disk';
+import Memory from '../components/Memory';
+import Network from '../components/Network';
 
 const Dashboard = () => {
-  const pieData = [
-    { id: 0, value: 10, label: 'A' },
-    { id: 1, value: 20, label: 'B' },
-    { id: 2, value: 15, label: 'C' },
-  ];
-
-  const barData = [
-    { month: 'فروردین', value: 30 },
-    { month: 'اردیبهشت', value: 40 },
-    { month: 'خرداد', value: 25 },
-  ];
-
-  const [lineSeries1, setLineSeries1] = useState([20, 35, 40]);
-  const lineSeries2 = [15, 25, 30, 45, 35, 50, 60];
-  const [gaugeValue, setGaugeValue] = useState(60);
-  // Repeat for barData, pieData, scatterData…
-
-  const scatterData = [
-    { x: 1, y: 5 },
-    { x: 2, y: 15 },
-    { x: 3, y: 9 },
-    { x: 4, y: 20 },
-    { x: 5, y: 12 },
-  ];
-
-  useEffect(() => {
-    const id = setInterval(() => {
-      setLineSeries1((prev) => [...prev.slice(-9), Math.random() * 100]);
-      setGaugeValue(() => Math.round(Math.random() * 100));
-    }, 1000);
-    return () => clearInterval(id); // cleanup on unmount
-  }, []);
-
   return (
     <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={3}>
-          <Paper sx={{ p: 2, bgcolor: 'var(--color-card-bg)' }}>
-            <Typography
-              variant="subtitle1"
-              sx={{ mb: 1, color: 'var(--color-primary)' }}
-            >
-              نمودار دونات
-            </Typography>
-            <PieChart
-              series={[{ data: pieData, innerRadius: 30, outerRadius: 80 }]}
-              height={200}
-              slotProps={{ legend: { hidden: true } }}
-            />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12} md={3}>
-          <Paper sx={{ p: 2, bgcolor: 'var(--color-card-bg)' }}>
-            <Typography
-              variant="subtitle1"
-              sx={{ mb: 1, color: 'var(--color-primary)' }}
-            >
-              نمودار دایره‌ای
-            </Typography>
-            <PieChart
-              series={[{ data: pieData }]}
-              height={200}
-              slotProps={{ legend: { hidden: true } }}
-            />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12} md={3}>
-          <Paper sx={{ p: 2, bgcolor: 'var(--color-card-bg)' }}>
-            <Typography
-              variant="subtitle1"
-              sx={{ mb: 1, color: 'var(--color-primary)' }}
-            >
-              گیج
-            </Typography>
-            <Gauge
-              value={gaugeValue}
-              startAngle={-90}
-              endAngle={90}
-              height={200}
-              sx={{
-                [`& .${gaugeClasses.valueText}`]: {
-                  fill: 'var(--color-primary)',
-                },
-              }}
-            />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12} md={3}>
-          <Paper sx={{ p: 2, bgcolor: 'var(--color-card-bg)' }}>
-            <Typography
-              variant="subtitle1"
-              sx={{ mb: 1, color: 'var(--color-primary)' }}
-            >
-              نمودار ستونی
-            </Typography>
-            <BarChart
-              xAxis={[{ scaleType: 'band', data: barData.map((d) => d.month) }]}
-              series={[{ data: barData.map((d) => d.value) }]}
-              height={200}
-            />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12} md={6}>
-          <Paper sx={{ p: 2, bgcolor: 'var(--color-card-bg)' }}>
-            <Typography
-              variant="subtitle1"
-              sx={{ mb: 1, color: 'var(--color-primary)' }}
-            >
-              نمودار خطی
-            </Typography>
-            <LineChart
-              xAxis={[{ data: ['1', '2', '3', '4', '5', '6', '7'] }]}
-              series={[
-                { data: lineSeries1, label: 'داده ۱' },
-                { data: lineSeries2, label: 'داده ۲' },
-              ]}
-              height={300}
-            />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12} md={6}>
-          <Paper sx={{ p: 2, bgcolor: 'var(--color-card-bg)' }}>
-            <Typography
-              variant="subtitle1"
-              sx={{ mb: 1, color: 'var(--color-primary)' }}
-            >
-              نمودار پراکندگی
-            </Typography>
-            <ScatterChart
-              xAxis={[{ min: 0, max: 6 }]}
-              yAxis={[{ min: 0, max: 25 }]}
-              series={[{ data: scatterData }]}
-              height={300}
-            />
-          </Paper>
-        </Grid>
-      </Grid>
+      <Cpu />
+      <Disk />
+      <Memory />
+      <Network />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- fetch CPU, disk, memory, and network stats via React Query hooks
- show metric data in dedicated components on dashboard
- suppress react-refresh lint warnings for context hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c56da08538832ab2586044673e6b9a