### PR TITLE
Refactor charts into reusable components

### DIFF
--- a/src/@types/network.ts
+++ b/src/@types/network.ts
@@ -1,10 +1,3 @@
-import type { ReactNode } from 'react';
-
-export type ResponsiveChartContainerProps = {
-  height: number;
-  children: (width: number) => ReactNode;
-};
-
 export type HistoryPoint = {
   time: number;
   upload: number;

--- a/src/components/Cpu.tsx
+++ b/src/components/Cpu.tsx
@@ -1,14 +1,9 @@
-import {
-  Box,
-  GlobalStyles,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
-import { Gauge, gaugeClasses } from '@mui/x-charts/Gauge';
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { gaugeClasses } from '@mui/x-charts/Gauge';
 import { useMemo } from 'react';
 import type { RgbColor } from '../@types/cpu.ts';
 import { useCpu } from '../hooks/useCpu';
+import AppGauge from './charts/AppGauge';
 
 const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
 
@@ -178,16 +173,7 @@ const Cpu = () => {
           justifyContent: 'center',
         }}
       >
-        <GlobalStyles
-          styles={{
-            // Force the center number in the Gauge to your token, including split tspans
-            '.MuiGauge-valueText, .MuiGauge-valueText tspan': {
-              fill: 'var(--color-text) !important',
-              color: 'var(--color-text) !important',
-            },
-          }}
-        />
-        <Gauge
+        <AppGauge
           value={cpuPercent}
           min={0}
           max={100}
@@ -196,7 +182,7 @@ const Cpu = () => {
           innerRadius="60%"
           outerRadius="100%"
           cornerRadius="50%"
-          text={({ value }) =>
+          valueFormatter={(value) =>
             `${percentFormatter.format(Math.round(value ?? 0))}٪`
           }
           sx={(theme) => ({

--- a/src/components/Disk.tsx
+++ b/src/components/Disk.tsx
@@ -6,9 +6,6 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import { BarChart } from '@mui/x-charts/BarChart';
-import { LineChart } from '@mui/x-charts/LineChart';
-import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
 import type { DeviceMetricDatum, NormalizedMetrics } from '../@types/disk';
 import {
@@ -27,6 +24,18 @@ import {
   formatLargeNumber,
 } from '../utils/formatters';
 import { createCardSx } from './cardStyles';
+import AppBarChart from './charts/AppBarChart';
+import AppLineChart from './charts/AppLineChart';
+import AppPieChart from './charts/AppPieChart';
+
+const tooltipMultilineSx = {
+  '& .MuiChartsTooltip-cell': {
+    whiteSpace: 'pre-line',
+  },
+  '& .MuiChartsTooltip-value': {
+    whiteSpace: 'pre-line',
+  },
+} as const;
 
 export const DiskOverview = () => {
   const { data, isLoading, error } = useDisk();
@@ -200,7 +209,7 @@ export const DiskOverview = () => {
                     justifyContent: 'center',
                   }}
                 >
-                  <PieChart
+                  <AppPieChart
                     series={[
                       {
                         id: `${disk.device}-usage`,
@@ -252,24 +261,7 @@ export const DiskOverview = () => {
                     hideLegend
                     slotProps={{
                       tooltip: {
-                        sx: {
-                          direction: 'rtl',
-                          '& .MuiChartsTooltip-table': {
-                            direction: 'rtl',
-                            color: 'var(--color-text)',
-                          },
-                          '& .MuiChartsTooltip-cell': {
-                            whiteSpace: 'pre-line',
-                            fontFamily: 'var(--font-vazir)',
-                            color: 'var(--color-text)',
-                          },
-                          '& .MuiChartsTooltip-label': {
-                            color: 'var(--color-text)',
-                          },
-                          '& .MuiChartsTooltip-value': {
-                            color: 'var(--color-text)',
-                          },
-                        },
+                        sx: tooltipMultilineSx,
                       },
                     }}
                   />
@@ -367,28 +359,6 @@ const Disk = () => {
   const { data, isLoading, error } = useDisk();
   const theme = useTheme();
   const cardSx = createCardSx(theme);
-
-  const tooltipSx = {
-    direction: 'rtl',
-    '& .MuiChartsTooltip-table': {
-      direction: 'rtl',
-      color: 'var(--color-text)',
-    },
-    '& .MuiChartsTooltip-label': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-    '& .MuiChartsTooltip-value': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-      whiteSpace: 'pre-line',
-    },
-    '& .MuiChartsTooltip-cell': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-      whiteSpace: 'pre-line',
-    },
-  } as const;
 
   const ioSummary = useMemo<DeviceMetricDatum[]>(() => {
     if (!data?.summary?.disk_io_summary) {
@@ -581,7 +551,7 @@ const Disk = () => {
                 تعداد عملیات خواندن/نوشتن
               </Typography>
               <Box sx={{ width: '100%', direction: 'ltr' }}>
-                <LineChart
+                <AppLineChart
                   dataset={ioChartDataset}
                   series={ioCountSeries}
                   xAxis={[
@@ -611,14 +581,7 @@ const Disk = () => {
                   height={300}
                   margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
                   slotProps={{
-                    tooltip: { sx: tooltipSx },
-                    legend: {
-                      sx: {
-                        color: 'var(--color-text)',
-                        fontFamily: 'var(--font-vazir)',
-                      },
-                      position: { vertical: 'top', horizontal: 'center' },
-                    },
+                    tooltip: { sx: tooltipMultilineSx },
                   }}
                 />
               </Box>
@@ -629,7 +592,7 @@ const Disk = () => {
                 حجم داده خواندن/نوشتن
               </Typography>
               <Box sx={{ width: '100%', direction: 'ltr' }}>
-                <LineChart
+                <AppLineChart
                   dataset={ioChartDataset}
                   series={ioBytesSeries}
                   xAxis={[
@@ -659,14 +622,7 @@ const Disk = () => {
                   height={300}
                   margin={{ top: 40, right: 32, left: 56, bottom: 64 }}
                   slotProps={{
-                    tooltip: { sx: tooltipSx },
-                    legend: {
-                      sx: {
-                        color: 'var(--color-text)',
-                        fontFamily: 'var(--font-vazir)',
-                      },
-                      position: { vertical: 'top', horizontal: 'center' },
-                    },
+                    tooltip: { sx: tooltipMultilineSx },
                   }}
                 />
               </Box>
@@ -687,7 +643,7 @@ const Disk = () => {
         </Typography>
         {barChartDataset.length > 0 ? (
           <Box sx={{ width: '100%', direction: 'ltr' }}>
-            <BarChart
+            <AppBarChart
               dataset={barChartDataset}
               xAxis={[{ scaleType: 'band', dataKey: 'device' }]}
               yAxis={[
@@ -718,14 +674,7 @@ const Disk = () => {
               height={280}
               margin={{ top: 60, right: 40, left: 40 }}
               slotProps={{
-                tooltip: { sx: tooltipSx },
-                legend: {
-                  sx: {
-                    color: 'var(--color-text)',
-                    fontFamily: 'var(--font-vazir)',
-                  },
-                  position: { vertical: 'top', horizontal: 'center' },
-                },
+                tooltip: { sx: tooltipMultilineSx },
               }}
             />
           </Box>

--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -1,10 +1,10 @@
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
-import { PieChart } from '@mui/x-charts/PieChart';
 import { useMemo } from 'react';
 import { BYTE_UNITS, clampPercent, parseNumeric } from '../constants/memory';
 import { useMemory } from '../hooks/useMemory';
 import { formatBytes } from '../utils/formatters';
 import { createCardSx } from './cardStyles';
+import AppPieChart from './charts/AppPieChart';
 
 const Memory = () => {
   const { data, isLoading, error } = useMemory();
@@ -237,7 +237,7 @@ const Memory = () => {
       </Box>
 
       <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-        <PieChart
+        <AppPieChart
           series={[
             {
               id: 'memory-usage',
@@ -290,21 +290,11 @@ const Memory = () => {
           slotProps={{
             tooltip: {
               sx: {
-                direction: 'rtl',
-                '& .MuiChartsTooltip-table': {
-                  direction: 'rtl',
-                  color: 'var(--color-text)',
-                },
                 '& .MuiChartsTooltip-cell': {
                   whiteSpace: 'pre-line',
-                  fontFamily: 'var(--font-vazir)',
-                  color: 'var(--color-text)',
-                },
-                '& .MuiChartsTooltip-label': {
-                  color: 'var(--color-text)',
                 },
                 '& .MuiChartsTooltip-value': {
-                  color: 'var(--color-text)',
+                  whiteSpace: 'pre-line',
                 },
               },
             },

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -1,67 +1,14 @@
 import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
-import { LineChart } from '@mui/x-charts';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type {
-  History,
-  IPv4Info,
-  ResponsiveChartContainerProps,
-} from '../@types/network';
+import type { History, IPv4Info } from '../@types/network';
 import {
   useNetwork,
   type InterfaceAddress,
   type NetworkInterface,
 } from '../hooks/useNetwork';
 import '../index.css';
-
-const ResponsiveChartContainer = ({
-  height,
-  children,
-}: ResponsiveChartContainerProps) => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [width, setWidth] = useState(0);
-
-  useEffect(() => {
-    const element = containerRef.current;
-    if (!element) {
-      return;
-    }
-
-    const updateWidth = () => {
-      setWidth(element.getBoundingClientRect().width);
-    };
-
-    if (typeof ResizeObserver === 'undefined') {
-      updateWidth();
-      return;
-    }
-
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) {
-        setWidth(entry.contentRect.width);
-      }
-    });
-
-    observer.observe(element);
-    updateWidth();
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
-
-  return (
-    <Box
-      ref={containerRef}
-      sx={{
-        width: '100%',
-        minHeight: height,
-      }}
-    >
-      {width > 0 && children(width)}
-    </Box>
-  );
-};
+import AppLineChart from './charts/AppLineChart';
+import ResponsiveChartContainer from './charts/ResponsiveChartContainer';
 
 const MAX_HISTORY_MS = 90 * 1000; // 1 minute 30 seconds
 
@@ -230,26 +177,6 @@ const Network = () => {
   const interfaces = data?.interfaces ?? {};
   const names = Object.keys(interfaces);
 
-  const tooltipSx = {
-    direction: 'rtl',
-    '& .MuiChartsTooltip-table': {
-      direction: 'rtl',
-      color: 'var(--color-text)',
-    },
-    '& .MuiChartsTooltip-label': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-    '& .MuiChartsTooltip-value': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-    '& .MuiChartsTooltip-cell': {
-      color: 'var(--color-text)',
-      fontFamily: 'var(--font-vazir)',
-    },
-  } as const;
-
   const cardBorderColor =
     theme.palette.mode === 'dark'
       ? 'rgba(255, 255, 255, 0.12)'
@@ -302,7 +229,7 @@ const Network = () => {
       {names.length === 0 ? (
         <ResponsiveChartContainer height={chartSize}>
           {(width) => (
-            <LineChart
+            <AppLineChart
               width={width}
               height={chartSize}
               dataset={[]}
@@ -325,7 +252,6 @@ const Network = () => {
               ]}
               slotProps={{
                 noDataOverlay: { message: 'No network data' },
-                tooltip: { sx: tooltipSx },
               }}
             />
           )}
@@ -374,7 +300,7 @@ const Network = () => {
               </Typography>
               <ResponsiveChartContainer height={chartSize}>
                 {(width) => (
-                  <LineChart
+                  <AppLineChart
                     width={width}
                     height={chartSize}
                     dataset={interfaceHistory}
@@ -418,15 +344,7 @@ const Network = () => {
                     ]}
                     margin={{ left: 40, right: 24, top: 20, bottom: 20 }}
                     slotProps={{
-                      legend: {
-                        sx: {
-                          color: 'var(--color-text)',
-                          fontFamily: 'var(--font-vazir)',
-                        },
-                        position: { vertical: 'top', horizontal: 'center' },
-                      },
                       noDataOverlay: { message: 'No network data' },
-                      tooltip: { sx: tooltipSx },
                     }}
                   />
                 )}

--- a/src/components/charts/AppBarChart.tsx
+++ b/src/components/charts/AppBarChart.tsx
@@ -1,0 +1,20 @@
+import { BarChart, type BarChartProps } from '@mui/x-charts/BarChart';
+import { mergeChartSlotProps } from './chartStyles';
+
+export type AppBarChartProps = BarChartProps & {
+  disableDefaultLegend?: boolean;
+};
+
+const AppBarChart = ({
+  slotProps,
+  disableDefaultLegend = false,
+  ...rest
+}: AppBarChartProps) => {
+  const mergedSlotProps = mergeChartSlotProps<BarChartProps['slotProps']>(slotProps, {
+    includeLegend: !disableDefaultLegend,
+  }) as BarChartProps['slotProps'];
+
+  return <BarChart {...rest} slotProps={mergedSlotProps} />;
+};
+
+export default AppBarChart;

--- a/src/components/charts/AppGauge.tsx
+++ b/src/components/charts/AppGauge.tsx
@@ -1,0 +1,35 @@
+import { GlobalStyles } from '@mui/material';
+import { Gauge, type GaugeProps } from '@mui/x-charts/Gauge';
+
+export type AppGaugeProps = GaugeProps & {
+  valueFormatter?: (value: number | null) => string;
+};
+
+const AppGauge = ({ valueFormatter, text, ...rest }: AppGaugeProps) => {
+  const gaugeText =
+    text ??
+    (({ value }: { value: number | null }) => {
+      if (valueFormatter) {
+        return valueFormatter(value ?? null);
+      }
+
+      const numericValue = typeof value === 'number' ? value : 0;
+      return `${Math.round(numericValue)}`;
+    });
+
+  return (
+    <>
+      <GlobalStyles
+        styles={{
+          '.MuiGauge-valueText, .MuiGauge-valueText tspan': {
+            fill: 'var(--color-text) !important',
+            color: 'var(--color-text) !important',
+          },
+        }}
+      />
+      <Gauge {...rest} text={gaugeText} />
+    </>
+  );
+};
+
+export default AppGauge;

--- a/src/components/charts/AppLineChart.tsx
+++ b/src/components/charts/AppLineChart.tsx
@@ -1,0 +1,20 @@
+import { LineChart, type LineChartProps } from '@mui/x-charts/LineChart';
+import { mergeChartSlotProps } from './chartStyles';
+
+export type AppLineChartProps = LineChartProps & {
+  disableDefaultLegend?: boolean;
+};
+
+const AppLineChart = ({
+  slotProps,
+  disableDefaultLegend = false,
+  ...rest
+}: AppLineChartProps) => {
+  const mergedSlotProps = mergeChartSlotProps<LineChartProps['slotProps']>(slotProps, {
+    includeLegend: !disableDefaultLegend,
+  }) as LineChartProps['slotProps'];
+
+  return <LineChart {...rest} slotProps={mergedSlotProps} />;
+};
+
+export default AppLineChart;

--- a/src/components/charts/AppPieChart.tsx
+++ b/src/components/charts/AppPieChart.tsx
@@ -1,0 +1,20 @@
+import { PieChart, type PieChartProps } from '@mui/x-charts/PieChart';
+import { mergeChartSlotProps } from './chartStyles';
+
+export type AppPieChartProps = PieChartProps & {
+  disableDefaultLegend?: boolean;
+};
+
+const AppPieChart = ({
+  slotProps,
+  disableDefaultLegend = true,
+  ...rest
+}: AppPieChartProps) => {
+  const mergedSlotProps = mergeChartSlotProps<PieChartProps['slotProps']>(slotProps, {
+    includeLegend: !disableDefaultLegend,
+  }) as PieChartProps['slotProps'];
+
+  return <PieChart {...rest} slotProps={mergedSlotProps} />;
+};
+
+export default AppPieChart;

--- a/src/components/charts/ResponsiveChartContainer.tsx
+++ b/src/components/charts/ResponsiveChartContainer.tsx
@@ -1,0 +1,59 @@
+import { Box } from '@mui/material';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+export type ResponsiveChartContainerProps = {
+  height: number;
+  children: (width: number) => ReactNode;
+};
+
+const ResponsiveChartContainer = ({
+  height,
+  children,
+}: ResponsiveChartContainerProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+
+    const updateWidth = () => {
+      setWidth(element.getBoundingClientRect().width);
+    };
+
+    if (typeof ResizeObserver === 'undefined') {
+      updateWidth();
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        setWidth(entry.contentRect.width);
+      }
+    });
+
+    observer.observe(element);
+    updateWidth();
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        width: '100%',
+        minHeight: height,
+      }}
+    >
+      {width > 0 && children(width)}
+    </Box>
+  );
+};
+
+export default ResponsiveChartContainer;

--- a/src/components/charts/chartStyles.ts
+++ b/src/components/charts/chartStyles.ts
@@ -1,0 +1,136 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const mergeRecords = (
+  base: Record<string, unknown>,
+  override?: Record<string, unknown>
+): Record<string, unknown> => {
+  if (!override) {
+    return { ...base };
+  }
+
+  const result: Record<string, unknown> = { ...base };
+
+  Object.entries(override).forEach(([key, value]) => {
+    const baseValue = result[key];
+
+    if (isRecord(baseValue) && isRecord(value)) {
+      result[key] = mergeRecords(baseValue, value);
+    } else if (value !== undefined) {
+      result[key] = value;
+    }
+  });
+
+  return result;
+};
+
+const tooltipSx: Record<string, unknown> = {
+  direction: 'rtl',
+  '& .MuiChartsTooltip-table': {
+    direction: 'rtl',
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+  '& .MuiChartsTooltip-cell': {
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+  '& .MuiChartsTooltip-label': {
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+  '& .MuiChartsTooltip-value': {
+    color: 'var(--color-text)',
+    fontFamily: 'var(--font-vazir)',
+  },
+};
+
+const legendSx: Record<string, unknown> = {
+  color: 'var(--color-text)',
+  fontFamily: 'var(--font-vazir)',
+};
+
+const legendPosition = {
+  vertical: 'top' as const,
+  horizontal: 'center' as const,
+};
+
+export const defaultTooltipSlotProps = {
+  sx: tooltipSx as SxProps<Theme>,
+};
+
+export const defaultLegendSlotProps = {
+  sx: legendSx as SxProps<Theme>,
+  position: legendPosition,
+};
+
+export type GenericChartSlotProps = {
+  tooltip?: { sx?: SxProps<Theme> } & Record<string, unknown>;
+  legend?:
+    | ({
+        sx?: SxProps<Theme>;
+        position?: { vertical?: 'top' | 'bottom'; horizontal?: 'left' | 'center' | 'right' };
+      } & Record<string, unknown>)
+    | null;
+  [key: string]: unknown;
+};
+
+export type MergeSlotPropsOptions = {
+  includeLegend?: boolean;
+  legendPosition?: { vertical?: 'top' | 'bottom'; horizontal?: 'left' | 'center' | 'right' };
+};
+
+export const mergeChartSlotProps = <TS extends GenericChartSlotProps | undefined>(
+  slotProps: TS,
+  { includeLegend = true, legendPosition: legendPositionOverride }: MergeSlotPropsOptions = {}
+) => {
+  const tooltipProps = slotProps?.tooltip ?? {};
+  const mergedTooltipSx = mergeRecords(
+    tooltipSx,
+    (tooltipProps.sx as Record<string, unknown> | undefined) ?? undefined
+  );
+
+  const result: GenericChartSlotProps = {
+    ...(slotProps ?? {}),
+    tooltip: {
+      ...tooltipProps,
+      sx: mergedTooltipSx as SxProps<Theme>,
+    },
+  };
+
+  if (includeLegend) {
+    if (slotProps && 'legend' in slotProps && slotProps.legend === null) {
+      result.legend = null;
+    } else {
+      const baseLegend = {
+        ...defaultLegendSlotProps,
+        position: mergeRecords(
+          legendPosition,
+          legendPositionOverride as Record<string, unknown> | undefined
+        ) as typeof legendPosition,
+      };
+
+      const legendProps = slotProps?.legend;
+      if (legendProps) {
+        result.legend = {
+          ...baseLegend,
+          ...legendProps,
+          position: mergeRecords(
+            baseLegend.position,
+            (legendProps.position as Record<string, unknown> | undefined) ?? undefined
+          ) as typeof legendPosition,
+          sx: mergeRecords(
+            baseLegend.sx as Record<string, unknown>,
+            (legendProps.sx as Record<string, unknown> | undefined) ?? undefined
+          ) as SxProps<Theme>,
+        };
+      } else {
+        result.legend = baseLegend;
+      }
+    }
+  }
+
+  return result as TS extends undefined ? GenericChartSlotProps : GenericChartSlotProps & NonNullable<TS>;
+};


### PR DESCRIPTION
## Summary
- add shared chart wrappers, tooltip merging utilities, and a responsive container to reuse chart styling
- refactor CPU, memory, disk, and network components to consume the shared chart primitives
- centralize tooltip styling helpers so multi-line tooltips stay consistent across charts

## Testing
- npm run lint *(fails: react-refresh/only-export-components reported in existing context files)*

------
https://chatgpt.com/codex/tasks/task_b_68ce6ff1903c832ab58d0441e74b6b3b