### PR TITLE
Adjust disk I/O chart axes for dynamic units

### DIFF
--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -90,9 +90,10 @@ const ACTIVITY_METRICS: DiskMetricConfig[] = [
   ...BYTE_METRICS,
 ];
 
-const BUSY_TIME_METRIC = IO_METRICS.find(
-  (metric): metric is DiskMetricConfig & { key: 'busy_time' } => metric.key === 'busy_time'
-);
+const IO_METRICS: DiskMetricConfig[] = [
+  ...ACTIVITY_METRICS,
+  BUSY_TIME_METRIC,
+];
 
 type BusyTimeTooltipInfo = {
   formatted: string;
@@ -106,7 +107,7 @@ interface DiskTooltipContextValue {
 }
 
 const DiskTooltipContext = createContext<DiskTooltipContextValue>({
-  label: BUSY_TIME_METRIC?.label ?? 'زمان مشغولی',
+  label: BUSY_TIME_METRIC.label,
   map: {},
 });
 
@@ -155,8 +156,76 @@ const formatLargeNumber = (value: number) => {
   return value.toFixed(0);
 };
 
-const formatBusyTime = (value: number) =>
-  BUSY_TIME_METRIC.format(Math.max(value, 0));
+type AxisUnitInfo = {
+  label: string;
+  divisor: number;
+};
+
+const createAxisNumberFormatter = (
+  divisor: number,
+  maximumFractionDigits: number
+) => {
+  const safeDivisor = divisor > 0 ? divisor : 1;
+  const formatter = new Intl.NumberFormat('fa-IR', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: Math.max(0, maximumFractionDigits),
+  });
+
+  return (value: number | null | undefined) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return formatter.format(0);
+    }
+
+    const scaled = Math.max(value, 0) / safeDivisor;
+    return formatter.format(scaled);
+  };
+};
+
+const COUNT_AXIS_BASE_UNIT: AxisUnitInfo = { label: 'عدد', divisor: 1 };
+
+const COUNT_AXIS_UNITS: AxisUnitInfo[] = [
+  { label: 'میلیارد', divisor: 1_000_000_000 },
+  { label: 'میلیون', divisor: 1_000_000 },
+  { label: 'هزار', divisor: 1_000 },
+];
+
+const determineCountAxisUnit = (value: number): AxisUnitInfo => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return COUNT_AXIS_BASE_UNIT;
+  }
+
+  for (const unit of COUNT_AXIS_UNITS) {
+    if (value >= unit.divisor) {
+      return unit;
+    }
+  }
+
+  return COUNT_AXIS_BASE_UNIT;
+};
+
+const BYTE_AXIS_BASE_UNIT: AxisUnitInfo = { label: 'بایت', divisor: 1 };
+
+const BYTE_AXIS_UNITS: AxisUnitInfo[] = [
+  { label: 'پتابایت', divisor: 1024 ** 5 },
+  { label: 'ترابایت', divisor: 1024 ** 4 },
+  { label: 'گیگابایت', divisor: 1024 ** 3 },
+  { label: 'مگابایت', divisor: 1024 ** 2 },
+  { label: 'کیلوبایت', divisor: 1024 },
+];
+
+const determineByteAxisUnit = (value: number): AxisUnitInfo => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return BYTE_AXIS_BASE_UNIT;
+  }
+
+  for (const unit of BYTE_AXIS_UNITS) {
+    if (value >= unit.divisor) {
+      return unit;
+    }
+  }
+
+  return BYTE_AXIS_BASE_UNIT;
+};
 
 const normalizeMetrics = (metrics?: Partial<DiskIOStats>) => {
   return METRIC_KEYS.reduce(
@@ -830,8 +899,10 @@ const Disk = () => {
         return entry;
       });
 
+      return { dataset, maxValues };
+    }, [topDevices]);
 
-  const { dataset: ioBytesDataset, maxValues: ioBytesMaxValues } = useMemo(
+  const { maxValues: ioBytesMaxValues } = useMemo(
     () => buildNormalizedDataset(BYTE_METRICS, topDevices),
     [topDevices]
   );
@@ -938,34 +1009,58 @@ const Disk = () => {
     [topDevices]
   );
 
-  const ioCountAxisMax = Math.max(
-    ioMetricMaxValues.read_count ?? 0,
-    ioMetricMaxValues.write_count ?? 0
+  const ioCountAxisMax = useMemo(
+    () =>
+      COUNT_METRICS.reduce(
+        (max, metric) =>
+          Math.max(max, ioMetricMaxValues[metric.key] ?? 0),
+        0
+      ),
+    [ioMetricMaxValues]
   );
-  const ioBytesAxisMax = Math.max(
-    ioMetricMaxValues.read_bytes ?? 0,
-    ioMetricMaxValues.write_bytes ?? 0
+
+  const ioBytesAxisMax = useMemo(
+    () =>
+      BYTE_METRICS.reduce(
+        (max, metric) =>
+          Math.max(max, ioBytesMaxValues[metric.key] ?? 0),
+        0
+      ),
+    [ioBytesMaxValues]
   );
+
+  const countAxisUnitInfo = useMemo(
+    () => determineCountAxisUnit(ioCountAxisMax),
+    [ioCountAxisMax]
+  );
+
+  const bytesAxisUnitInfo = useMemo(
+    () => determineByteAxisUnit(ioBytesAxisMax),
+    [ioBytesAxisMax]
+  );
+
   const ioCountAxisMaxValue =
     ioCountAxisMax > 0 ? ioCountAxisMax : undefined;
   const ioBytesAxisMaxValue =
     ioBytesAxisMax > 0 ? ioBytesAxisMax : undefined;
 
-  const formatCountAxisValue = (value: number) => {
-    if (!Number.isFinite(value)) {
-      return formatLargeNumber(0);
-    }
+  const formatCountAxisValue = useMemo(
+    () =>
+      createAxisNumberFormatter(
+        countAxisUnitInfo.divisor,
+        countAxisUnitInfo.divisor === 1 ? 0 : 1
+      ),
+    [countAxisUnitInfo.divisor]
+  );
 
-    return formatLargeNumber(Math.max(value, 0));
-  };
-
-  const formatBytesAxisValue = (value: number) => {
-    if (!Number.isFinite(value)) {
-      return formatBytes(0);
-    }
-
-    return formatBytes(Math.max(value, 0));
-  };
+  const formatBytesAxisValue = useMemo(
+    () =>
+      createAxisNumberFormatter(
+        bytesAxisUnitInfo.divisor,
+        bytesAxisUnitInfo.divisor === 1 ? 0 : 2
+      ),
+    [bytesAxisUnitInfo.divisor]
+  );
 
   if (isLoading) {
     return (
@@ -1029,13 +1124,15 @@ const Disk = () => {
                     ]}
                     yAxis={[
                       {
+                        id: 'io-count-axis',
+                        scaleType: 'linear' as const,
                         min: 0,
                         max: ioCountAxisMaxValue,
-                        label: 'تعداد عملیات (عدد)',
+                        label: `تعداد عملیات (${countAxisUnitInfo.label})`,
                         valueFormatter: formatCountAxisValue,
                         tickLabelStyle: { fill: 'var(--color-text)' },
                         labelStyle: { fill: 'var(--color-text)' },
-                        position: 'left',
+                        position: 'left' as const,
                         tickSize: 45,
                         width: 96,
                       },
@@ -1067,13 +1164,15 @@ const Disk = () => {
                     ]}
                     yAxis={[
                       {
+                        id: 'io-bytes-axis',
+                        scaleType: 'linear' as const,
                         min: 0,
                         max: ioBytesAxisMaxValue,
-                        label: 'حجم داده (بایت)',
+                        label: `حجم داده (${bytesAxisUnitInfo.label})`,
                         valueFormatter: formatBytesAxisValue,
                         tickLabelStyle: { fill: 'var(--color-text)' },
                         labelStyle: { fill: 'var(--color-text)' },
-                        position: 'left',
+                        position: 'left' as const,
                         tickSize: 45,
                         width: 96,
                       },


### PR DESCRIPTION
## Summary
- add helper utilities to determine the appropriate axis units for disk charts and format tick values consistently
- update the I/O line charts to reuse those helpers so y-axis labels and maxima reflect each metric’s units
- restore the normalized dataset helper for reuse when deriving byte-oriented maxima
- reintroduce the IO_METRICS mapping and tighten the axis configuration so the charts compile cleanly with TypeScript

## Testing
- npm run lint *(fails: react-refresh/only-export-components reported in existing context files)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cab0d295f0832a992f5ebf6fe889b2