### PR TITLE
refactor: centralize formatter utilities

### DIFF
--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -13,6 +13,7 @@ import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
 import type { DiskIOStats } from '../@types/disk';
 import { useDisk } from '../hooks/useDisk';
+import { formatBytes, formatDuration, formatLargeNumber } from '../util/formatters';
 import '../index.css';
 
 const BYTES_IN_GB = 1024 ** 3;
@@ -67,62 +68,6 @@ const IO_METRICS: DiskMetricConfig[] = [
     format: (value) => `${formatLargeNumber(Math.max(value, 0))} ms`,
   },
 ];
-
-const formatDuration = (valueMs: number) => {
-  if (!Number.isFinite(valueMs)) return '-';
-
-  const sign = valueMs < 0 ? '-' : '';
-  let currentValue = Math.abs(valueMs);
-
-  const units = ['ms', 's', 'min', 'h', 'd'] as const;
-  const steps = [1000, 60, 60, 24]; // ms→s, s→min, min→h, h→d
-
-  let unitIndex = 0;
-  while (unitIndex < steps.length && currentValue >= steps[unitIndex]) {
-    currentValue /= steps[unitIndex];
-    unitIndex += 1;
-  }
-
-  const formatter = new Intl.NumberFormat('en-US', {
-    maximumFractionDigits: currentValue >= 100 ? 0 : 1,
-  });
-
-  return `${sign}${formatter.format(currentValue)} ${units[unitIndex]}`;
-};
-
-const formatBytes = (value: number) => {
-  if (!Number.isFinite(value)) {
-    return '-';
-  }
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
-  let currentValue = value;
-  let unitIndex = 0;
-
-  while (currentValue >= 1024 && unitIndex < units.length - 1) {
-    currentValue /= 1024;
-    unitIndex += 1;
-  }
-
-  const formatter = new Intl.NumberFormat('en-US', {
-    maximumFractionDigits: currentValue >= 100 ? 0 : 1,
-  });
-
-  return `${formatter.format(currentValue)} ${units[unitIndex]}`;
-};
-
-const formatLargeNumber = (value: number) => {
-  if (value >= 1_000_000_000) {
-    return `${(value / 1_000_000_000).toFixed(1)}B`;
-  }
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  return value.toFixed(0);
-};
 
 const normalizeMetrics = (metrics?: Partial<DiskIOStats>) => {
   return METRIC_KEYS.reduce(

--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -2,6 +2,7 @@ import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
 import { useMemory } from '../hooks/useMemory';
+import { formatBytes } from '../util/formatters';
 
 const BYTE_UNITS = ['B', 'KB', 'MB', 'GB'] as const;
 
@@ -27,29 +28,22 @@ const Memory = () => {
     []
   );
 
-  const byteFormatter = useMemo(
-    () =>
-      new Intl.NumberFormat('fa-IR', {
-        maximumFractionDigits: 2,
-      }),
-    []
-  );
-
   const formatBytesValue = (value: number | null | undefined) => {
-    if (value == null || !Number.isFinite(value)) {
+    if (value == null) {
       return '—';
     }
 
-    const absoluteValue = Math.max(value, 0);
-    let unitIndex = 0;
-    let normalizedValue = absoluteValue;
-
-    while (normalizedValue >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
-      normalizedValue /= 1024;
-      unitIndex += 1;
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+      return '—';
     }
 
-    return `${byteFormatter.format(normalizedValue)} ${BYTE_UNITS[unitIndex]}`;
+    return formatBytes(Math.max(numericValue, 0), {
+      locale: 'fa-IR',
+      maximumFractionDigits: 2,
+      units: BYTE_UNITS,
+      fallback: '—',
+    });
   };
 
   const containerBorderColor =

--- a/src/util/formatters.ts
+++ b/src/util/formatters.ts
@@ -1,0 +1,157 @@
+const DEFAULT_BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const;
+const DEFAULT_DURATION_UNITS = ['ms', 's', 'min', 'h', 'd'] as const;
+const DEFAULT_DURATION_STEPS = [1000, 60, 60, 24] as const;
+
+type NullableNumber = number | null | undefined;
+
+export type FormatBytesOptions = {
+  locale?: string;
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+  units?: readonly string[];
+  fallback?: string;
+};
+
+export const formatBytes = (
+  value: NullableNumber,
+  {
+    locale = 'en-US',
+    minimumFractionDigits,
+    maximumFractionDigits,
+    units = DEFAULT_BYTE_UNITS,
+    fallback = '-',
+  }: FormatBytesOptions = {}
+): string => {
+  const numericValue =
+    typeof value === 'number' ? value : value != null ? Number(value) : NaN;
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  const sign = numericValue < 0 ? '-' : '';
+  let currentValue = Math.abs(numericValue);
+  let unitIndex = 0;
+
+  const resolvedUnits = units.length > 0 ? units : DEFAULT_BYTE_UNITS;
+
+  while (unitIndex < resolvedUnits.length - 1 && currentValue >= 1024) {
+    currentValue /= 1024;
+    unitIndex += 1;
+  }
+
+  const effectiveMaximumFractionDigits =
+    maximumFractionDigits ?? (currentValue >= 100 ? 0 : 1);
+
+  const formatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: effectiveMaximumFractionDigits,
+    minimumFractionDigits,
+  });
+
+  const unitLabel =
+    resolvedUnits[unitIndex] ?? resolvedUnits[resolvedUnits.length - 1] ?? '';
+
+  const formattedValue = formatter.format(currentValue);
+
+  return unitLabel
+    ? `${sign}${formattedValue} ${unitLabel}`
+    : `${sign}${formattedValue}`;
+};
+
+export type FormatDurationOptions = {
+  locale?: string;
+  units?: readonly string[];
+  steps?: readonly number[];
+  maximumFractionDigits?: number;
+  minimumFractionDigits?: number;
+  fallback?: string;
+};
+
+export const formatDuration = (
+  valueMs: NullableNumber,
+  {
+    locale = 'en-US',
+    units = DEFAULT_DURATION_UNITS,
+    steps = DEFAULT_DURATION_STEPS,
+    maximumFractionDigits,
+    minimumFractionDigits,
+    fallback = '-',
+  }: FormatDurationOptions = {}
+): string => {
+  const numericValue =
+    typeof valueMs === 'number' ? valueMs : valueMs != null ? Number(valueMs) : NaN;
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  const sign = numericValue < 0 ? '-' : '';
+  let currentValue = Math.abs(numericValue);
+  let unitIndex = 0;
+
+  const resolvedUnits = units.length > 0 ? units : DEFAULT_DURATION_UNITS;
+  const resolvedSteps = steps.length > 0 ? steps : DEFAULT_DURATION_STEPS;
+
+  while (
+    unitIndex < resolvedSteps.length &&
+    currentValue >= resolvedSteps[unitIndex]
+  ) {
+    currentValue /= resolvedSteps[unitIndex];
+    unitIndex += 1;
+  }
+
+  const effectiveUnitIndex =
+    unitIndex < resolvedUnits.length
+      ? unitIndex
+      : Math.max(resolvedUnits.length - 1, 0);
+
+  const effectiveMaximumFractionDigits =
+    maximumFractionDigits ?? (currentValue >= 100 ? 0 : 1);
+
+  const formatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: effectiveMaximumFractionDigits,
+    minimumFractionDigits,
+  });
+
+  const unitLabel =
+    resolvedUnits[effectiveUnitIndex] ?? resolvedUnits[resolvedUnits.length - 1] ?? '';
+
+  const formattedValue = formatter.format(currentValue);
+
+  return unitLabel
+    ? `${sign}${formattedValue} ${unitLabel}`
+    : `${sign}${formattedValue}`;
+};
+
+export type FormatLargeNumberOptions = {
+  fallback?: string;
+};
+
+export const formatLargeNumber = (
+  value: NullableNumber,
+  { fallback = '-' }: FormatLargeNumberOptions = {}
+): string => {
+  const numericValue =
+    typeof value === 'number' ? value : value != null ? Number(value) : NaN;
+
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  const absoluteValue = Math.abs(numericValue);
+  const sign = numericValue < 0 ? '-' : '';
+
+  if (absoluteValue >= 1_000_000_000) {
+    return `${sign}${(absoluteValue / 1_000_000_000).toFixed(1)}B`;
+  }
+
+  if (absoluteValue >= 1_000_000) {
+    return `${sign}${(absoluteValue / 1_000_000).toFixed(1)}M`;
+  }
+
+  if (absoluteValue >= 1_000) {
+    return `${sign}${(absoluteValue / 1_000).toFixed(1)}K`;
+  }
+
+  return numericValue.toFixed(0);
+};


### PR DESCRIPTION
## Summary
- add a shared formatter utility module for byte, duration, and large-number formatting
- update disk and memory components to import and use the centralized formatters

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in existing context files)*
- npm run build *(fails: missing ../components/auth/LoginForm.tsx import referenced by AuthPage)*

------
https://chatgpt.com/codex/tasks/task_b_68ce3f3ca810832a8994afa8ecf626cf