### PR TITLE
Refactor: centralize component constants and types

### DIFF
--- a/src/@types/components/appToaster.ts
+++ b/src/@types/components/appToaster.ts
@@ -1,0 +1,11 @@
+export type AppToasterPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export interface AppToasterProps {
+  position?: AppToasterPosition;
+}

--- a/src/@types/components/cpu.ts
+++ b/src/@types/components/cpu.ts
@@ -1,0 +1,5 @@
+export type RgbColor = {
+  r: number;
+  g: number;
+  b: number;
+};

--- a/src/@types/components/disk.ts
+++ b/src/@types/components/disk.ts
@@ -1,0 +1,15 @@
+import type { DiskIOStats } from '../disk';
+
+export type NormalizedMetrics = Record<keyof DiskIOStats, number>;
+
+export type DiskMetricConfig = {
+  key: keyof DiskIOStats;
+  label: string;
+  getValue: (metrics: NormalizedMetrics) => number;
+  format: (value: number) => string;
+};
+
+export interface DeviceMetricDatum {
+  name: string;
+  metrics: NormalizedMetrics;
+}

--- a/src/@types/components/navigationDrawer.ts
+++ b/src/@types/components/navigationDrawer.ts
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+
+export interface NavigationDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export interface NavigationItem {
+  text: string;
+  icon: ReactNode;
+  path: string;
+}

--- a/src/@types/components/network.ts
+++ b/src/@types/components/network.ts
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+export type ResponsiveChartContainerProps = {
+  height: number;
+  children: (width: number) => ReactNode;
+};
+
+export type HistoryPoint = {
+  time: number;
+  upload: number;
+  download: number;
+};
+
+export type History = Record<string, HistoryPoint[]>;
+
+export type IPv4Info = {
+  address: string;
+  netmask: string | null;
+};

--- a/src/@types/components/themeToggle.ts
+++ b/src/@types/components/themeToggle.ts
@@ -1,0 +1,6 @@
+import type { SxProps, Theme } from '@mui/material';
+
+export interface ThemeToggleProps {
+  fixed?: boolean;
+  sx?: SxProps<Theme>;
+}

--- a/src/components/AppToaster.tsx
+++ b/src/components/AppToaster.tsx
@@ -1,15 +1,6 @@
 import { Toaster } from 'react-hot-toast';
+import type { AppToasterProps } from '../@types/components/appToaster';
 import '../index.css';
-
-type AppToasterProps = {
-  position?:
-    | 'top-left'
-    | 'top-center'
-    | 'top-right'
-    | 'bottom-left'
-    | 'bottom-center'
-    | 'bottom-right';
-};
 
 export default function AppToaster({
   position = 'top-center',

--- a/src/components/Cpu.tsx
+++ b/src/components/Cpu.tsx
@@ -7,28 +7,9 @@ import {
 } from '@mui/material';
 import { Gauge, gaugeClasses } from '@mui/x-charts/Gauge';
 import { useMemo } from 'react';
+import { clampPercent, getGaugeColor } from '../constants/components/cpu';
 import { useCpu } from '../hooks/useCpu';
 import { createCardSx } from './cardStyles';
-
-const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
-
-type RgbColor = { r: number; g: number; b: number };
-
-const formatRgb = ({ r, g, b }: RgbColor) => `rgb(${r}, ${g}, ${b})`;
-
-const interpolateColor = (start: RgbColor, end: RgbColor, ratio: number) => ({
-  r: Math.round(start.r + (end.r - start.r) * ratio),
-  g: Math.round(start.g + (end.g - start.g) * ratio),
-  b: Math.round(start.b + (end.b - start.b) * ratio),
-});
-
-const START_COLOR: RgbColor = { r: 0, g: 255, b: 0 };
-const ALERT_COLOR: RgbColor = { r: 255, g: 0, b: 0 };
-
-const getGaugeColor = (value: number) => {
-  const ratio = clampPercent(value) / 100;
-  return formatRgb(interpolateColor(START_COLOR, ALERT_COLOR, ratio));
-};
 
 const Cpu = () => {
   const { data, isLoading, error } = useCpu();

--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -10,93 +10,22 @@ import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
-import type { DiskIOStats } from '../@types/disk';
+import type {
+  DeviceMetricDatum,
+  NormalizedMetrics,
+} from '../@types/components/disk';
 import { useDisk } from '../hooks/useDisk';
 import { formatBytes, formatDuration, formatLargeNumber } from '../util/formatters';
 import '../index.css';
 import { createCardSx } from './cardStyles';
-
-const BYTES_IN_GB = 1024 ** 3;
-const METRIC_KEYS: Array<keyof DiskIOStats> = [
-  'read_count',
-  'write_count',
-  'read_bytes',
-  'write_bytes',
-  'read_time',
-  'write_time',
-  'read_merged_count',
-  'write_merged_count',
-  'busy_time',
-];
-
-type DiskMetricConfig = {
-  key: keyof DiskIOStats;
-  label: string;
-  getValue: (metrics: NormalizedMetrics) => number;
-  format: (value: number) => string;
-};
-
-const IO_METRICS: DiskMetricConfig[] = [
-  {
-    key: 'read_count',
-    label: 'تعداد خواندن',
-    getValue: (metrics) => metrics.read_count,
-    format: (value) => `${formatLargeNumber(Math.max(value, 0))} عملیات`,
-  },
-  {
-    key: 'write_count',
-    label: 'تعداد نوشتن',
-    getValue: (metrics) => metrics.write_count,
-    format: (value) => `${formatLargeNumber(Math.max(value, 0))} عملیات`,
-  },
-  {
-    key: 'read_bytes',
-    label: 'حجم خوانده‌شده',
-    getValue: (metrics) => metrics.read_bytes,
-    format: (value) => formatBytes(Math.max(value, 0)),
-  },
-  {
-    key: 'write_bytes',
-    label: 'حجم نوشته‌شده',
-    getValue: (metrics) => metrics.write_bytes,
-    format: (value) => formatBytes(Math.max(value, 0)),
-  },
-  {
-    key: 'busy_time',
-    label: 'زمان مشغولی (ms)',
-    getValue: (metrics) => metrics.busy_time,
-    format: (value) => `${formatLargeNumber(Math.max(value, 0))} ms`,
-  },
-];
-
-const normalizeMetrics = (metrics?: Partial<DiskIOStats>) => {
-  return METRIC_KEYS.reduce(
-    (acc, key) => {
-      acc[key] = Number(metrics?.[key] ?? 0);
-      return acc;
-    },
-    {} as Record<keyof DiskIOStats, number>
-  );
-};
-
-type NormalizedMetrics = ReturnType<typeof normalizeMetrics>;
-
-const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
-
-const safeNumber = (value: unknown) => {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : 0;
-};
-
-const diskPercentFormatter = new Intl.NumberFormat('fa-IR', {
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
-});
-
-interface DeviceMetricDatum {
-  name: string;
-  metrics: NormalizedMetrics;
-}
+import {
+  BYTES_IN_GB,
+  IO_METRICS,
+  clampPercent,
+  diskPercentFormatter,
+  normalizeMetrics,
+  safeNumber,
+} from '../constants/components/disk';
 
 export const DiskOverview = () => {
   const { data, isLoading, error } = useDisk();

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -17,35 +17,11 @@ import { toast } from 'react-hot-toast';
 import { FaEye, FaEyeSlash, FaLock, FaUser } from 'react-icons/fa';
 import { LuLogIn } from 'react-icons/lu';
 import { useNavigate } from 'react-router-dom';
+import { loginTextFieldSx } from '../constants/components/loginForm';
 import { useAuth } from '../contexts/AuthContext.tsx';
 import { useLogin } from '../hooks/useLogin';
 import { useRememberUsername } from '../hooks/useRememberUsername';
 import { type LoginFormData, loginSchema } from '../schemas/authSchema';
-
-const TextFieldSx = {
-  '& .MuiOutlinedInput-root': {
-    borderRadius: 2.5,
-    color: 'var(--color-text)',
-    backgroundColor: 'var(--color-input-bg)',
-    border: '1px solid var(--color-input-border)',
-    transition: 'all 0.3s ease',
-    '&:hover': {
-      backgroundColor: 'var(--color-input-bg)',
-      borderColor: 'var(--color-primary-light)',
-    },
-    '&.Mui-focused': {
-      backgroundColor: 'var(--color-input-bg)',
-      borderColor: 'var(--color-primary)',
-      boxShadow: '0 0 0 3px rgba(126, 87, 194, 0.1)',
-    },
-    '&.Mui-error': {
-      borderColor: 'var(--color-error)',
-    },
-  },
-  '& .MuiOutlinedInput-input': {
-    padding: '12px 14px',
-  },
-};
 
 function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
@@ -120,7 +96,7 @@ function LoginForm() {
                   ),
                 },
               }}
-              sx={TextFieldSx}
+              sx={loginTextFieldSx}
             />
           )}
         />
@@ -168,7 +144,7 @@ function LoginForm() {
                   ),
                 },
               }}
-              sx={TextFieldSx}
+              sx={loginTextFieldSx}
             />
           )}
         />

--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -1,18 +1,10 @@
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
+import { BYTE_UNITS, clampPercent, parseNumeric } from '../constants/components/memory';
 import { useMemory } from '../hooks/useMemory';
 import { createCardSx } from './cardStyles';
 import { formatBytes } from '../util/formatters';
-
-const BYTE_UNITS = ['B', 'KB', 'MB', 'GB'] as const;
-
-const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
-
-const parseNumeric = (value: unknown): number | null => {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : null;
-};
 
 const Memory = () => {
   const { data, isLoading, error } = useMemory();

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -9,27 +9,10 @@ import {
   Toolbar,
 } from '@mui/material';
 import React from 'react';
-import { BiHistory } from 'react-icons/bi';
-import { FaShare } from 'react-icons/fa';
-import { FiUsers } from 'react-icons/fi';
-import { MdClose, MdSpaceDashboard } from 'react-icons/md';
-import { RiSettings3Fill } from 'react-icons/ri';
+import { MdClose } from 'react-icons/md';
 import { Link } from 'react-router-dom';
-
-interface NavigationDrawerProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-const drawerWidth = 200;
-
-const navItems = [
-  { text: 'داشبورد', icon: <MdSpaceDashboard />, path: '/dashboard' },
-  { text: 'کاربران', icon: <FiUsers />, path: '/users' },
-  { text: 'تاریخچه', icon: <BiHistory />, path: '/history' },
-  { text: 'اشتراک گذاری', icon: <FaShare />, path: '/share' },
-  { text: 'تنظیمات', icon: <RiSettings3Fill />, path: '/settings' },
-];
+import type { NavigationDrawerProps } from '../@types/components/navigationDrawer';
+import { drawerWidth, navItems } from '../constants/components/navigationDrawer';
 
 const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
   open,

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -1,18 +1,19 @@
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { LineChart } from '@mui/x-charts';
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   useNetwork,
   type InterfaceAddress,
   type NetworkInterface,
 } from '../hooks/useNetwork';
 import '../index.css';
+import type {
+  History,
+  IPv4Info,
+  ResponsiveChartContainerProps,
+} from '../@types/components/network';
+import { MAX_HISTORY_MS } from '../constants/components/network';
 import { createCardSx } from './cardStyles';
-
-type ResponsiveChartContainerProps = {
-  height: number;
-  children: (width: number) => ReactNode;
-};
 
 const ResponsiveChartContainer = ({
   height,
@@ -64,14 +65,6 @@ const ResponsiveChartContainer = ({
   );
 };
 
-type History = Record<
-  string,
-  Array<{ time: number; upload: number; download: number }>
->;
-
-const MAX_HISTORY_MS = 90 * 1000; // 1 minute 30 seconds
-
-type IPv4Info = { address: string; netmask: string | null };
 
 const trimIfStringHasValue = (value: string) => {
   const trimmed = value.trim();

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,12 +1,8 @@
-import { IconButton, type SxProps, type Theme } from '@mui/material';
+import { IconButton } from '@mui/material';
 import React from 'react';
 import { LuMoon, LuSun } from 'react-icons/lu';
+import type { ThemeToggleProps } from '../@types/components/themeToggle';
 import { useTheme } from '../contexts/ThemeContext';
-
-interface ThemeToggleProps {
-  fixed?: boolean;
-  sx?: SxProps<Theme>;
-}
 
 const ThemeToggle: React.FC<ThemeToggleProps> = ({ fixed = true, sx }) => {
   const { isDark, toggleTheme } = useTheme();

--- a/src/constants/components/cpu.ts
+++ b/src/constants/components/cpu.ts
@@ -1,0 +1,20 @@
+import type { RgbColor } from '../../@types/components/cpu';
+
+export const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+export const formatRgb = ({ r, g, b }: RgbColor) => `rgb(${r}, ${g}, ${b})`;
+
+export const interpolateColor = (start: RgbColor, end: RgbColor, ratio: number) => ({
+  r: Math.round(start.r + (end.r - start.r) * ratio),
+  g: Math.round(start.g + (end.g - start.g) * ratio),
+  b: Math.round(start.b + (end.b - start.b) * ratio),
+});
+
+export const START_COLOR: RgbColor = { r: 0, g: 255, b: 0 };
+
+export const ALERT_COLOR: RgbColor = { r: 255, g: 0, b: 0 };
+
+export const getGaugeColor = (value: number) => {
+  const ratio = clampPercent(value) / 100;
+  return formatRgb(interpolateColor(START_COLOR, ALERT_COLOR, ratio));
+};

--- a/src/constants/components/disk.ts
+++ b/src/constants/components/disk.ts
@@ -1,0 +1,76 @@
+import type { DiskIOStats } from '../../@types/disk';
+import type {
+  DiskMetricConfig,
+  NormalizedMetrics,
+} from '../../@types/components/disk';
+import { formatBytes, formatLargeNumber } from '../../util/formatters';
+
+export const BYTES_IN_GB = 1024 ** 3;
+
+export const METRIC_KEYS: Array<keyof DiskIOStats> = [
+  'read_count',
+  'write_count',
+  'read_bytes',
+  'write_bytes',
+  'read_time',
+  'write_time',
+  'read_merged_count',
+  'write_merged_count',
+  'busy_time',
+];
+
+export const normalizeMetrics = (
+  metrics?: Partial<DiskIOStats>
+): NormalizedMetrics =>
+  METRIC_KEYS.reduce<NormalizedMetrics>(
+    (acc, key) => {
+      acc[key] = Number(metrics?.[key] ?? 0);
+      return acc;
+    },
+    {} as NormalizedMetrics
+  );
+
+export const IO_METRICS: DiskMetricConfig[] = [
+  {
+    key: 'read_count',
+    label: 'تعداد خواندن',
+    getValue: (metrics) => metrics.read_count,
+    format: (value) => `${formatLargeNumber(Math.max(value, 0))} عملیات`,
+  },
+  {
+    key: 'write_count',
+    label: 'تعداد نوشتن',
+    getValue: (metrics) => metrics.write_count,
+    format: (value) => `${formatLargeNumber(Math.max(value, 0))} عملیات`,
+  },
+  {
+    key: 'read_bytes',
+    label: 'حجم خوانده‌شده',
+    getValue: (metrics) => metrics.read_bytes,
+    format: (value) => formatBytes(Math.max(value, 0)),
+  },
+  {
+    key: 'write_bytes',
+    label: 'حجم نوشته‌شده',
+    getValue: (metrics) => metrics.write_bytes,
+    format: (value) => formatBytes(Math.max(value, 0)),
+  },
+  {
+    key: 'busy_time',
+    label: 'زمان مشغولی (ms)',
+    getValue: (metrics) => metrics.busy_time,
+    format: (value) => `${formatLargeNumber(Math.max(value, 0))} ms`,
+  },
+];
+
+export const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+export const safeNumber = (value: unknown) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
+export const diskPercentFormatter = new Intl.NumberFormat('fa-IR', {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});

--- a/src/constants/components/loginForm.ts
+++ b/src/constants/components/loginForm.ts
@@ -1,0 +1,26 @@
+import type { SxProps, Theme } from '@mui/material';
+
+export const loginTextFieldSx: SxProps<Theme> = {
+  '& .MuiOutlinedInput-root': {
+    borderRadius: 2.5,
+    color: 'var(--color-text)',
+    backgroundColor: 'var(--color-input-bg)',
+    border: '1px solid var(--color-input-border)',
+    transition: 'all 0.3s ease',
+    '&:hover': {
+      backgroundColor: 'var(--color-input-bg)',
+      borderColor: 'var(--color-primary-light)',
+    },
+    '&.Mui-focused': {
+      backgroundColor: 'var(--color-input-bg)',
+      borderColor: 'var(--color-primary)',
+      boxShadow: '0 0 0 3px rgba(126, 87, 194, 0.1)',
+    },
+    '&.Mui-error': {
+      borderColor: 'var(--color-error)',
+    },
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: '12px 14px',
+  },
+};

--- a/src/constants/components/memory.ts
+++ b/src/constants/components/memory.ts
@@ -1,0 +1,8 @@
+export const BYTE_UNITS = ['B', 'KB', 'MB', 'GB'] as const;
+
+export const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+export const parseNumeric = (value: unknown): number | null => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};

--- a/src/constants/components/navigationDrawer.ts
+++ b/src/constants/components/navigationDrawer.ts
@@ -1,0 +1,17 @@
+import { createElement } from 'react';
+import { BiHistory } from 'react-icons/bi';
+import { FaShare } from 'react-icons/fa';
+import { FiUsers } from 'react-icons/fi';
+import { MdSpaceDashboard } from 'react-icons/md';
+import { RiSettings3Fill } from 'react-icons/ri';
+import type { NavigationItem } from '../../@types/components/navigationDrawer';
+
+export const drawerWidth = 200;
+
+export const navItems: NavigationItem[] = [
+  { text: 'داشبورد', icon: createElement(MdSpaceDashboard), path: '/dashboard' },
+  { text: 'کاربران', icon: createElement(FiUsers), path: '/users' },
+  { text: 'تاریخچه', icon: createElement(BiHistory), path: '/history' },
+  { text: 'اشتراک گذاری', icon: createElement(FaShare), path: '/share' },
+  { text: 'تنظیمات', icon: createElement(RiSettings3Fill), path: '/settings' },
+];

--- a/src/constants/components/network.ts
+++ b/src/constants/components/network.ts
@@ -1,0 +1,1 @@
+export const MAX_HISTORY_MS = 90 * 1000; // 1 minute 30 seconds

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,33 +1,41 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 type ThemeContextType = {
-    isDark: boolean;
-    toggleTheme: () => void;
+  isDark: boolean;
+  toggleTheme: () => void;
 };
 
 const ThemeContext = createContext<ThemeContextType>({
-    isDark: false,
-    toggleTheme: () => {},
+  isDark: false,
+  toggleTheme: () => {},
 });
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => useContext(ThemeContext);
 
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [isDark, setIsDark] = useState(() => {
-        const saved = localStorage.getItem('theme');
-        return saved ? saved === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
-    });
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isDark, setIsDark] = useState(() => {
+    const saved = localStorage.getItem('theme');
+    return saved
+      ? saved === 'dark'
+      : window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
 
-    useEffect(() => {
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-    }, [isDark]);
-
-    const toggleTheme = () => setIsDark(prev => !prev);
-
-    return (
-        <ThemeContext.Provider value={{ isDark, toggleTheme }}>
-            {children}
-        </ThemeContext.Provider>
+  useEffect(() => {
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    document.documentElement.setAttribute(
+      'data-theme',
+      isDark ? 'dark' : 'light'
     );
+  }, [isDark]);
+
+  const toggleTheme = () => setIsDark((prev) => !prev);
+
+  return (
+    <ThemeContext.Provider value={{ isDark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
 };


### PR DESCRIPTION
## Summary
- extract component prop types into dedicated files under `src/@types/components`
- move reusable constants and helpers for UI widgets into `src/constants/components`
- update components to import the shared constants/types and silence lint fast-refresh warnings on context hooks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ce46cc18f8832a848aa2a9d17d260b