### PR TITLE
Refactor dashboard layout into flexible grid

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,68 +1,93 @@
 import { Box } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
+import type { SxProps, Theme } from '@mui/material/styles';
 import Cpu from '../components/Cpu';
 import Disk, { DiskOverview } from '../components/Disk';
 import Memory from '../components/Memory';
 import Network from '../components/Network';
 
+type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+type ResponsiveSize = Partial<Record<Breakpoint, number>>;
+
+type DashboardWidgetRenderer = () => JSX.Element;
+
+interface DashboardWidget {
+  id: string;
+  component: DashboardWidgetRenderer;
+  size?: ResponsiveSize;
+}
+
+const containerSx: SxProps<Theme> = {
+  p: { xs: 2, md: 3 },
+  fontFamily: 'var(--font-vazir)',
+};
+
+const gridContainerSx: SxProps<Theme> = {
+  alignItems: 'stretch',
+  alignContent: 'start',
+};
+
+const gridItemSx: SxProps<Theme> = {
+  display: 'flex',
+  minWidth: 0,
+  '& > *': {
+    flexGrow: 1,
+    minWidth: 0,
+  },
+};
+
+const dashboardWidgets: DashboardWidget[] = [
+  {
+    id: 'cpu',
+    component: Cpu,
+    size: { xs: 12, md: 6, xl: 3 },
+  },
+  {
+    id: 'memory',
+    component: Memory,
+    size: { xs: 12, md: 6, xl: 3 },
+  },
+  {
+    id: 'disk-overview',
+    component: DiskOverview,
+    size: { xs: 12, md: 12, xl: 6 },
+  },
+  {
+    id: 'disk',
+    component: Disk,
+    size: { xs: 12, md: 12, xl: 6 },
+  },
+  {
+    id: 'network',
+    component: Network,
+    size: { xs: 12, md: 12, xl: 6 },
+  },
+];
+
 const Dashboard = () => {
   return (
-    <Box
-      sx={{
-        p: 3,
-        fontFamily: 'var(--font-vazir)',
-        display: 'grid',
-        gap: 3,
-        gridTemplateColumns: {
-          xs: 'repeat(1, minmax(0, 1fr))',
-          md: 'repeat(12, minmax(0, 1fr))',
-        },
-      }}
-    >
-      <Box
-        sx={{
-          gridColumn: { xs: '1 / -1', md: 'span 6', lg: 'span 2' },
-          display: 'flex',
-          width: '100%',
-        }}
+    <Box sx={containerSx}>
+      <Grid
+        container
+        spacing={{ xs: 2, md: 3 }}
+        columns={{ xs: 12, sm: 12, md: 12, lg: 12, xl: 12 }}
+        sx={gridContainerSx}
       >
-        <Cpu />
-      </Box>
-      <Box
-        sx={{
-          gridColumn: { xs: '1 / -1', md: 'span 6', lg: 'span 2' },
-          display: 'flex',
-          width: '100%',
-        }}
-      >
-        <Memory />
-      </Box>
-      <Box
-        sx={{
-          gridColumn: { xs: '1 / -1', md: '1 / -1', lg: 'span 8' },
-          display: 'flex',
-          width: '100%',
-        }}
-      >
-        <DiskOverview />
-      </Box>
-      <Box
-        sx={{
-          gridColumn: '1 / -1',
-          display: 'flex',
-          width: '100%',
-        }}
-      >
-        <Disk />
-      </Box>
-      <Box
-        sx={{
-          gridColumn: '1 / -1',
-          display: 'flex',
-          width: '100%',
-        }}
-      >
-        <Network />
-      </Box>
+        {dashboardWidgets.map(({ id, component: WidgetComponent, size }) => (
+          <Grid
+            key={id}
+            xs={size?.xs ?? 12}
+            sm={size?.sm}
+            md={size?.md}
+            lg={size?.lg}
+            xl={size?.xl}
+            sx={gridItemSx}
+          >
+            <WidgetComponent />
+          </Grid>
+        ))}
+      </Grid>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- replace the dashboard's hard-coded CSS grid with a responsive MUI Grid layout driven by configuration
- define widget metadata in one place so future charts can be added without touching layout code and automatically flow into the grid

## Testing
- npm run lint *(fails: existing `react-refresh/only-export-components` errors in context files)*

------
https://chatgpt.com/codex/tasks/task_b_68ce7658c010832ab4cfbe15f4b2a9fe