### PR TITLE
Add zpool overview dashboard widget

### DIFF
--- a/src/@types/zpool.ts
+++ b/src/@types/zpool.ts
@@ -1,0 +1,27 @@
+export interface ZpoolListResponse {
+  data: string[];
+}
+
+export type ZpoolCapacityPayload = Record<string, unknown>;
+
+export interface ZpoolCapacityResponse {
+  data: ZpoolCapacityPayload;
+}
+
+export interface ZpoolCapacityEntry {
+  name: string;
+  totalBytes: number | null;
+  usedBytes: number | null;
+  freeBytes: number | null;
+  capacityPercent: number | null;
+  deduplication?: string | null;
+  deduplicationRatio?: number | null;
+  fragmentationPercent?: number | null;
+  health?: string;
+  raw: ZpoolCapacityPayload;
+}
+
+export interface ZpoolQueryResult {
+  pools: ZpoolCapacityEntry[];
+  failedPools: string[];
+}

--- a/src/components/Zpool.tsx
+++ b/src/components/Zpool.tsx
@@ -1,0 +1,473 @@
+import {
+  Alert,
+  Box,
+  Skeleton,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { useMemo } from 'react';
+import { diskPercentFormatter, tooltipMultilineSx } from '../constants/disk';
+import { useZpool } from '../hooks/useZpool';
+import { createCardSx } from './cardStyles';
+import AppPieChart from './charts/AppPieChart';
+import { formatBytes } from '../utils/formatters';
+
+const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+const Zpool = () => {
+  const { data, isLoading, error } = useZpool({ refetchInterval: 15000 });
+  const theme = useTheme();
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const chartSize = isSmallScreen ? 180 : 230;
+
+  const cardSx = createCardSx(theme);
+
+  const pools = useMemo(() => data?.pools ?? [], [data?.pools]);
+  const failedPools = useMemo(() => data?.failedPools ?? [], [data?.failedPools]);
+
+  const isDarkMode = theme.palette.mode === 'dark';
+  const cardBorderColor = isDarkMode
+    ? 'rgba(255, 255, 255, 0.08)'
+    : 'rgba(0, 0, 0, 0.08)';
+  const statsDividerColor = isDarkMode
+    ? 'rgba(255, 255, 255, 0.08)'
+    : 'rgba(0, 0, 0, 0.08)';
+  const statsBackground = isDarkMode
+    ? 'rgba(255, 255, 255, 0.04)'
+    : 'rgba(0, 0, 0, 0.03)';
+
+  if (isLoading) {
+    return (
+      <Box sx={cardSx}>
+        <Skeleton
+          variant="text"
+          width="40%"
+          height={28}
+          sx={{ borderRadius: 1 }}
+        />
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 2,
+          }}
+        >
+          {Array.from({ length: 2 }).map((_, index) => (
+            <Box
+              key={index}
+              sx={{
+                flex: '1 1 240px',
+                minWidth: 220,
+                p: 2.5,
+                borderRadius: 3,
+                bgcolor: 'var(--color-card-bg)',
+                border: `1px solid ${cardBorderColor}`,
+                boxShadow: '0 16px 32px rgba(0, 0, 0, 0.18)',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 2,
+              }}
+            >
+              <Skeleton
+                variant="text"
+                width="70%"
+                height={22}
+                sx={{ borderRadius: 1, alignSelf: 'stretch' }}
+              />
+              <Skeleton
+                variant="text"
+                width="50%"
+                height={18}
+                sx={{ borderRadius: 1, alignSelf: 'stretch' }}
+              />
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  justifyContent: 'center',
+                }}
+              >
+                <Skeleton
+                  variant="circular"
+                  width={chartSize}
+                  height={chartSize}
+                  sx={{ bgcolor: 'action.hover' }}
+                />
+              </Box>
+              <Box
+                sx={{
+                  width: '100%',
+                  bgcolor: statsBackground,
+                  borderRadius: 2,
+                  px: 2,
+                  py: 1.5,
+                  border: `1px solid ${statsDividerColor}`,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 1,
+                }}
+              >
+                {Array.from({ length: 4 }).map((_, statIndex) => (
+                  <Box
+                    key={statIndex}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 2,
+                      borderBottom:
+                        statIndex === 3
+                          ? 'none'
+                          : `1px dashed ${statsDividerColor}`,
+                      py: 0.75,
+                    }}
+                  >
+                    <Skeleton
+                      variant="text"
+                      width="60%"
+                      height={16}
+                      sx={{ borderRadius: 1 }}
+                    />
+                    <Skeleton
+                      variant="text"
+                      width="30%"
+                      height={16}
+                      sx={{ borderRadius: 1 }}
+                    />
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={cardSx}>
+        <Typography variant="body2" sx={{ color: 'var(--color-error)' }}>
+          خطا در دریافت اطلاعات استخرها: {error.message}
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={cardSx}>
+      <Typography
+        variant="subtitle2"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          fontWeight: 600,
+        }}
+      >
+        <Box component="span" sx={{ fontSize: 20 }}>
+          🗃️
+        </Box>
+        نمای کلی استخرهای ZFS
+      </Typography>
+
+      {failedPools.length > 0 && (
+        <Alert
+          severity="warning"
+          variant="outlined"
+          sx={{ direction: 'rtl', fontSize: '0.875rem' }}
+        >
+          بازیابی اطلاعات برای استخرهای زیر با خطا مواجه شد: {failedPools.join('، ')}
+        </Alert>
+      )}
+
+      {pools.length > 0 ? (
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 2,
+          }}
+        >
+          {pools.map((pool) => {
+            const totalRaw = pool.totalBytes ?? 0;
+            const usedRaw = pool.usedBytes ?? 0;
+            const freeRaw = pool.freeBytes ?? 0;
+
+            const nonNegativeUsed = Math.max(usedRaw, 0);
+            const nonNegativeFree = Math.max(freeRaw, 0);
+            const derivedTotal =
+              totalRaw > 0 ? totalRaw : nonNegativeUsed + nonNegativeFree;
+            const safeTotal =
+              derivedTotal > 0 ? derivedTotal : nonNegativeUsed + nonNegativeFree;
+            const boundedUsed =
+              safeTotal > 0
+                ? Math.min(nonNegativeUsed, safeTotal)
+                : nonNegativeUsed;
+            const fallbackFree =
+              safeTotal > boundedUsed ? safeTotal - boundedUsed : 0;
+            const boundedFree =
+              nonNegativeFree > 0
+                ? Math.min(
+                    nonNegativeFree,
+                    fallbackFree > 0 ? fallbackFree : nonNegativeFree
+                  )
+                : fallbackFree;
+            const chartRemaining =
+              safeTotal > 0
+                ? Math.max(safeTotal - boundedUsed, 0)
+                : boundedFree;
+
+            const percentValueRaw = pool.capacityPercent;
+            const safePercent =
+              percentValueRaw != null && Number.isFinite(percentValueRaw)
+                ? clampPercent(percentValueRaw)
+                : safeTotal > 0
+                  ? clampPercent((boundedUsed / safeTotal) * 100)
+                  : 0;
+            const percentText = `${diskPercentFormatter.format(safePercent)}٪`;
+
+            const chartOuterRadius = Math.min(110, chartSize / 2 - 8);
+            const chartInnerRadius = Math.max(
+              chartOuterRadius - 24,
+              chartOuterRadius * 0.22
+            );
+
+            const stats: Array<{ key: string; label: string; value: string }> = [
+              {
+                key: 'used',
+                label: 'استفاده‌شده',
+                value: formatBytes(boundedUsed),
+              },
+              { key: 'free', label: 'خالی', value: formatBytes(boundedFree) },
+              { key: 'total', label: 'کل', value: formatBytes(safeTotal) },
+              { key: 'percent', label: 'درصد استفاده', value: percentText },
+            ];
+
+            if (pool.health) {
+              stats.push({ key: 'health', label: 'سلامت', value: pool.health });
+            }
+
+            if (pool.fragmentationPercent != null) {
+              stats.push({
+                key: 'fragmentation',
+                label: 'درصد پراکندگی',
+                value: `${diskPercentFormatter.format(pool.fragmentationPercent)}٪`,
+              });
+            }
+
+            if (pool.deduplication || pool.deduplicationRatio != null) {
+              const dedupValue = pool.deduplicationRatio;
+              const formatted = pool.deduplication
+                ? pool.deduplication
+                : dedupValue != null && Number.isFinite(dedupValue)
+                  ? `${dedupValue.toFixed(2)}x`
+                  : '-';
+              stats.push({
+                key: 'dedup',
+                label: 'ضریب Dedup',
+                value: formatted,
+              });
+            }
+
+            const usedColor = theme.palette.primary.main;
+            const remainingColor = isDarkMode
+              ? 'rgba(255, 255, 255, 0.28)'
+              : 'rgba(0, 0, 0, 0.16)';
+            const fadedColor = isDarkMode
+              ? 'rgba(255, 255, 255, 0.08)'
+              : 'rgba(0, 0, 0, 0.08)';
+
+            return (
+              <Box
+                key={pool.name}
+                sx={{
+                  flex: '1 1 260px',
+                  minWidth: 240,
+                  p: 2.5,
+                  borderRadius: 3,
+                  bgcolor: 'var(--color-card-bg)',
+                  border: `1px solid ${cardBorderColor}`,
+                  boxShadow: '0 16px 32px rgba(0, 0, 0, 0.18)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 2,
+                }}
+              >
+                <Stack spacing={0.5} sx={{ alignSelf: 'stretch' }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {pool.name}
+                  </Typography>
+                  {pool.health && (
+                    <Typography
+                      variant="caption"
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      وضعیت سلامت: {pool.health}
+                    </Typography>
+                  )}
+                </Stack>
+
+                <Box
+                  sx={{
+                    position: 'relative',
+                    width: '100%',
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <AppPieChart
+                    series={[
+                      {
+                        id: `${pool.name}-capacity`,
+                        data: [
+                          {
+                            id: 'used',
+                            value: boundedUsed,
+                            label: 'استفاده‌شده',
+                            color: usedColor,
+                          },
+                          {
+                            id: 'remaining',
+                            value: chartRemaining,
+                            label: 'باقی‌مانده',
+                            color: remainingColor,
+                          },
+                        ],
+                        innerRadius: 50,
+                        outerRadius: chartOuterRadius,
+                        paddingAngle: 1.2,
+                        cornerRadius: 5,
+                        startAngle: 0,
+                        endAngle: 360,
+                        highlightScope: { fade: 'global', highlight: 'item' },
+                        faded: {
+                          innerRadius: Math.max(
+                            chartInnerRadius - 6,
+                            chartInnerRadius * 0.9
+                          ),
+                          additionalRadius: -12,
+                          color: fadedColor,
+                        },
+                        valueFormatter: (item) => {
+                          if (item.id === 'used') {
+                            return [
+                              `${formatBytes(boundedUsed)} : استفاده‌شده`,
+                              `${formatBytes(safeTotal)} : کل`,
+                              `${formatBytes(boundedFree)} : خالی`,
+                              `${percentText} : درصد استفاده`,
+                            ].join('\n');
+                          }
+                          return `${formatBytes(chartRemaining)} : باقی‌مانده`;
+                        },
+                      },
+                    ]}
+                    width={chartSize}
+                    height={chartSize}
+                    margin={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    hideLegend
+                    slotProps={{
+                      tooltip: {
+                        sx: tooltipMultilineSx,
+                      },
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      inset: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexDirection: 'column',
+                      pointerEvents: 'none',
+                      gap: 0.5,
+                    }}
+                  >
+                    <Typography
+                      variant="h5"
+                      sx={{
+                        fontFamily: 'var(--font-didot)',
+                        fontWeight: 700,
+                        color: 'var(--color-primary)',
+                      }}
+                    >
+                      {percentText}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ color: theme.palette.text.secondary }}
+                    >
+                      درصد استفاده
+                    </Typography>
+                  </Box>
+                </Box>
+
+                <Box
+                  sx={{
+                    width: '100%',
+                    bgcolor: statsBackground,
+                    borderRadius: 2,
+                    px: 2,
+                    py: 1.5,
+                    border: `1px solid ${statsDividerColor}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  {stats.map((stat, index) => (
+                    <Box
+                      key={stat.key}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                        py: 0.75,
+                        borderBottom:
+                          index === stats.length - 1
+                            ? 'none'
+                            : `1px dashed ${statsDividerColor}`,
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontWeight: 500,
+                          color: theme.palette.text.secondary,
+                        }}
+                      >
+                        {stat.label}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: 700, color: 'var(--color-primary)' }}
+                      >
+                        {stat.value}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      ) : (
+        <Typography
+          variant="body2"
+          sx={{ color: theme.palette.text.secondary }}
+        >
+          هیچ استخر فعالی یافت نشد.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default Zpool;

--- a/src/hooks/useZpool.ts
+++ b/src/hooks/useZpool.ts
@@ -1,0 +1,283 @@
+import { useQuery } from '@tanstack/react-query';
+import type {
+  ZpoolCapacityEntry,
+  ZpoolCapacityPayload,
+  ZpoolCapacityResponse,
+  ZpoolListResponse,
+  ZpoolQueryResult,
+} from '../@types/zpool';
+import axiosInstance from '../lib/axiosInstance';
+
+const ZPOOL_LIST_ENDPOINT = '/api/zpool/';
+
+const createZpoolCapacityEndpoint = (poolName: string) =>
+  `/api/zpool/${encodeURIComponent(poolName)}/capacity/`;
+
+const BYTE_UNITS: Record<string, number> = {
+  b: 1,
+  byte: 1,
+  bytes: 1,
+  k: 1024,
+  kb: 1024,
+  kib: 1024,
+  m: 1024 ** 2,
+  mb: 1024 ** 2,
+  mib: 1024 ** 2,
+  g: 1024 ** 3,
+  gb: 1024 ** 3,
+  gib: 1024 ** 3,
+  t: 1024 ** 4,
+  tb: 1024 ** 4,
+  tib: 1024 ** 4,
+  p: 1024 ** 5,
+  pb: 1024 ** 5,
+  pib: 1024 ** 5,
+};
+
+const parseByteValue = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const numericValue = Number(trimmed);
+    if (Number.isFinite(numericValue)) {
+      return numericValue;
+    }
+
+    const unitMatch = trimmed.match(/^(-?\d+(?:\.\d+)?)\s*([a-zA-Z]+)?$/);
+    if (unitMatch) {
+      const baseValue = Number(unitMatch[1]);
+      const unit = unitMatch[2]?.toLowerCase();
+
+      if (Number.isFinite(baseValue)) {
+        if (!unit) {
+          return baseValue;
+        }
+
+        const normalizedUnit = unit.replace(/s$/, '');
+        const multiplier =
+          BYTE_UNITS[normalizedUnit] ?? BYTE_UNITS[normalizedUnit.replace(/b$/, '')];
+
+        if (multiplier != null) {
+          return baseValue * multiplier;
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
+const parsePercentValue = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/%/g, '').replace(/,/g, '.').trim();
+    if (!cleaned) {
+      return null;
+    }
+
+    const numericValue = Number(cleaned);
+    if (Number.isFinite(numericValue)) {
+      return numericValue;
+    }
+  }
+
+  return null;
+};
+
+const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+const parseDedup = (value: unknown): { ratio: number | null; display: string | null } => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return {
+      ratio: value,
+      display: `${value.toFixed(2)}x`,
+    };
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { ratio: null, display: null };
+    }
+
+    const cleaned = trimmed.replace(/x$/i, '').replace(/,/g, '.');
+    const numericValue = Number(cleaned);
+
+    return {
+      ratio: Number.isFinite(numericValue) ? numericValue : null,
+      display: trimmed,
+    };
+  }
+
+  return { ratio: null, display: null };
+};
+
+const normalizeZpoolCapacity = (
+  poolName: string,
+  raw: ZpoolCapacityPayload
+): ZpoolCapacityEntry => {
+  const totalCandidate =
+    parseByteValue(raw.total) ??
+    parseByteValue(raw.size) ??
+    parseByteValue((raw as Record<string, unknown>).capacity_total) ??
+    parseByteValue((raw as Record<string, unknown>).capacityTotal) ??
+    parseByteValue((raw as Record<string, unknown>).total_capacity);
+
+  const usedCandidate =
+    parseByteValue(raw.used) ??
+    parseByteValue((raw as Record<string, unknown>).alloc) ??
+    parseByteValue((raw as Record<string, unknown>).allocated) ??
+    parseByteValue((raw as Record<string, unknown>).capacity_used) ??
+    parseByteValue((raw as Record<string, unknown>).used_capacity);
+
+  const freeCandidate =
+    parseByteValue(raw.free) ??
+    parseByteValue((raw as Record<string, unknown>).available) ??
+    parseByteValue((raw as Record<string, unknown>).capacity_free) ??
+    parseByteValue((raw as Record<string, unknown>).free_capacity);
+
+  const percentCandidate =
+    parsePercentValue(raw.capacity) ??
+    parsePercentValue((raw as Record<string, unknown>).cap) ??
+    parsePercentValue((raw as Record<string, unknown>).utilization) ??
+    parsePercentValue((raw as Record<string, unknown>).percent) ??
+    parsePercentValue((raw as Record<string, unknown>).capacity_percent);
+
+  let totalBytes = totalCandidate;
+  let usedBytes = usedCandidate;
+  let freeBytes = freeCandidate;
+  let capacityPercent = percentCandidate;
+
+  if (totalBytes == null && usedBytes != null && freeBytes != null) {
+    totalBytes = usedBytes + freeBytes;
+  }
+
+  if (usedBytes == null && capacityPercent != null && totalBytes != null) {
+    usedBytes = (capacityPercent / 100) * totalBytes;
+  }
+
+  if (freeBytes == null && totalBytes != null && usedBytes != null) {
+    freeBytes = totalBytes - usedBytes;
+  }
+
+  if (capacityPercent == null && totalBytes != null && usedBytes != null && totalBytes > 0) {
+    capacityPercent = (usedBytes / totalBytes) * 100;
+  }
+
+  const dedupSource =
+    raw.dedup ??
+    (raw as Record<string, unknown>).deduplication ??
+    (raw as Record<string, unknown>).dedup_ratio ??
+    (raw as Record<string, unknown>).dedupratio;
+  const { ratio: dedupRatio, display: dedupDisplay } = parseDedup(dedupSource);
+
+  const fragmentationSource =
+    raw.fragmentation ??
+    (raw as Record<string, unknown>).frag ??
+    (raw as Record<string, unknown>).fragmentation_percent ??
+    (raw as Record<string, unknown>).fragmentationPercent;
+  const fragmentationPercent =
+    fragmentationSource != null ? parsePercentValue(fragmentationSource) : null;
+
+  const healthSource =
+    raw.health ??
+    (raw as Record<string, unknown>).status ??
+    (raw as Record<string, unknown>).state;
+
+  return {
+    name:
+      typeof raw.name === 'string' && raw.name.trim()
+        ? (raw.name as string)
+        : poolName,
+    totalBytes: totalBytes ?? null,
+    usedBytes: usedBytes ?? null,
+    freeBytes: freeBytes ?? null,
+    capacityPercent:
+      capacityPercent != null && Number.isFinite(capacityPercent)
+        ? clampPercent(capacityPercent)
+        : null,
+    deduplication: dedupDisplay,
+    deduplicationRatio: dedupRatio,
+    fragmentationPercent:
+      fragmentationPercent != null && Number.isFinite(fragmentationPercent)
+        ? clampPercent(fragmentationPercent)
+        : null,
+    health:
+      typeof healthSource === 'string'
+        ? healthSource
+        : Array.isArray(healthSource)
+          ? healthSource.join(', ')
+          : undefined,
+    raw,
+  };
+};
+
+const fetchZpools = async (): Promise<ZpoolQueryResult> => {
+  const { data: listResponse } = await axiosInstance.get<ZpoolListResponse>(
+    ZPOOL_LIST_ENDPOINT
+  );
+
+  const poolNames = Array.isArray(listResponse?.data)
+    ? listResponse.data.filter((poolName): poolName is string =>
+        typeof poolName === 'string' && poolName.trim().length > 0
+      )
+    : [];
+
+  if (poolNames.length === 0) {
+    return { pools: [], failedPools: [] };
+  }
+
+  const requests = poolNames.map((poolName) =>
+    axiosInstance
+      .get<ZpoolCapacityResponse>(createZpoolCapacityEndpoint(poolName))
+      .then((response) => normalizeZpoolCapacity(poolName, response.data?.data ?? {}))
+      .catch((error) => {
+        throw { poolName, error };
+      })
+  );
+
+  const settledResults = await Promise.allSettled(requests);
+
+  const pools: ZpoolCapacityEntry[] = [];
+  const failedPools: string[] = [];
+
+  settledResults.forEach((result) => {
+    if (result.status === 'fulfilled') {
+      pools.push(result.value);
+      return;
+    }
+
+    const failure = result.reason as { poolName?: string } | undefined;
+    if (failure?.poolName) {
+      failedPools.push(failure.poolName);
+    }
+  });
+
+  pools.sort((a, b) => a.name.localeCompare(b.name, 'fa'));
+  failedPools.sort((a, b) => a.localeCompare(b, 'fa'));
+
+  return { pools, failedPools };
+};
+
+interface UseZpoolOptions {
+  refetchInterval?: number;
+}
+
+export const useZpool = (options?: UseZpoolOptions) => {
+  return useQuery<ZpoolQueryResult, Error>({
+    queryKey: ['zpool'],
+    queryFn: fetchZpools,
+    refetchInterval: options?.refetchInterval ?? 10000,
+    refetchIntervalInBackground: true,
+  });
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import Cpu from '../components/Cpu';
 import Disk from '../components/Disk';
 import Memory from '../components/Memory';
 import Network from '../components/Network';
+import Zpool from '../components/Zpool';
 
 type BreakpointKey = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
@@ -70,11 +71,11 @@ const dashboardWidgets: DashboardWidget[] = [
     component: Memory,
     columns: { xs: 12, md: 6, xl: 3 },
   },
-  // {
-  //   id: 'disk-overview',
-  //   component: DiskOverview,
-  //   columns: { xs: 12, md: 12, xl: 6 },
-  // },
+  {
+    id: 'zpool-overview',
+    component: Zpool,
+    columns: { xs: 12, md: 12, xl: 6 },
+  },
   {
     id: 'disk',
     component: Disk,


### PR DESCRIPTION
## Summary
- add shared zpool capacity types and React Query hook that collects per-pool capacity data from the API
- build a reusable Zpool overview card with capacity pie charts, status messaging, and stat breakdowns styled like the existing disk overview
- place the new zpool widget on the dashboard grid in lieu of the previous disk overview card

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components violations in AuthContext.tsx and ThemeContext.tsx)*
- npx eslint src/components/Zpool.tsx src/hooks/useZpool.ts src/pages/Dashboard.tsx src/@types/zpool.ts
- npm run build *(fails: pre-existing chart slot prop type errors and missing LoginForm import)*

------
https://chatgpt.com/codex/tasks/task_b_68d3e25fa57c832a8ec625921d21913a