### PR TITLE
Limit network chart history to 90 seconds

### DIFF
--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material';
 
 import { LineChart } from '@mui/x-charts';
 import { axisClasses } from '@mui/x-charts/ChartsAxis';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNetwork } from '../hooks/useNetwork';
 import '../index.css';
 
@@ -11,25 +11,28 @@ type History = Record<
   Array<{ time: number; upload: number; download: number }>
 >;
 
-const MAX_POINTS = 100;
+const MAX_HISTORY_MS = 90 * 1000; // 1 minute 30 seconds
 
 const Network = () => {
   const { data, isLoading, error } = useNetwork();
 
   const [history, setHistory] = useState<History>({});
+  const startTimeRef = useRef<number>(Date.now());
 
   useEffect(() => {
     if (!data?.interfaces) return;
     setHistory((prev) => {
+      const now = Date.now();
       const next: History = { ...prev };
       Object.entries(data.interfaces).forEach(([name, { bandwidth }]) => {
-        const points = next[name] ? [...next[name]] : [];
+        const points = next[name]
+          ? next[name].filter((p) => now - p.time <= MAX_HISTORY_MS)
+          : [];
         points.push({
-          time: Date.now(),
+          time: now,
           upload: bandwidth.upload,
           download: bandwidth.download,
         });
-        if (points.length > MAX_POINTS) points.shift();
         next[name] = points;
       });
       return next;
@@ -79,6 +82,10 @@ const Network = () => {
       ) : (
         names.map((name) => {
           const unit = interfaces[name]?.bandwidth.unit ?? '';
+          const now = Date.now();
+          const elapsed = now - startTimeRef.current;
+          const min = elapsed < MAX_HISTORY_MS ? startTimeRef.current : now - MAX_HISTORY_MS;
+          const max = min + MAX_HISTORY_MS;
           return (
             <Box
               key={name}
@@ -106,6 +113,8 @@ const Network = () => {
                     valueFormatter: (value) =>
                       new Date(value).toLocaleTimeString(),
                     scaleType: 'time',
+                    min,
+                    max,
                   },
                 ]}
                 yAxis={[

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,6 +10,7 @@ const ThemeContext = createContext<ThemeContextType>({
     toggleTheme: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => useContext(ThemeContext);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,5 +1,6 @@
 import { createTheme } from '@mui/material/styles';
 import { axisClasses } from '@mui/x-charts/ChartsAxis';
+import { legendClasses } from '@mui/x-charts/ChartsLegend';
 import '@mui/x-charts/themeAugmentation';
 
 function readCssVar(name: string, fallback: string) {
@@ -70,14 +71,11 @@ export const getTheme = (isDark: boolean) => {
           },
         },
       },
-      MuiChartsLabel: {
-        styleOverrides: {
-          root: { fill: 'var(--color-text)' },
-        },
-      },
       MuiChartsLegend: {
         styleOverrides: {
-          label: { fill: 'var(--color-text)' },
+          root: {
+            [`& .${legendClasses.label}`]: { fill: 'var(--color-text)' },
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary
- Start network charts at current time and expand within a 90-second window
- Silence React Refresh lint warnings for context hooks
- Adjust legend styling to avoid build-time type errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c69f9a14b0832a80f93542874cc769