### PR TITLE
Enhance disk overview charts and show network interface IPs

### DIFF
--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -7,8 +7,15 @@ interface Bandwidth {
   unit: string;
 }
 
+interface InterfaceAddress {
+  address?: string | null;
+  family?: string | null;
+  [key: string]: unknown;
+}
+
 interface NetworkInterface {
   bandwidth: Bandwidth;
+  addresses?: InterfaceAddress[] | Record<string, InterfaceAddress | null> | null;
 }
 
 export interface NetworkData {


### PR DESCRIPTION
## Summary
- Replace the disk consumption list with responsive donut cards that mirror the CPU/Memory styling while surfacing the same usage metrics per device.
- Stack the read/write throughput chart so each device renders as a single combined column with consistent coloring.
- Surface interface IP addresses beside network chart titles and extend the network hook typing to include address data.

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components errors in existing context files)*
- `npx eslint src/components/Disk.tsx src/components/Network.tsx src/hooks/useNetwork.ts`


------
https://chatgpt.com/codex/tasks/task_b_68ca4ffc68f0832aaaddd814d861cd84