### PR TITLE
Add zpool deletion hook with confirmation dialog

### DIFF
--- a/src/hooks/useDeleteZpool.ts
+++ b/src/hooks/useDeleteZpool.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ZpoolQueryResult } from '../@types/zpool';
+import axiosInstance from '../lib/axiosInstance';
+
+interface DeleteZpoolPayload {
+  name: string;
+}
+
+interface DeleteZpoolResponse {
+  detail?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+const deleteZpool = async ({ name }: DeleteZpoolPayload) => {
+  const response = await axiosInstance.delete<DeleteZpoolResponse>(
+    '/api/zpool/delete',
+    {
+      params: { name },
+      data: { name },
+    }
+  );
+
+  return response.data;
+};
+
+export const useDeleteZpool = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<DeleteZpoolResponse, Error, DeleteZpoolPayload>({
+    mutationFn: deleteZpool,
+    onSuccess: (_data, variables) => {
+      queryClient.setQueryData<ZpoolQueryResult | undefined>(
+        ['zpool'],
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          return {
+            ...current,
+            pools: current.pools.filter((pool) => pool.name !== variables.name),
+            failedPools: current.failedPools.filter(
+              (poolName) => poolName !== variables.name
+            ),
+          };
+        }
+      );
+
+      queryClient.invalidateQueries({ queryKey: ['zpool'] });
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add a dedicated React Query mutation hook for deleting zpools through the `/api/zpool/delete` endpoint and invalidating cached data
- replace the alert-based delete flow in the Integrated Storage page with a confirmation dialog that calls the new hook and surfaces any API errors

## Testing
- `npm run lint` *(fails: existing lint violations in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d79ff11cec832fb55075bd480a67bd