### PR TITLE
refactor: centralize card styles

### DIFF
--- a/src/components/Cpu.tsx
+++ b/src/components/Cpu.tsx
@@ -8,6 +8,7 @@ import {
 import { Gauge, gaugeClasses } from '@mui/x-charts/Gauge';
 import { useMemo } from 'react';
 import { useCpu } from '../hooks/useCpu';
+import { createCardSx } from './cardStyles';
 
 const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
 
@@ -98,27 +99,10 @@ const Cpu = () => {
       ? 'rgba(255, 255, 255, 0.04)'
       : 'rgba(0, 0, 0, 0.03)';
 
-  const cardBorderColor =
-    theme.palette.mode === 'dark'
-      ? 'rgba(255, 255, 255, 0.12)'
-      : 'rgba(0, 0, 0, 0.08)';
-
   const cardSx = {
-    width: '100%',
-    p: 3,
-    bgcolor: 'var(--color-card-bg)',
-    borderRadius: 3,
-    mb: 3,
-    color: 'var(--color-bg-primary)',
-    display: 'flex',
-    flexDirection: 'column' as const,
+    ...createCardSx(theme),
     alignItems: 'center',
-    gap: 3,
-    boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
-    border: `1px solid ${cardBorderColor}`,
-    backdropFilter: 'blur(14px)',
-    height: '100%',
-  };
+  } as const;
 
   const stats = [
     {

--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -6,7 +6,6 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import type { Theme } from '@mui/material/styles';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { PieChart } from '@mui/x-charts/PieChart';
@@ -14,6 +13,7 @@ import { useMemo } from 'react';
 import type { DiskIOStats } from '../@types/disk';
 import { useDisk } from '../hooks/useDisk';
 import '../index.css';
+import { createCardSx } from './cardStyles';
 
 const BYTES_IN_GB = 1024 ** 3;
 const METRIC_KEYS: Array<keyof DiskIOStats> = [
@@ -147,28 +147,6 @@ const diskPercentFormatter = new Intl.NumberFormat('fa-IR', {
   minimumFractionDigits: 1,
   maximumFractionDigits: 1,
 });
-
-const createCardSx = (theme: Theme) => {
-  const cardBorderColor =
-    theme.palette.mode === 'dark'
-      ? 'rgba(255, 255, 255, 0.12)'
-      : 'rgba(0, 0, 0, 0.08)';
-
-  return {
-    p: 3,
-    bgcolor: 'var(--color-card-bg)',
-    borderRadius: 3,
-    mb: 3,
-    color: 'var(--color-bg-primary)',
-    display: 'flex',
-    flexDirection: 'column' as const,
-    gap: 3,
-    boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
-    border: `1px solid ${cardBorderColor}`,
-    backdropFilter: 'blur(14px)',
-    height: '100%',
-  } as const;
-};
 
 interface DeviceMetricDatum {
   name: string;

--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -2,6 +2,7 @@ import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
 import { useMemory } from '../hooks/useMemory';
+import { createCardSx } from './cardStyles';
 
 const BYTE_UNITS = ['B', 'KB', 'MB', 'GB'] as const;
 
@@ -52,11 +53,6 @@ const Memory = () => {
     return `${byteFormatter.format(normalizedValue)} ${BYTE_UNITS[unitIndex]}`;
   };
 
-  const containerBorderColor =
-    theme.palette.mode === 'dark'
-      ? 'rgba(255, 255, 255, 0.12)'
-      : 'rgba(0, 0, 0, 0.08)';
-
   const statsDividerColor =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.08)'
@@ -77,21 +73,7 @@ const Memory = () => {
       ? 'rgba(255, 255, 255, 0.08)'
       : 'rgba(0, 0, 0, 0.08)';
 
-  const cardSx = {
-    width: '100%',
-    p: 3,
-    bgcolor: 'var(--color-card-bg)',
-    borderRadius: 3,
-    mb: 3,
-    color: 'var(--color-bg-primary)',
-    display: 'flex',
-    flexDirection: 'column' as const,
-    gap: 3,
-    boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
-    border: `1px solid ${containerBorderColor}`,
-    backdropFilter: 'blur(14px)',
-    height: '100%',
-  };
+  const cardSx = createCardSx(theme);
 
   if (isLoading) {
     return (

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -7,6 +7,7 @@ import {
   type NetworkInterface,
 } from '../hooks/useNetwork';
 import '../index.css';
+import { createCardSx } from './cardStyles';
 
 type ResponsiveChartContainerProps = {
   height: number;
@@ -257,11 +258,6 @@ const Network = () => {
     },
   } as const;
 
-  const cardBorderColor =
-    theme.palette.mode === 'dark'
-      ? 'rgba(255, 255, 255, 0.12)'
-      : 'rgba(0, 0, 0, 0.08)';
-
   const metaInfoBorderColor =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.12)'
@@ -272,24 +268,13 @@ const Network = () => {
       ? 'rgba(255, 255, 255, 0.04)'
       : 'rgba(0, 0, 0, 0.03)';
 
+  const cardSx = {
+    ...createCardSx(theme),
+    alignItems: 'stretch',
+  } as const;
+
   return (
-    <Box
-      sx={{
-        p: 3,
-        bgcolor: 'var(--color-card-bg)',
-        borderRadius: 3,
-        mb: 3,
-        color: 'var(--color-bg-primary)',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'stretch',
-        gap: 3,
-        border: `1px solid ${cardBorderColor}`,
-        boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
-        width: '100%',
-        height: '100%',
-      }}
-    >
+    <Box sx={cardSx}>
       <Typography
         variant="subtitle2"
         sx={{

--- a/src/components/cardStyles.ts
+++ b/src/components/cardStyles.ts
@@ -1,0 +1,24 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export const createCardSx = (theme: Theme): SxProps<Theme> => {
+  const borderColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(0, 0, 0, 0.08)';
+
+  return {
+    width: '100%',
+    p: 3,
+    bgcolor: 'var(--color-card-bg)',
+    borderRadius: 3,
+    mb: 3,
+    color: 'var(--color-bg-primary)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 3,
+    boxShadow: '0 20px 40px rgba(0, 0, 0, 0.18)',
+    border: `1px solid ${borderColor}`,
+    backdropFilter: 'blur(14px)',
+    height: '100%',
+  } satisfies SxProps<Theme>;
+};


### PR DESCRIPTION
## Summary
- add a `createCardSx` helper that encapsulates the shared widget card styling
- refactor the CPU, Memory, Disk, and Network widgets to consume the shared helper while keeping component-specific overrides

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68ce3f4f17fc832aa5d0d61e63e1672f