### PR TITLE
Split disk overview and show network IPv4 details

### DIFF
--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -1,13 +1,15 @@
 import {
   Box,
   Divider,
-  LinearProgress,
   Stack,
   Typography,
+  useMediaQuery,
   useTheme,
 } from '@mui/material';
 import { BarChart } from '@mui/x-charts/BarChart';
+import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
+import type { Theme } from '@mui/material/styles';
 import type { DiskIOStats } from '../@types/disk';
 import { useDisk } from '../hooks/useDisk';
 import '../index.css';
@@ -78,6 +80,36 @@ const normalizeMetrics = (metrics?: Partial<DiskIOStats>) => {
 };
 
 type NormalizedMetrics = ReturnType<typeof normalizeMetrics>;
+
+const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+const safeNumber = (value: unknown) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
+const createCardSx = (theme: Theme) => {
+  const cardBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(0, 0, 0, 0.08)';
+
+  return {
+    width: '100%',
+    p: 3,
+    bgcolor: 'var(--color-card-bg)',
+    borderRadius: 3,
+    mb: 3,
+    color: 'var(--color-bg-primary)',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 3,
+    boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
+    border: `1px solid ${cardBorderColor}`,
+    backdropFilter: 'blur(14px)',
+    height: '100%',
+  } as const;
+};
 
 interface ParallelDatum {
   name: string;
@@ -273,30 +305,350 @@ const ParallelCoordinatesChart = ({
   );
 };
 
+export const DiskOverview = () => {
+  const { data, isLoading, error } = useDisk();
+  const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const cardSx = createCardSx(theme);
+
+  const disksWithUsage = useMemo(
+    () =>
+      (data?.disks ?? []).filter((disk) => disk.usage && disk.usage.total > 0),
+    [data?.disks]
+  );
+
+  const diskPercentFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat('fa-IR', {
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }),
+    []
+  );
+
+  const diskCardsBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.08)'
+      : 'rgba(0, 0, 0, 0.08)';
+
+  const diskStatsDividerColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.08)'
+      : 'rgba(0, 0, 0, 0.08)';
+
+  const diskStatsBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)';
+
+  const diskChartSize = isSmallScreen ? 180 : 230;
+
+  if (isLoading) {
+    return (
+      <Box sx={cardSx}>
+        <Typography variant="body2">در حال بارگذاری اطلاعات دیسک...</Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={cardSx}>
+        <Typography variant="body2" sx={{ color: 'var(--color-error)' }}>
+          خطا در دریافت داده‌های دیسک: {error.message}
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={cardSx}>
+      <Typography
+        variant="subtitle2"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          fontWeight: 600,
+        }}
+      >
+        <Box component="span" sx={{ fontSize: 20 }}>
+          💽
+        </Box>
+        نمای کلی مصرف دیسک
+      </Typography>
+
+      {disksWithUsage.length > 0 ? (
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 2,
+          }}
+        >
+          {disksWithUsage.map((disk) => {
+            const usage = disk.usage ?? {};
+            const totalRaw = safeNumber(usage.total);
+            const usedRaw = safeNumber(usage.used);
+            const freeRaw = safeNumber(usage.free);
+
+            const nonNegativeUsed = Math.max(usedRaw, 0);
+            const nonNegativeFree = Math.max(freeRaw, 0);
+            const derivedTotal =
+              totalRaw > 0 ? totalRaw : nonNegativeUsed + nonNegativeFree;
+            const safeTotal =
+              derivedTotal > 0 ? derivedTotal : nonNegativeUsed + nonNegativeFree;
+            const boundedUsed =
+              safeTotal > 0
+                ? Math.min(nonNegativeUsed, safeTotal)
+                : nonNegativeUsed;
+            const fallbackFree = safeTotal > boundedUsed ? safeTotal - boundedUsed : 0;
+            const boundedFree =
+              nonNegativeFree > 0
+                ? Math.min(
+                    nonNegativeFree,
+                    fallbackFree > 0 ? fallbackFree : nonNegativeFree
+                  )
+                : fallbackFree;
+            const percentValueRaw = usage.percent;
+            const safePercent =
+              percentValueRaw != null && Number.isFinite(Number(percentValueRaw))
+                ? clampPercent(Number(percentValueRaw))
+                : safeTotal > 0
+                  ? clampPercent((boundedUsed / safeTotal) * 100)
+                  : 0;
+            const percentText = `${diskPercentFormatter.format(safePercent)}٪`;
+            const chartRemaining =
+              safeTotal > 0 ? Math.max(safeTotal - boundedUsed, 0) : boundedFree;
+            const chartOuterRadius = Math.min(110, diskChartSize / 2 - 8);
+            const chartInnerRadius = Math.max(
+              chartOuterRadius - 24,
+              chartOuterRadius * 0.72
+            );
+            const stats: Array<{ key: string; label: string; value: string }> = [
+              { key: 'used', label: 'استفاده‌شده', value: formatBytes(boundedUsed) },
+              { key: 'free', label: 'خالی', value: formatBytes(boundedFree) },
+              { key: 'total', label: 'کل', value: formatBytes(safeTotal) },
+              { key: 'percent', label: 'درصد استفاده', value: percentText },
+            ];
+            const usedColor = theme.palette.primary.main;
+            const remainingColor =
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, 0.28)'
+                : 'rgba(0, 0, 0, 0.16)';
+            const fadedColor =
+              theme.palette.mode === 'dark'
+                ? 'rgba(255, 255, 255, 0.08)'
+                : 'rgba(0, 0, 0, 0.08)';
+
+            return (
+              <Box
+                key={disk.device}
+                sx={{
+                  flex: '1 1 280px',
+                  minWidth: { xs: '100%', sm: 260 },
+                  maxWidth: '100%',
+                  p: 2.5,
+                  borderRadius: 3,
+                  bgcolor: 'var(--color-card-bg)',
+                  border: `1px solid ${diskCardsBorderColor}`,
+                  boxShadow: '0 16px 32px rgba(0, 0, 0, 0.18)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 2,
+                }}
+              >
+                <Stack spacing={1} sx={{ width: '100%' }}>
+                  <Box>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {disk.device} ({disk.mountpoint || 'نامشخص'})
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      سیستم فایل: {(disk.fstype || '-').toUpperCase()}
+                    </Typography>
+                  </Box>
+                </Stack>
+
+                <Box
+                  sx={{
+                    position: 'relative',
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <PieChart
+                    series={[
+                      {
+                        id: `${disk.device}-usage`,
+                        data: [
+                          {
+                            id: 'used',
+                            value: boundedUsed,
+                            label: 'استفاده‌شده',
+                            color: usedColor,
+                          },
+                          {
+                            id: 'remaining',
+                            value: chartRemaining,
+                            label: 'باقی‌مانده',
+                            color: remainingColor,
+                          },
+                        ],
+                        innerRadius: chartInnerRadius,
+                        outerRadius: chartOuterRadius,
+                        paddingAngle: 1.2,
+                        cornerRadius: 5,
+                        startAngle: 90,
+                        endAngle: 450,
+                        highlightScope: { fade: 'global', highlight: 'item' },
+                        faded: {
+                          innerRadius: Math.max(
+                            chartInnerRadius - 6,
+                            chartInnerRadius * 0.9
+                          ),
+                          additionalRadius: -12,
+                          color: fadedColor,
+                        },
+                        valueFormatter: (item) => {
+                          if (item.id === 'used') {
+                            return [
+                              `${formatBytes(boundedUsed)} : استفاده‌شده `,
+                              `${formatBytes(safeTotal)} : کل `,
+                              `${formatBytes(boundedFree)} : خالی `,
+                              `${percentText} : درصد استفاده `,
+                            ].join('\n');
+                          }
+                          return `${formatBytes(chartRemaining)} : باقی‌مانده`;
+                        },
+                      },
+                    ]}
+                    width={diskChartSize}
+                    height={diskChartSize}
+                    margin={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    hideLegend
+                    slotProps={{
+                      tooltip: {
+                        sx: {
+                          direction: 'rtl',
+                          '& .MuiChartsTooltip-table': {
+                            direction: 'rtl',
+                            color: 'var(--color-text)',
+                          },
+                          '& .MuiChartsTooltip-cell': {
+                            whiteSpace: 'pre-line',
+                            fontFamily: 'var(--font-vazir)',
+                            color: 'var(--color-text)',
+                          },
+                          '& .MuiChartsTooltip-label': {
+                            color: 'var(--color-text)',
+                          },
+                          '& .MuiChartsTooltip-value': {
+                            color: 'var(--color-text)',
+                          },
+                        },
+                      },
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      inset: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexDirection: 'column',
+                      pointerEvents: 'none',
+                      gap: 0.5,
+                    }}
+                  >
+                    <Typography
+                      variant="h5"
+                      sx={{
+                        fontFamily: 'var(--font-didot)',
+                        fontWeight: 700,
+                        color: 'var(--color-primary)',
+                      }}
+                    >
+                      {percentText}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      درصد استفاده
+                    </Typography>
+                  </Box>
+                </Box>
+
+                <Box
+                  sx={{
+                    width: '100%',
+                    bgcolor: diskStatsBackground,
+                    borderRadius: 2,
+                    px: 2,
+                    py: 1.5,
+                    border: `1px solid ${diskStatsDividerColor}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  {stats.map((stat, index) => (
+                    <Box
+                      key={stat.key}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                        py: 0.75,
+                        borderBottom:
+                          index === stats.length - 1
+                            ? 'none'
+                            : `1px dashed ${diskStatsDividerColor}`,
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontWeight: 500,
+                          color: theme.palette.text.secondary,
+                        }}
+                      >
+                        {stat.label}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: 700, color: 'var(--color-primary)' }}
+                      >
+                        {stat.value}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      ) : (
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          داده‌ای برای مصرف دیسک در دسترس نیست.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
 const Disk = () => {
   const { data, isLoading, error } = useDisk();
   const theme = useTheme();
-
-  const cardBorderColor =
-    theme.palette.mode === 'dark'
-      ? 'rgba(255, 255, 255, 0.12)'
-      : 'rgba(0, 0, 0, 0.08)';
-
-  const cardSx = {
-    width: '100%',
-    p: 3,
-    bgcolor: 'var(--color-card-bg)',
-    borderRadius: 3,
-    mb: 3,
-    color: 'var(--color-bg-primary)',
-    display: 'flex',
-    flexDirection: 'column' as const,
-    gap: 3,
-    boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
-    border: `1px solid ${cardBorderColor}`,
-    backdropFilter: 'blur(14px)',
-    height: '100%',
-  } as const;
+  const cardSx = createCardSx(theme);
 
   const tooltipSx = {
     direction: 'rtl',
@@ -317,12 +669,6 @@ const Disk = () => {
       fontFamily: 'var(--font-vazir)',
     },
   } as const;
-
-  const disksWithUsage = useMemo(
-    () =>
-      (data?.disks ?? []).filter((disk) => disk.usage && disk.usage.total > 0),
-    [data?.disks]
-  );
 
   const ioSummary = useMemo<ParallelDatum[]>(() => {
     if (!data?.summary?.disk_io_summary) {
@@ -419,95 +765,6 @@ const Disk = () => {
         وضعیت دیسک
       </Typography>
 
-      <Stack spacing={2}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 500 }}>
-          نمای کلی مصرف دیسک
-        </Typography>
-        <Stack spacing={2}>
-          {disksWithUsage.map((disk) => {
-            const percent = Math.min(100, disk.usage.percent ?? 0);
-            return (
-              <Box
-                key={disk.device}
-                sx={{
-                  p: 2,
-                  borderRadius: 2,
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? 'rgba(255, 255, 255, 0.04)'
-                      : 'rgba(0, 0, 0, 0.04)',
-                  border: `1px solid ${
-                    theme.palette.mode === 'dark'
-                      ? 'rgba(255, 255, 255, 0.08)'
-                      : 'rgba(0, 0, 0, 0.08)'
-                  }`,
-                }}
-              >
-                <Stack spacing={1.2}>
-                  <Stack
-                    direction="row"
-                    alignItems="center"
-                    justifyContent="space-between"
-                  >
-                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {disk.device} ({disk.mountpoint || 'نامشخص'})
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      sx={{ color: 'text.secondary' }}
-                    >
-                      {(disk.fstype || '-').toUpperCase()}
-                    </Typography>
-                  </Stack>
-                  <LinearProgress
-                    variant="determinate"
-                    value={percent}
-                    sx={{
-                      height: 10,
-                      borderRadius: 999,
-                      bgcolor:
-                        theme.palette.mode === 'dark'
-                          ? 'rgba(255, 255, 255, 0.08)'
-                          : 'rgba(0, 0, 0, 0.1)',
-                      '& .MuiLinearProgress-bar': {
-                        borderRadius: 999,
-                      },
-                    }}
-                  />
-                  <Stack
-                    direction={{ xs: 'column', sm: 'row' }}
-                    spacing={1}
-                    justifyContent="space-between"
-                    sx={{
-                      color: theme.palette.text.secondary,
-                      fontSize: 12,
-                    }}
-                  >
-                    <Typography variant="caption">
-                      استفاده‌شده: {formatBytes(disk.usage.used)}
-                    </Typography>
-                    <Typography variant="caption">
-                      خالی: {formatBytes(disk.usage.free)}
-                    </Typography>
-                    <Typography variant="caption">
-                      کل: {formatBytes(disk.usage.total)}
-                    </Typography>
-                    <Typography variant="caption">
-                      درصد استفاده: {percent.toFixed(1)}%
-                    </Typography>
-                  </Stack>
-                </Stack>
-              </Box>
-            );
-          })}
-          {disksWithUsage.length === 0 && (
-            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-              داده‌ای برای مصرف دیسک در دسترس نیست.
-            </Typography>
-          )}
-        </Stack>
-      </Stack>
-
       <Divider sx={{ my: 1 }} />
 
       <Stack spacing={2}>
@@ -542,11 +799,15 @@ const Disk = () => {
                 {
                   dataKey: 'readGB',
                   label: 'خواندن (GB)',
+                  stack: 'total',
+                  color: theme.palette.primary.main,
                   valueFormatter: (value) => `${(value ?? 0).toFixed(2)} GB`,
                 },
                 {
                   dataKey: 'writeGB',
                   label: 'نوشتن (GB)',
+                  stack: 'total',
+                  color: theme.palette.warning.main,
                   valueFormatter: (value) => `${(value ?? 0).toFixed(2)} GB`,
                 },
               ]}

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { LineChart } from '@mui/x-charts';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { useNetwork } from '../hooks/useNetwork';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useNetwork, type InterfaceAddress, type NetworkInterface } from '../hooks/useNetwork';
 import '../index.css';
 
 type ResponsiveChartContainerProps = {
@@ -66,6 +66,131 @@ type History = Record<
 
 const MAX_HISTORY_MS = 90 * 1000; // 1 minute 30 seconds
 
+type IPv4Info = { address: string; netmask: string | null };
+
+const toCleanString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+};
+
+const flattenAddressEntries = (value: unknown): InterfaceAddress[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => flattenAddressEntries(entry));
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+
+    if ('address' in record || 'netmask' in record || 'family' in record) {
+      const candidate = record as InterfaceAddress;
+
+      return [
+        {
+          ...candidate,
+          address: toCleanString(candidate.address),
+          netmask: toCleanString(candidate.netmask),
+          family: toCleanString(candidate.family),
+        },
+      ];
+    }
+
+    return Object.values(record).flatMap((entry) => flattenAddressEntries(entry));
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? [{ address: trimmed }] : [];
+  }
+
+  return [];
+};
+
+const extractIPv4Info = (
+  networkInterface: NetworkInterface | undefined
+): IPv4Info[] => {
+  if (!networkInterface) {
+    return [];
+  }
+
+  const flattened = flattenAddressEntries(networkInterface.addresses);
+
+  const ipv4Entries = flattened
+    .map((entry) => {
+      const address = toCleanString(entry.address);
+      const family = toCleanString(entry.family)?.toLowerCase() ?? '';
+
+      if (!address) {
+        return null;
+      }
+
+      const isIPv4ByAddress = address.includes('.') && !address.includes(':');
+      const isIPv4ByFamily =
+        family === 'ipv4' ||
+        family === 'inet' ||
+        family.includes('af_inet') ||
+        (family.includes('inet') && !family.includes('6'));
+
+      if (!isIPv4ByAddress && !isIPv4ByFamily) {
+        return null;
+      }
+
+      if (!isIPv4ByAddress) {
+        return null;
+      }
+
+      const netmask = toCleanString(entry.netmask);
+
+      return {
+        address,
+        netmask: netmask ?? null,
+      };
+    })
+    .filter((value): value is IPv4Info => Boolean(value));
+
+  return ipv4Entries.reduce<IPv4Info[]>((acc, current) => {
+    const existingIndex = acc.findIndex((item) => item.address === current.address);
+
+    if (existingIndex === -1) {
+      acc.push(current);
+    } else if (!acc[existingIndex].netmask && current.netmask) {
+      acc[existingIndex] = { ...acc[existingIndex], netmask: current.netmask };
+    }
+
+    return acc;
+  }, []);
+};
+
+const formatInterfaceSpeed = (
+  status: NetworkInterface['status'] | undefined,
+  formatter: Intl.NumberFormat
+) => {
+  const rawSpeed = status?.speed;
+  const numericSpeed =
+    typeof rawSpeed === 'number'
+      ? rawSpeed
+      : typeof rawSpeed === 'string'
+        ? Number(rawSpeed)
+        : null;
+
+  if (numericSpeed == null || Number.isNaN(numericSpeed) || numericSpeed <= 0) {
+    return 'نامشخص';
+  }
+
+  return `${formatter.format(numericSpeed)} Mbps`;
+};
+
 const Network = () => {
   const { data, isLoading, error } = useNetwork();
   const theme = useTheme();
@@ -94,6 +219,11 @@ const Network = () => {
       return next;
     });
   }, [data]);
+
+  const speedFormatter = useMemo(
+    () => new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 0 }),
+    []
+  );
 
   if (error) return <Typography>Error: {error.message}</Typography>;
 
@@ -124,6 +254,16 @@ const Network = () => {
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.12)'
       : 'rgba(0, 0, 0, 0.08)';
+
+  const metaInfoBorderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(0, 0, 0, 0.12)';
+
+  const metaInfoBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)';
 
   return (
     <Box
@@ -192,7 +332,17 @@ const Network = () => {
         </ResponsiveChartContainer>
       ) : (
         names.map((name) => {
-          const unit = interfaces[name]?.bandwidth.unit ?? '';
+          const interfaceInfo = interfaces[name];
+          const unit = interfaceInfo?.bandwidth.unit ?? '';
+          const ipv4Details = extractIPv4Info(interfaceInfo);
+          const displayName =
+            ipv4Details.length > 0
+              ? `${name} (${ipv4Details.map((item) => item.address).join('، ')})`
+              : name;
+          const speedText = formatInterfaceSpeed(
+            interfaceInfo?.status,
+            speedFormatter
+          );
           const now = Date.now();
           const elapsed = now - startTimeRef.current;
           const min =
@@ -222,7 +372,7 @@ const Network = () => {
                 variant="h6"
                 sx={{ mb: 1, color: 'var(--color-primary)' }}
               >
-                {name}
+                {displayName}
               </Typography>
               <ResponsiveChartContainer height={chartSize}>
                 {(width) => (
@@ -279,6 +429,55 @@ const Network = () => {
                   />
                 )}
               </ResponsiveChartContainer>
+              <Box
+                sx={{
+                  mt: 2,
+                  width: '100%',
+                  bgcolor: metaInfoBackground,
+                  borderRadius: 2,
+                  px: 2,
+                  py: 1.5,
+                  border: `1px dashed ${metaInfoBorderColor}`,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 0.75,
+                }}
+              >
+                {ipv4Details.length > 0 ? (
+                  ipv4Details.map((entry, index) => {
+                    const labelPrefix =
+                      ipv4Details.length > 1
+                        ? `آدرس IPv4 ${index + 1}: `
+                        : 'آدرس IPv4: ';
+                    const netmaskSuffix = entry.netmask
+                      ? ` — نت‌ماسک: ${entry.netmask}`
+                      : '';
+
+                    return (
+                      <Typography
+                        key={`${entry.address}-${index}`}
+                        variant="body2"
+                        sx={{ color: theme.palette.text.secondary }}
+                      >
+                        {`${labelPrefix}${entry.address}${netmaskSuffix}`}
+                      </Typography>
+                    );
+                  })
+                ) : (
+                  <Typography
+                    variant="body2"
+                    sx={{ color: theme.palette.text.secondary }}
+                  >
+                    آدرس IPv4 در دسترس نیست.
+                  </Typography>
+                )}
+                <Typography
+                  variant="body2"
+                  sx={{ color: theme.palette.text.secondary }}
+                >
+                  سرعت لینک: {speedText}
+                </Typography>
+              </Box>
             </Box>
           );
         })

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -7,8 +7,22 @@ interface Bandwidth {
   unit: string;
 }
 
-interface NetworkInterface {
+export interface InterfaceAddress {
+  address?: string | null;
+  netmask?: string | null;
+  family?: string | null;
+  [key: string]: unknown;
+}
+
+export interface InterfaceStatus {
+  speed?: number | null;
+  [key: string]: unknown;
+}
+
+export interface NetworkInterface {
   bandwidth: Bandwidth;
+  addresses?: InterfaceAddress[] | Record<string, InterfaceAddress | null> | null;
+  status?: InterfaceStatus | null;
 }
 
 export interface NetworkData {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 import Cpu from '../components/Cpu';
-import Disk from '../components/Disk';
+import Disk, { DiskOverview } from '../components/Disk';
 import Memory from '../components/Memory';
 import Network from '../components/Network';
 
@@ -18,6 +18,15 @@ const Dashboard = () => {
         },
       }}
     >
+      <Box
+        sx={{
+          gridColumn: { xs: '1 / -1', md: '1 / -1', lg: 'span 8' },
+          display: 'flex',
+          width: '100%',
+        }}
+      >
+        <DiskOverview />
+      </Box>
       <Box
         sx={{
           gridColumn: { xs: '1 / -1', md: 'span 6', lg: 'span 2' },


### PR DESCRIPTION
## Summary
- Extract the disk usage donut cards into a dedicated `DiskOverview` export and leave the remaining analytics in the default disk component, reusing the shared card styling. 
- Surface the new overview component alongside the CPU and memory widgets on the dashboard grid so the donut cards appear on the top row.
- Extend network typing to include IPv4 metadata and render each interface with its IPv4 address, netmask, and link speed beneath the throughput chart.

## Testing
- `npx eslint src/components/Disk.tsx src/pages/Dashboard.tsx src/components/Network.tsx src/hooks/useNetwork.ts`


------
https://chatgpt.com/codex/tasks/task_b_68ca4ffc68f0832aaaddd814d861cd84