### PR TITLE
Split disk I/O charts with unit scaling and add custom tooltip

### DIFF
--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -8,9 +8,21 @@ import {
 } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
 import { BarChart } from '@mui/x-charts/BarChart';
-import { LineChart } from '@mui/x-charts/LineChart';
+import { ChartsLabelMark } from '@mui/x-charts/ChartsLabel';
+import {
+  ChartsTooltipCell,
+  ChartsTooltipContainer,
+  ChartsTooltipPaper,
+  ChartsTooltipRow,
+  ChartsTooltipTable,
+  chartsTooltipClasses,
+  type ChartsTooltipClasses,
+  type ChartsTooltipProps,
+  useAxesTooltip,
+} from '@mui/x-charts/ChartsTooltip';
+import { LineChart, type LineChartSlotProps, type LineSeries } from '@mui/x-charts/LineChart';
 import { PieChart } from '@mui/x-charts/PieChart';
-import { useMemo } from 'react';
+import { createContext, useCallback, useContext, useMemo } from 'react';
 import type { DiskIOStats } from '../@types/disk';
 import { useDisk } from '../hooks/useDisk';
 import '../index.css';
@@ -67,6 +79,37 @@ const IO_METRICS: DiskMetricConfig[] = [
     format: (value) => `${formatLargeNumber(Math.max(value, 0))} ms`,
   },
 ];
+
+const BUSY_TIME_METRIC = IO_METRICS.find(
+  (metric): metric is DiskMetricConfig & { key: 'busy_time' } => metric.key === 'busy_time'
+);
+
+type BusyTimeTooltipInfo = {
+  formatted: string;
+};
+
+type BusyTimeTooltipMap = Record<string, BusyTimeTooltipInfo>;
+
+interface DiskTooltipContextValue {
+  label: string;
+  map: BusyTimeTooltipMap;
+}
+
+const DiskTooltipContext = createContext<DiskTooltipContextValue>({
+  label: BUSY_TIME_METRIC?.label ?? 'زمان مشغولی',
+  map: {},
+});
+
+const combineClasses = (...classes: Array<string | undefined>) =>
+  classes.filter(Boolean).join(' ') || undefined;
+
+const IO_METRIC_METADATA = IO_METRICS.reduce(
+  (acc, metric, index) => {
+    acc[metric.key] = { config: metric, index };
+    return acc;
+  },
+  {} as Partial<Record<keyof DiskIOStats, { config: DiskMetricConfig; index: number }>>
+);
 
 const formatBytes = (value: number) => {
   if (!Number.isFinite(value)) {
@@ -147,6 +190,174 @@ const createCardSx = (theme: Theme) => {
     height: '100%',
   } as const;
 };
+
+type DiskAxisTooltipContentProps = {
+  classes?: Partial<ChartsTooltipClasses>;
+  sx?: ChartsTooltipProps['sx'];
+};
+
+const DiskAxisTooltipContent = ({ classes, sx }: DiskAxisTooltipContentProps) => {
+  const tooltipData = useAxesTooltip();
+  const { label: busyTimeLabel, map: busyTimeMap } = useContext(DiskTooltipContext);
+
+  if (tooltipData === null) {
+    return null;
+  }
+
+  return (
+    <ChartsTooltipPaper
+      sx={sx}
+      className={combineClasses(chartsTooltipClasses.paper, classes?.paper)}
+    >
+      {tooltipData.map(({
+        axisId,
+        axisValue,
+        axisFormattedValue,
+        mainAxis,
+        seriesItems,
+      }) => {
+        const axisKey = axisValue != null ? String(axisValue) : undefined;
+        const busyTimeInfo = axisKey ? busyTimeMap[axisKey] : undefined;
+
+        return (
+          <ChartsTooltipTable
+            key={axisId}
+            className={combineClasses(chartsTooltipClasses.table, classes?.table)}
+          >
+            {axisValue != null && !mainAxis.hideTooltip && (
+              <Typography component="caption">{axisFormattedValue}</Typography>
+            )}
+            <tbody>
+              {seriesItems.map(({
+                seriesId,
+                color,
+                formattedValue,
+                formattedLabel,
+                markType,
+              }) => {
+                if (formattedValue == null) {
+                  return null;
+                }
+
+                return (
+                  <ChartsTooltipRow
+                    key={seriesId}
+                    className={combineClasses(chartsTooltipClasses.row, classes?.row)}
+                  >
+                    <ChartsTooltipCell
+                      component="th"
+                      className={combineClasses(
+                        chartsTooltipClasses.cell,
+                        chartsTooltipClasses.labelCell,
+                        classes?.cell,
+                        classes?.labelCell
+                      )}
+                    >
+                      <Box
+                        component="span"
+                        className={combineClasses(
+                          chartsTooltipClasses.markContainer,
+                          classes?.markContainer
+                        )}
+                      >
+                        <ChartsLabelMark
+                          type={markType}
+                          color={color}
+                          className={combineClasses(
+                            chartsTooltipClasses.mark,
+                            classes?.mark
+                          )}
+                        />
+                      </Box>
+                      {formattedLabel ?? null}
+                    </ChartsTooltipCell>
+                    <ChartsTooltipCell
+                      component="td"
+                      className={combineClasses(
+                        chartsTooltipClasses.cell,
+                        chartsTooltipClasses.valueCell,
+                        classes?.cell,
+                        classes?.valueCell
+                      )}
+                    >
+                      {formattedValue}
+                    </ChartsTooltipCell>
+                  </ChartsTooltipRow>
+                );
+              })}
+              {busyTimeInfo ? (
+                <ChartsTooltipRow
+                  className={combineClasses(chartsTooltipClasses.row, classes?.row)}
+                >
+                  <ChartsTooltipCell
+                    component="th"
+                    className={combineClasses(
+                      chartsTooltipClasses.cell,
+                      chartsTooltipClasses.labelCell,
+                      classes?.cell,
+                      classes?.labelCell
+                    )}
+                  >
+                    <Box
+                      component="span"
+                      className={combineClasses(
+                        chartsTooltipClasses.markContainer,
+                        classes?.markContainer
+                      )}
+                      sx={{ visibility: 'hidden' }}
+                    />
+                    {busyTimeLabel}
+                  </ChartsTooltipCell>
+                  <ChartsTooltipCell
+                    component="td"
+                    className={combineClasses(
+                      chartsTooltipClasses.cell,
+                      chartsTooltipClasses.valueCell,
+                      classes?.cell,
+                      classes?.valueCell
+                    )}
+                  >
+                    {busyTimeInfo.formatted}
+                  </ChartsTooltipCell>
+                </ChartsTooltipRow>
+              ) : null}
+            </tbody>
+          </ChartsTooltipTable>
+        );
+      })}
+    </ChartsTooltipPaper>
+  );
+};
+
+const DiskTooltip = (props: ChartsTooltipProps) => {
+  const { classes, sx, ...other } = props;
+
+  return (
+    <ChartsTooltipContainer {...other} classes={classes} sx={sx}>
+      <DiskAxisTooltipContent classes={classes} sx={sx} />
+    </ChartsTooltipContainer>
+  );
+};
+
+const DISK_TOOLTIP_SX = {
+  direction: 'rtl',
+  '& .MuiChartsTooltip-table': {
+    direction: 'rtl',
+    color: 'var(--color-text)',
+  },
+  '& .MuiChartsTooltip-label': {
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+  '& .MuiChartsTooltip-value': {
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+  '& .MuiChartsTooltip-cell': {
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+} as const;
 
 interface DeviceMetricDatum {
   name: string;
@@ -493,26 +704,6 @@ const Disk = () => {
   const theme = useTheme();
   const cardSx = createCardSx(theme);
 
-  const tooltipSx = {
-    direction: 'rtl',
-    '& .MuiChartsTooltip-table': {
-      direction: 'rtl',
-      color: 'var(--color-text)',
-    },
-    '& .MuiChartsTooltip-label': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-    '& .MuiChartsTooltip-value': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-    '& .MuiChartsTooltip-cell': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-  } as const;
-
   const ioSummary = useMemo<DeviceMetricDatum[]>(() => {
     if (!data?.summary?.disk_io_summary) {
       return [];
@@ -564,12 +755,9 @@ const Disk = () => {
 
         IO_METRICS.forEach((metric) => {
           const rawValue = metric.getValue(item.metrics);
-          const max = maxValues[metric.key];
-          if (max > 0 && Number.isFinite(rawValue)) {
-            entry[metric.key] = clampPercent((rawValue / max) * 100);
-          } else {
-            entry[metric.key] = 0;
-          }
+          entry[metric.key] = Number.isFinite(rawValue)
+            ? Math.max(rawValue, 0)
+            : 0;
         });
 
         return entry;
@@ -597,30 +785,76 @@ const Disk = () => {
     ]
   );
 
-  const ioLineSeries = useMemo(
-    () =>
-      IO_METRICS.map((metric, index) => {
-        const color = chartColors[index % chartColors.length];
-        const max = ioMetricMaxValues[metric.key] ?? 0;
+  const createSeriesForKeys = useCallback(
+    (keys: Array<keyof DiskIOStats>) =>
+      keys
+        .map<LineSeries | null>((key) => {
+          const metadata = IO_METRIC_METADATA[key];
+          if (!metadata) {
+            return null;
+          }
 
-        return {
-          dataKey: metric.key,
-          label: metric.label,
-          color,
-          curve: 'monotoneX' as const,
-          showMark: true,
-          valueFormatter: (value: number | null) => {
-            if (!Number.isFinite(value) || max <= 0) {
-              return metric.format(0);
-            }
+          const { config: metric, index } = metadata;
+          const color = chartColors[index % chartColors.length];
+          const max = ioMetricMaxValues[metric.key] ?? 0;
 
-            const normalized = Number(value);
-            const actual = (normalized / 100) * max;
-            return metric.format(actual);
-          },
-        };
-      }),
+          return {
+            id: metric.key,
+            dataKey: metric.key,
+            label: metric.label,
+            color,
+            curve: 'monotoneX',
+            showMark: true,
+            valueFormatter: (value: number | null) => {
+              if (!Number.isFinite(value) || max <= 0) {
+                return metric.format(0);
+              }
+
+              return metric.format(Math.max(Number(value), 0));
+            },
+          } satisfies LineSeries;
+        })
+        .filter((series): series is LineSeries => series !== null),
     [chartColors, ioMetricMaxValues]
+  );
+
+  const ioCountSeries = useMemo(
+    () => createSeriesForKeys(['read_count', 'write_count']),
+    [createSeriesForKeys]
+  );
+
+  const ioBytesSeries = useMemo(
+    () => createSeriesForKeys(['read_bytes', 'write_bytes']),
+    [createSeriesForKeys]
+  );
+
+  const busyTimeTooltipData = useMemo<DiskTooltipContextValue>(() => {
+    if (!BUSY_TIME_METRIC) {
+      return { label: 'زمان مشغولی', map: {} };
+    }
+
+    const map = topDevices.reduce<BusyTimeTooltipMap>((acc, item) => {
+      const rawValue = BUSY_TIME_METRIC.getValue(item.metrics);
+      acc[item.name] = { formatted: BUSY_TIME_METRIC.format(rawValue) };
+      return acc;
+    }, {});
+
+    return { label: BUSY_TIME_METRIC.label, map };
+  }, [topDevices]);
+
+  const lineChartSlotProps = useMemo(
+    () =>
+      ({
+        tooltip: { sx: DISK_TOOLTIP_SX },
+        legend: {
+          sx: {
+            color: 'var(--color-text)',
+            fontFamily: 'var(--font-vazir)',
+          },
+          position: { vertical: 'top', horizontal: 'center' },
+        },
+      }) satisfies LineChartSlotProps,
+    []
   );
 
   const barChartDataset = useMemo(
@@ -632,6 +866,35 @@ const Disk = () => {
       })),
     [topDevices]
   );
+
+  const ioCountAxisMax = Math.max(
+    ioMetricMaxValues.read_count ?? 0,
+    ioMetricMaxValues.write_count ?? 0
+  );
+  const ioBytesAxisMax = Math.max(
+    ioMetricMaxValues.read_bytes ?? 0,
+    ioMetricMaxValues.write_bytes ?? 0
+  );
+  const ioCountAxisMaxValue =
+    ioCountAxisMax > 0 ? ioCountAxisMax : undefined;
+  const ioBytesAxisMaxValue =
+    ioBytesAxisMax > 0 ? ioBytesAxisMax : undefined;
+
+  const formatCountAxisValue = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return formatLargeNumber(0);
+    }
+
+    return formatLargeNumber(Math.max(value, 0));
+  };
+
+  const formatBytesAxisValue = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return formatBytes(0);
+    }
+
+    return formatBytes(Math.max(value, 0));
+  };
 
   if (isLoading) {
     return (
@@ -675,48 +938,86 @@ const Disk = () => {
           مقایسه شاخص‌های ورودی/خروجی (نمودار روند نرمال‌شده)
         </Typography>
         {ioLineDataset.length > 0 ? (
-          <Box sx={{ width: '100%', direction: 'ltr' }}>
-            <LineChart
-              dataset={ioLineDataset}
-              series={ioLineSeries}
-              xAxis={[
-                {
-                  dataKey: 'device',
-                  scaleType: 'band',
-                  tickLabelStyle: { fill: 'var(--color-text)' },
-                  labelStyle: { fill: 'var(--color-text)' },
-                },
-              ]}
-              yAxis={[
-                {
-                  min: 0,
-                  max: 105,
-                  label: 'شاخص نرمال‌شده (٪)',
-                  valueFormatter: (value: number) =>
-                    `${diskPercentFormatter.format(value)}٪`,
-                  tickLabelStyle: { fill: 'var(--color-text)' },
-                  labelStyle: { fill: 'var(--color-text)' },
-                  position: 'left',
-                  tickSize: 45,
-                  width: 96,
-                },
-              ]}
-              axisHighlight={{ x: 'line' }}
-              grid={{ horizontal: true, vertical: false }}
-              height={320}
-              margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
-              slotProps={{
-                tooltip: { sx: tooltipSx },
-                legend: {
-                  sx: {
-                    color: 'var(--color-text)',
-                    fontFamily: 'var(--font-vazir)',
-                  },
-                  position: { vertical: 'top', horizontal: 'center' },
-                },
-              }}
-            />
-          </Box>
+          <DiskTooltipContext.Provider value={busyTimeTooltipData}>
+            <Stack spacing={3}>
+              <Box>
+                <Typography variant="body2" sx={{ fontWeight: 500, mb: 1 }}>
+                  تعداد عملیات خواندن/نوشتن
+                </Typography>
+                <Box sx={{ width: '100%', direction: 'ltr' }}>
+                  <LineChart
+                    dataset={ioLineDataset}
+                    series={ioCountSeries}
+                    xAxis={[
+                      {
+                        dataKey: 'device',
+                        scaleType: 'band',
+                        tickLabelStyle: { fill: 'var(--color-text)' },
+                        labelStyle: { fill: 'var(--color-text)' },
+                      },
+                    ]}
+                    yAxis={[
+                      {
+                        min: 0,
+                        max: ioCountAxisMaxValue,
+                        label: 'تعداد عملیات (عدد)',
+                        valueFormatter: formatCountAxisValue,
+                        tickLabelStyle: { fill: 'var(--color-text)' },
+                        labelStyle: { fill: 'var(--color-text)' },
+                        position: 'left',
+                        tickSize: 45,
+                        width: 96,
+                      },
+                    ]}
+                    axisHighlight={{ x: 'line' }}
+                    grid={{ horizontal: true, vertical: false }}
+                    height={280}
+                    margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
+                    slots={{ tooltip: DiskTooltip }}
+                    slotProps={lineChartSlotProps}
+                  />
+                </Box>
+              </Box>
+              <Box>
+                <Typography variant="body2" sx={{ fontWeight: 500, mb: 1 }}>
+                  حجم خواندن/نوشتن
+                </Typography>
+                <Box sx={{ width: '100%', direction: 'ltr' }}>
+                  <LineChart
+                    dataset={ioLineDataset}
+                    series={ioBytesSeries}
+                    xAxis={[
+                      {
+                        dataKey: 'device',
+                        scaleType: 'band',
+                        tickLabelStyle: { fill: 'var(--color-text)' },
+                        labelStyle: { fill: 'var(--color-text)' },
+                      },
+                    ]}
+                    yAxis={[
+                      {
+                        min: 0,
+                        max: ioBytesAxisMaxValue,
+                        label: 'حجم داده (بایت)',
+                        valueFormatter: formatBytesAxisValue,
+                        tickLabelStyle: { fill: 'var(--color-text)' },
+                        labelStyle: { fill: 'var(--color-text)' },
+                        position: 'left',
+                        tickSize: 45,
+                        width: 96,
+                      },
+                    ]}
+                    axisHighlight={{ x: 'line' }}
+                    grid={{ horizontal: true, vertical: false }}
+                    height={280}
+                    margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
+                    slots={{ tooltip: DiskTooltip }}
+                    slotProps={lineChartSlotProps}
+                  />
+                </Box>
+              </Box>
+            </Stack>
+          </DiskTooltipContext.Provider>
         ) : (
           <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             شاخص قابل توجهی برای نمایش وجود ندارد.
@@ -763,7 +1064,7 @@ const Disk = () => {
               height={280}
               margin={{ top: 60, right: 40, left: 40 }}
               slotProps={{
-                tooltip: { sx: tooltipSx },
+                tooltip: { sx: DISK_TOOLTIP_SX },
                 legend: {
                   sx: {
                     color: 'var(--color-text)',


### PR DESCRIPTION
## Summary
- add a disk tooltip context and custom tooltip content so busy_time appears alongside trend series
- split the disk I/O trend view into separate charts for read/write counts and bytes while reusing shared styling
- switch the split disk I/O charts to unit-based axes that label counts and bytes and cap each y-axis at the maximum metric value

## Testing
- npm run build
- npm run lint *(fails: react-refresh/only-export-components errors in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68caa7944c54832a857f3d263b118cf8