### PR TITLE
feat: add global loader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider as MUIThemeProvider } from '@mui/material/styles';
 import { RouterProvider } from 'react-router';
 import AppToaster from './components/AppToaster.tsx';
+import GlobalLoader from './components/GlobalLoader.tsx';
 import { useTheme } from './contexts/ThemeContext';
 import router from './routes/Routes';
 import getTheme from './theme';
@@ -12,6 +13,7 @@ function AppContent() {
   return (
     <MUIThemeProvider theme={theme}>
       <AppToaster />
+      <GlobalLoader />
       <RouterProvider router={router} />
     </MUIThemeProvider>
   );

--- a/src/components/GlobalLoader.tsx
+++ b/src/components/GlobalLoader.tsx
@@ -1,0 +1,13 @@
+import LoadingPage from './LoadingPage.tsx';
+import { useIsFetching, useIsMutating } from '@tanstack/react-query';
+
+export default function GlobalLoader() {
+  const isFetching = useIsFetching({
+    predicate: (query) => !query.meta?.skipGlobalLoader,
+  });
+  const isMutating = useIsMutating({
+    predicate: (mutation) => !mutation.meta?.skipGlobalLoader,
+  });
+
+  return isFetching + isMutating > 0 ? <LoadingPage /> : null;
+}


### PR DESCRIPTION
## Summary
- show global loading page whenever React Query fetches or mutates
- wire up GlobalLoader at the top of the app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components in AuthContext.tsx, ThemeContext.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c66ee400d4832aa7b4501ad01156f7