### PR TITLE
Refine not found page styling and copy

### DIFF
--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -17,94 +17,54 @@ const NotFoundPage = () => {
 
   return (
     <Box
+      component="section"
       sx={{
         position: 'relative',
         minHeight: { xs: '70svh', md: '80svh' },
         width: '100%',
-        display: 'grid',
-        placeItems: 'center',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         overflow: 'hidden',
-        px: { xs: 2, sm: 4 },
+        px: { xs: 2.5, sm: 4 },
         py: { xs: 6, md: 8 },
+        backgroundColor: 'var(--color-background)',
         fontFamily: 'var(--font-vazir)',
       }}
     >
-      <Box
-        aria-hidden
-        sx={{
-          position: 'absolute',
-          inset: 0,
-          backgroundImage:
-            'radial-gradient(circle at 15% 20%, rgba(0,198,169,0.25), transparent 60%), ' +
-            'radial-gradient(circle at 80% 0%, rgba(35,167,213,0.22), transparent 50%), ' +
-            'radial-gradient(circle at 85% 85%, rgba(163,146,75,0.18), transparent 45%)',
-          backgroundSize: '200% 200%',
-          animation: 'gradientMove 18s ease infinite',
-          opacity: 0.85,
-        }}
-      />
-
-      <Box
-        aria-hidden
-        sx={{
-          position: 'absolute',
-          width: { xs: 200, sm: 260 },
-          height: { xs: 200, sm: 260 },
-          top: { xs: '-70px', sm: '-90px' },
-          right: { xs: '-70px', sm: '-90px' },
-          borderRadius: '50%',
-          background: 'linear-gradient(140deg, rgba(35,167,213,0.35), rgba(0,198,169,0.25))',
-          filter: 'blur(0px)',
-          opacity: 0.6,
-        }}
-      />
-
-      <Box
-        aria-hidden
-        sx={{
-          position: 'absolute',
-          width: { xs: 220, sm: 280 },
-          height: { xs: 220, sm: 280 },
-          bottom: { xs: '-90px', sm: '-110px' },
-          left: { xs: '-80px', sm: '-100px' },
-          borderRadius: '50%',
-          background: 'linear-gradient(160deg, rgba(163,146,75,0.28), rgba(35,167,213,0.18))',
-          filter: 'blur(0px)',
-          opacity: 0.55,
-        }}
-      />
-
       <Box
         sx={{
           position: 'relative',
           zIndex: 1,
           width: '100%',
-          maxWidth: 680,
+          maxWidth: 620,
           textAlign: 'center',
           px: { xs: 4, sm: 6 },
-          py: { xs: 6, sm: 8 },
-          borderRadius: 4,
+          py: { xs: 5, sm: 7 },
+          borderRadius: 3,
           backgroundColor: 'var(--color-card-bg)',
-          backdropFilter: 'saturate(160%) blur(12px)',
+          backdropFilter: 'blur(10px)',
+          border: '1px solid',
+          borderColor: (theme) =>
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, 0.08)'
+              : 'rgba(15, 23, 42, 0.08)',
           boxShadow: (theme) =>
-            `0 24px 60px ${
-              theme.palette.mode === 'dark' ? '#000000aa' : '#00000033'
-            }`,
+            theme.palette.mode === 'dark'
+              ? '0 18px 48px rgba(0, 0, 0, 0.5)'
+              : '0 16px 44px rgba(15, 23, 42, 0.12)',
         }}
       >
-        <Stack spacing={3} alignItems="center">
+        <Stack spacing={{ xs: 3, sm: 4 }} alignItems="center">
           <Typography
             variant="h1"
             sx={{
               fontFamily: 'var(--font-didot)',
-              fontWeight: 700,
+              fontWeight: 600,
               lineHeight: 1,
-              fontSize: { xs: '4.5rem', sm: '6rem', md: '7.5rem' },
-              backgroundImage:
-                'linear-gradient(120deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
-              WebkitBackgroundClip: 'text',
-              backgroundClip: 'text',
-              color: 'transparent',
+              letterSpacing: '0.12em',
+              fontSize: { xs: '3.75rem', sm: '4.5rem', md: '5.5rem' },
+              color: 'var(--color-primary)',
             }}
           >
             404
@@ -114,11 +74,11 @@ const NotFoundPage = () => {
             <Typography
               variant="h4"
               sx={{
-                fontWeight: 800,
+                fontWeight: 700,
                 color: 'var(--color-bg-primary)',
               }}
             >
-              اوه! صفحه مورد نظر پیدا نشد
+              صفحه مورد نظر یافت نشد
             </Typography>
             <Typography
               variant="body1"
@@ -126,10 +86,10 @@ const NotFoundPage = () => {
                 maxWidth: 520,
                 mx: 'auto',
                 color: 'var(--color-text)',
-                lineHeight: 1.8,
+                lineHeight: 1.9,
               }}
             >
-              ممکن است مسیر حذف شده باشد یا هرگز وجود نداشته است. آدرس وارد شده را بررسی کنید یا یکی از گزینه‌های زیر را برای ادامه انتخاب نمایید.
+              صفحه‌ای که در جستجوی آن هستید در حال حاضر در دسترس نیست. احتمال دارد نشانی تغییر کرده یا صفحه حذف شده باشد. لطفاً نشانی وارد شده را بازبینی کنید یا از گزینه‌های زیر برای ادامه استفاده نمایید.
             </Typography>
           </Stack>
 
@@ -146,22 +106,17 @@ const NotFoundPage = () => {
               startIcon={<MdHome size={22} />}
               sx={{
                 minWidth: { xs: '100%', sm: 220 },
-                borderRadius: '14px',
-                py: 1.5,
+                borderRadius: 2,
+                py: 1.4,
                 fontWeight: 600,
                 fontSize: '1rem',
-                color: 'var(--color-bg-primary)',
-                backgroundImage:
-                  'linear-gradient(135deg, var(--color-primary), var(--color-primary-light))',
-                boxShadow: '0 16px 34px rgba(0, 198, 169, 0.35)',
+                boxShadow: 'none',
                 '&:hover': {
-                  backgroundImage:
-                    'linear-gradient(135deg, var(--color-primary-light), var(--color-primary))',
-                  boxShadow: '0 18px 40px rgba(0, 198, 169, 0.45)',
+                  boxShadow: 'none',
                 },
               }}
             >
-              {isAuthenticated ? 'بازگشت به داشبورد' : 'بازگشت به صفحه ورود'}
+              {isAuthenticated ? 'ورود به داشبورد' : 'ورود به سامانه'}
             </Button>
 
             <Button
@@ -170,11 +125,11 @@ const NotFoundPage = () => {
               startIcon={<MdArrowBack size={22} />}
               sx={{
                 minWidth: { xs: '100%', sm: 220 },
-                borderRadius: '14px',
-                py: 1.5,
+                borderRadius: 2,
+                py: 1.4,
                 fontWeight: 600,
                 fontSize: '1rem',
-                borderWidth: 2,
+                borderWidth: 1.5,
                 borderColor: 'var(--color-primary)',
                 color: 'var(--color-primary)',
                 '&:hover': {


### PR DESCRIPTION
## Summary
- simplify the 404 view layout with a centered card, subtle border, and neutral background to provide a more formal presentation
- revise the page messaging and button labels with formal Persian language suitable for official communication

## Testing
- npm run lint *(fails: pre-existing lint errors in Disk.tsx, Network.tsx, AuthContext.tsx, ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68ca8a0ced94832ab7979fc4512287a9