### PR TITLE
Split disk IO trend into count and bytes charts

### DIFF
--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -9,6 +9,7 @@ import {
 import type { Theme } from '@mui/material/styles';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
+import type { SeriesValueFormatterContext } from '@mui/x-charts/models/seriesType/common';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
 import type { DiskIOStats } from '../@types/disk';
@@ -35,7 +36,7 @@ type DiskMetricConfig = {
   format: (value: number) => string;
 };
 
-const IO_METRICS: DiskMetricConfig[] = [
+const COUNT_METRICS: DiskMetricConfig[] = [
   {
     key: 'read_count',
     label: 'تعداد خواندن',
@@ -48,6 +49,9 @@ const IO_METRICS: DiskMetricConfig[] = [
     getValue: (metrics) => metrics.write_count,
     format: (value) => `${formatLargeNumber(Math.max(value, 0))} عملیات`,
   },
+];
+
+const BYTE_METRICS: DiskMetricConfig[] = [
   {
     key: 'read_bytes',
     label: 'حجم خوانده‌شده',
@@ -60,13 +64,16 @@ const IO_METRICS: DiskMetricConfig[] = [
     getValue: (metrics) => metrics.write_bytes,
     format: (value) => formatBytes(Math.max(value, 0)),
   },
-  {
-    key: 'busy_time',
-    label: 'زمان مشغولی (ms)',
-    getValue: (metrics) => metrics.busy_time,
-    format: (value) => `${formatLargeNumber(Math.max(value, 0))} ms`,
-  },
 ];
+
+const BUSY_TIME_METRIC: DiskMetricConfig = {
+  key: 'busy_time',
+  label: 'زمان مشغولی (ms)',
+  getValue: (metrics) => metrics.busy_time,
+  format: (value) => `${formatLargeNumber(Math.max(value, 0))} ms`,
+};
+
+const ACTIVITY_METRICS: DiskMetricConfig[] = [...COUNT_METRICS, ...BYTE_METRICS];
 
 const formatBytes = (value: number) => {
   if (!Number.isFinite(value)) {
@@ -101,6 +108,8 @@ const formatLargeNumber = (value: number) => {
   }
   return value.toFixed(0);
 };
+
+const formatBusyTime = (value: number) => BUSY_TIME_METRIC.format(Math.max(value, 0));
 
 const normalizeMetrics = (metrics?: Partial<DiskIOStats>) => {
   return METRIC_KEYS.reduce(
@@ -151,6 +160,16 @@ const createCardSx = (theme: Theme) => {
 interface DeviceMetricDatum {
   name: string;
   metrics: NormalizedMetrics;
+}
+
+type NormalizedChartDatum = {
+  device: string;
+  busy_time: number;
+} & Partial<Record<keyof DiskIOStats, number>>;
+
+interface NormalizedDatasetResult {
+  dataset: NormalizedChartDatum[];
+  maxValues: Partial<Record<keyof DiskIOStats, number>>;
 }
 
 export const DiskOverview = () => {
@@ -488,6 +507,50 @@ export const DiskOverview = () => {
   );
 };
 
+const buildNormalizedDataset = (
+  metrics: DiskMetricConfig[],
+  devices: DeviceMetricDatum[]
+): NormalizedDatasetResult => {
+  const maxValues = metrics.reduce(
+    (acc, metric) => {
+      const values = devices.map((item) => {
+        const rawValue = metric.getValue(item.metrics);
+        return Number.isFinite(rawValue) ? rawValue : 0;
+      });
+
+      const metricMax = Math.max(...values, 0);
+      acc[metric.key] = metricMax;
+      return acc;
+    },
+    {} as NormalizedDatasetResult['maxValues']
+  );
+
+  const dataset = devices.map((item) => {
+    const busyRaw = item.metrics.busy_time;
+    const busyTime = Number.isFinite(busyRaw) ? Math.max(busyRaw, 0) : 0;
+
+    const entry: NormalizedChartDatum = {
+      device: item.name,
+      busy_time: busyTime,
+    };
+
+    metrics.forEach((metric) => {
+      const rawValue = metric.getValue(item.metrics);
+      const max = maxValues[metric.key] ?? 0;
+
+      if (max > 0 && Number.isFinite(rawValue)) {
+        entry[metric.key] = clampPercent((rawValue / max) * 100);
+      } else {
+        entry[metric.key] = 0;
+      }
+    });
+
+    return entry;
+  });
+
+  return { dataset, maxValues };
+};
+
 const Disk = () => {
   const { data, isLoading, error } = useDisk();
   const theme = useTheme();
@@ -506,6 +569,7 @@ const Disk = () => {
     '& .MuiChartsTooltip-value': {
       color: 'var(--color-text)',
       fontFamily: 'var(--font-vazir)',
+      whiteSpace: 'pre-line',
     },
     '& .MuiChartsTooltip-cell': {
       color: 'var(--color-text)',
@@ -524,7 +588,7 @@ const Disk = () => {
         metrics: normalizeMetrics(metrics),
       }))
       .filter((entry) =>
-        IO_METRICS.some((metric) => metric.getValue(entry.metrics) > 0)
+        ACTIVITY_METRICS.some((metric) => metric.getValue(entry.metrics) > 0)
       );
   }, [data?.summary?.disk_io_summary]);
 
@@ -544,39 +608,15 @@ const Disk = () => {
       .slice(0, 5);
   }, [ioSummary]);
 
-  const { dataset: ioLineDataset, maxValues: ioMetricMaxValues } =
-    useMemo(() => {
-      const maxValues = IO_METRICS.reduce(
-        (acc, metric) => {
-          const values = topDevices.map((item) => {
-            const rawValue = metric.getValue(item.metrics);
-            return Number.isFinite(rawValue) ? rawValue : 0;
-          });
+  const { dataset: ioCountDataset, maxValues: ioCountMaxValues } = useMemo(
+    () => buildNormalizedDataset(COUNT_METRICS, topDevices),
+    [topDevices]
+  );
 
-          acc[metric.key] = Math.max(...values, 0);
-          return acc;
-        },
-        {} as Record<keyof DiskIOStats, number>
-      );
-
-      const dataset = topDevices.map((item) => {
-        const entry: Record<string, string | number> = { device: item.name };
-
-        IO_METRICS.forEach((metric) => {
-          const rawValue = metric.getValue(item.metrics);
-          const max = maxValues[metric.key];
-          if (max > 0 && Number.isFinite(rawValue)) {
-            entry[metric.key] = clampPercent((rawValue / max) * 100);
-          } else {
-            entry[metric.key] = 0;
-          }
-        });
-
-        return entry;
-      });
-
-      return { dataset, maxValues };
-    }, [topDevices]);
+  const { dataset: ioBytesDataset, maxValues: ioBytesMaxValues } = useMemo(
+    () => buildNormalizedDataset(BYTE_METRICS, topDevices),
+    [topDevices]
+  );
 
   const chartColors = useMemo(
     () => [
@@ -597,11 +637,12 @@ const Disk = () => {
     ]
   );
 
-  const ioLineSeries = useMemo(
+  const ioCountSeries = useMemo(
     () =>
-      IO_METRICS.map((metric, index) => {
+      COUNT_METRICS.map((metric, index) => {
         const color = chartColors[index % chartColors.length];
-        const max = ioMetricMaxValues[metric.key] ?? 0;
+        const max = ioCountMaxValues[metric.key] ?? 0;
+        const includeBusyInfo = index === 0;
 
         return {
           dataKey: metric.key,
@@ -609,18 +650,81 @@ const Disk = () => {
           color,
           curve: 'monotoneX' as const,
           showMark: true,
-          valueFormatter: (value: number | null) => {
-            if (!Number.isFinite(value) || max <= 0) {
-              return metric.format(0);
+          valueFormatter: (
+            value: number | null,
+            context: SeriesValueFormatterContext
+          ) => {
+            const dataIndex = context?.dataIndex ?? 0;
+            const entry =
+              dataIndex >= 0 && dataIndex < ioCountDataset.length
+                ? ioCountDataset[dataIndex]
+                : undefined;
+            const busyTimeValue = Number(entry?.busy_time ?? 0);
+            const busyInfo = includeBusyInfo
+              ? `\nزمان مشغولی: ${formatBusyTime(busyTimeValue)}`
+              : '';
+
+            if (
+              typeof value !== 'number' ||
+              !Number.isFinite(value) ||
+              max <= 0
+            ) {
+              const formatted = metric.format(0);
+              return includeBusyInfo ? `${formatted}${busyInfo}` : formatted;
             }
 
-            const normalized = Number(value);
-            const actual = (normalized / 100) * max;
-            return metric.format(actual);
+            const actual = (value / 100) * max;
+            const formatted = metric.format(actual);
+            return includeBusyInfo ? `${formatted}${busyInfo}` : formatted;
           },
         };
       }),
-    [chartColors, ioMetricMaxValues]
+    [chartColors, ioCountDataset, ioCountMaxValues]
+  );
+
+  const ioBytesSeries = useMemo(
+    () =>
+      BYTE_METRICS.map((metric, index) => {
+        const color = chartColors[index % chartColors.length];
+        const max = ioBytesMaxValues[metric.key] ?? 0;
+        const includeBusyInfo = index === 0;
+
+        return {
+          dataKey: metric.key,
+          label: metric.label,
+          color,
+          curve: 'monotoneX' as const,
+          showMark: true,
+          valueFormatter: (
+            value: number | null,
+            context: SeriesValueFormatterContext
+          ) => {
+            const dataIndex = context?.dataIndex ?? 0;
+            const entry =
+              dataIndex >= 0 && dataIndex < ioBytesDataset.length
+                ? ioBytesDataset[dataIndex]
+                : undefined;
+            const busyTimeValue = Number(entry?.busy_time ?? 0);
+            const busyInfo = includeBusyInfo
+              ? `\nزمان مشغولی: ${formatBusyTime(busyTimeValue)}`
+              : '';
+
+            if (
+              typeof value !== 'number' ||
+              !Number.isFinite(value) ||
+              max <= 0
+            ) {
+              const formatted = metric.format(0);
+              return includeBusyInfo ? `${formatted}${busyInfo}` : formatted;
+            }
+
+            const actual = (value / 100) * max;
+            const formatted = metric.format(actual);
+            return includeBusyInfo ? `${formatted}${busyInfo}` : formatted;
+          },
+        };
+      }),
+    [chartColors, ioBytesDataset, ioBytesMaxValues]
   );
 
   const barChartDataset = useMemo(
@@ -674,49 +778,103 @@ const Disk = () => {
         <Typography variant="subtitle2" sx={{ fontWeight: 500 }}>
           مقایسه شاخص‌های ورودی/خروجی (نمودار روند نرمال‌شده)
         </Typography>
-        {ioLineDataset.length > 0 ? (
-          <Box sx={{ width: '100%', direction: 'ltr' }}>
-            <LineChart
-              dataset={ioLineDataset}
-              series={ioLineSeries}
-              xAxis={[
-                {
-                  dataKey: 'device',
-                  scaleType: 'band',
-                  tickLabelStyle: { fill: 'var(--color-text)' },
-                  labelStyle: { fill: 'var(--color-text)' },
-                },
-              ]}
-              yAxis={[
-                {
-                  min: 0,
-                  max: 105,
-                  label: 'شاخص نرمال‌شده (٪)',
-                  valueFormatter: (value: number) =>
-                    `${diskPercentFormatter.format(value)}٪`,
-                  tickLabelStyle: { fill: 'var(--color-text)' },
-                  labelStyle: { fill: 'var(--color-text)' },
-                  position: 'left',
-                  tickSize: 45,
-                  width: 96,
-                },
-              ]}
-              axisHighlight={{ x: 'line' }}
-              grid={{ horizontal: true, vertical: false }}
-              height={320}
-              margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
-              slotProps={{
-                tooltip: { sx: tooltipSx },
-                legend: {
-                  sx: {
-                    color: 'var(--color-text)',
-                    fontFamily: 'var(--font-vazir)',
-                  },
-                  position: { vertical: 'top', horizontal: 'center' },
-                },
-              }}
-            />
-          </Box>
+        {ioCountDataset.length > 0 ? (
+          <Stack spacing={3}>
+            <Stack spacing={1.5}>
+              <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                روند تعداد عملیات خواندن/نوشتن
+              </Typography>
+              <Box sx={{ width: '100%', direction: 'ltr' }}>
+                <LineChart
+                  dataset={ioCountDataset}
+                  series={ioCountSeries}
+                  xAxis={[
+                    {
+                      dataKey: 'device',
+                      scaleType: 'band',
+                      tickLabelStyle: { fill: 'var(--color-text)' },
+                      labelStyle: { fill: 'var(--color-text)' },
+                    },
+                  ]}
+                  yAxis={[
+                    {
+                      min: 0,
+                      max: 105,
+                      label: 'شاخص نرمال‌شده (٪)',
+                      valueFormatter: (value: number) =>
+                        `${diskPercentFormatter.format(value)}٪`,
+                      tickLabelStyle: { fill: 'var(--color-text)' },
+                      labelStyle: { fill: 'var(--color-text)' },
+                      position: 'left',
+                      tickSize: 45,
+                      width: 96,
+                    },
+                  ]}
+                  axisHighlight={{ x: 'line' }}
+                  grid={{ horizontal: true, vertical: false }}
+                  height={320}
+                  margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
+                  slotProps={{
+                    tooltip: { sx: tooltipSx },
+                    legend: {
+                      sx: {
+                        color: 'var(--color-text)',
+                        fontFamily: 'var(--font-vazir)',
+                      },
+                      position: { vertical: 'top', horizontal: 'center' },
+                    },
+                  }}
+                />
+              </Box>
+            </Stack>
+            <Stack spacing={1.5}>
+              <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                روند حجم داده خواندن/نوشتن
+              </Typography>
+              <Box sx={{ width: '100%', direction: 'ltr' }}>
+                <LineChart
+                  dataset={ioBytesDataset}
+                  series={ioBytesSeries}
+                  xAxis={[
+                    {
+                      dataKey: 'device',
+                      scaleType: 'band',
+                      tickLabelStyle: { fill: 'var(--color-text)' },
+                      labelStyle: { fill: 'var(--color-text)' },
+                    },
+                  ]}
+                  yAxis={[
+                    {
+                      min: 0,
+                      max: 105,
+                      label: 'شاخص نرمال‌شده (٪)',
+                      valueFormatter: (value: number) =>
+                        `${diskPercentFormatter.format(value)}٪`,
+                      tickLabelStyle: { fill: 'var(--color-text)' },
+                      labelStyle: { fill: 'var(--color-text)' },
+                      position: 'left',
+                      tickSize: 45,
+                      width: 96,
+                    },
+                  ]}
+                  axisHighlight={{ x: 'line' }}
+                  grid={{ horizontal: true, vertical: false }}
+                  height={320}
+                  margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
+                  slotProps={{
+                    tooltip: { sx: tooltipSx },
+                    legend: {
+                      sx: {
+                        color: 'var(--color-text)',
+                        fontFamily: 'var(--font-vazir)',
+                      },
+                      position: { vertical: 'top', horizontal: 'center' },
+                    },
+                  }}
+                />
+              </Box>
+            </Stack>
+          </Stack>
         ) : (
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             شاخص قابل توجهی برای نمایش وجود ندارد.


### PR DESCRIPTION
## Summary
- split the normalized disk I/O trend section into separate line charts for read/write operations and read/write throughput while surfacing busy time in the tooltips
- add helpers for building normalized datasets so the new charts share consistent scaling and busy-time formatting

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68caa7944c54832a857f3d263b118cf8