### PR TITLE
Update zpool hook for expanded API response

### DIFF
--- a/src/@types/zpool.ts
+++ b/src/@types/zpool.ts
@@ -1,11 +1,7 @@
-export interface ZpoolListResponse {
-  data: string[];
-}
-
 export type ZpoolCapacityPayload = Record<string, unknown>;
 
-export interface ZpoolCapacityResponse {
-  data: ZpoolCapacityPayload;
+export interface ZpoolListResponse {
+  data: ZpoolCapacityPayload[];
 }
 
 export interface ZpoolCapacityEntry {


### PR DESCRIPTION
## Summary
- update the zpool typings to reflect that /api/zpool now returns full pool payloads
- simplify the zpool query hook to read capacity data directly from the list response and keep graceful fallbacks

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components and unused variable warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68d7a9a89754832f9bd9ff0aa195f00c