### PR TITLE
feat: add live network charts

### DIFF
--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -1,18 +1,88 @@
 import { Box, Typography } from '@mui/material';
+import { LineChart } from '@mui/x-charts';
+import { useEffect, useState } from 'react';
 import { useNetwork } from '../hooks/useNetwork';
+
+type History = Record<string, Array<{ time: number; upload: number; download: number }>>;
+
+const MAX_POINTS = 60;
 
 const Network = () => {
   const { data, isLoading, error } = useNetwork();
+  const [history, setHistory] = useState<History>({});
 
-  if (isLoading) return <Typography>Loading Network...</Typography>;
+  useEffect(() => {
+    if (!data?.interfaces) return;
+    setHistory((prev) => {
+      const next: History = { ...prev };
+      Object.entries(data.interfaces).forEach(([name, { bandwidth }]) => {
+        const points = next[name] ? [...next[name]] : [];
+        points.push({
+          time: Date.now(),
+          upload: bandwidth.upload,
+          download: bandwidth.download,
+        });
+        if (points.length > MAX_POINTS) points.shift();
+        next[name] = points;
+      });
+      return next;
+    });
+  }, [data]);
+
   if (error) return <Typography>Error: {error.message}</Typography>;
 
+  const interfaces = data?.interfaces ?? {};
+  const names = Object.keys(interfaces);
+
   return (
-    <Box sx={{ p: 2, bgcolor: 'var(--color-card-bg)', mb: 2 }}>
-      <Typography variant="h6" sx={{ mb: 1, color: 'var(--color-primary)' }}>
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h5" sx={{ mb: 2, color: 'var(--color-primary)' }}>
         Network
       </Typography>
-      <pre>{JSON.stringify(data, null, 2)}</pre>
+      {names.length === 0 ? (
+        <LineChart
+          height={250}
+          dataset={[]}
+          loading={isLoading}
+          xAxis={[{ dataKey: 'time', scaleType: 'time' }]}
+          series={[
+            { dataKey: 'download', label: 'دانلود', color: '#00bcd4' },
+            { dataKey: 'upload', label: 'آپلود', color: '#ff4d94' },
+          ]}
+          slotProps={{
+            noDataOverlay: { message: 'No network data' },
+          }}
+        />
+      ) : (
+        names.map((name) => (
+          <Box key={name} sx={{ p: 2, bgcolor: 'var(--color-card-bg)', mb: 2, borderRadius: 1 }}>
+            <Typography variant="h6" sx={{ mb: 1, color: 'var(--color-primary)' }}>
+              {name}
+            </Typography>
+            <LineChart
+              height={250}
+              dataset={history[name] ?? []}
+              loading={isLoading}
+              xAxis={[
+                {
+                  dataKey: 'time',
+                  valueFormatter: (value) => new Date(value).toLocaleTimeString(),
+                  scaleType: 'time',
+                },
+              ]}
+              series={[
+                { dataKey: 'download', label: 'دانلود', color: '#00bcd4' },
+                { dataKey: 'upload', label: 'آپلود', color: '#ff4d94' },
+              ]}
+              margin={{ left: 40, right: 20, top: 20, bottom: 20 }}
+              slotProps={{
+                legend: { position: { vertical: 'top', horizontal: 'center' } },
+                noDataOverlay: { message: 'No network data' },
+              }}
+            />
+          </Box>
+        ))
+      )}
     </Box>
   );
 };

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -1,14 +1,28 @@
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '../lib/axiosInstance';
 
+interface Bandwidth {
+  download: number;
+  upload: number;
+}
+
+interface NetworkInterface {
+  bandwidth: Bandwidth;
+}
+
+export interface NetworkData {
+  interfaces: Record<string, NetworkInterface>;
+}
+
 const fetchNetwork = async () => {
-  const { data } = await axiosInstance.get('/network');
+  const { data } = await axiosInstance.get<NetworkData>('/network');
   return data;
 };
 
 export const useNetwork = () => {
-  return useQuery<unknown, Error>({
+  return useQuery<NetworkData, Error>({
     queryKey: ['network'],
     queryFn: fetchNetwork,
+    refetchInterval: 1000,
   });
 };


### PR DESCRIPTION
## Summary
- visualize per-interface upload/download with live line charts
- refresh network data every second via React Query
- wrap network charts in container and use built-in loading/no-data states

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c657124218832a9dd7b0004dc2ac3c