### PR TITLE
Fix duplicate IPv4 detail keys in Network component

### DIFF
--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -423,27 +423,31 @@ const Network = () => {
                       ipv4Details.length > 1
                         ? ` IPv4 ${index + 1}: `
                         : ' IPv4: ';
-                    const netmaskSuffix = entry.netmask
+                    const netmaskText = entry.netmask
                       ? ` نت‌ماسک: ${entry.netmask}`
-                      : '';
+                      : null;
+                    const baseKey = entry.address ?? `ipv4-${index}`;
 
                     return (
-                      <>
+                      <Box
+                        key={`${baseKey}-${index}`}
+                        sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}
+                      >
                         <Typography
-                          key={`${entry.address}-${index}`}
                           variant="body2"
                           sx={{ color: theme.palette.text.secondary }}
                         >
                           {`${labelPrefix}${entry.address}`}
                         </Typography>
-                        <Typography
-                          key={`${entry.address}-${index}`}
-                          variant="body2"
-                          sx={{ color: theme.palette.text.secondary }}
-                        >
-                          {`${netmaskSuffix}`}
-                        </Typography>
-                      </>
+                        {netmaskText && (
+                          <Typography
+                            variant="body2"
+                            sx={{ color: theme.palette.text.secondary }}
+                          >
+                            {netmaskText}
+                          </Typography>
+                        )}
+                      </Box>
                     );
                   })
                 ) : (


### PR DESCRIPTION
## Summary
- wrap IPv4 detail rows in a uniquely keyed container to avoid duplicate React keys
- skip rendering empty netmask entries so only real values are displayed

## Testing
- `npm run lint` *(fails: existing react-refresh/only-export-components errors in context files)*

------
https://chatgpt.com/codex/tasks/task_b_68d3d3df6428832ab356856e619de925