### PR TITLE
Use toasts for pool actions and filter disks

### DIFF
--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -19,6 +19,7 @@ interface CreatePoolPayload {
 
 interface UseCreatePoolOptions {
   onSuccess?: (poolName: string) => void;
+  onError?: (errorMessage: string) => void;
 }
 
 const extractApiMessage = (error: AxiosError<ApiErrorResponse>) => {
@@ -53,7 +54,7 @@ const extractApiMessage = (error: AxiosError<ApiErrorResponse>) => {
   return error.message;
 };
 
-export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
+export const useCreatePool = ({ onSuccess, onError }: UseCreatePoolOptions = {}) => {
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [poolName, setPoolName] = useState('');
@@ -96,7 +97,10 @@ export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
       onSuccess?.(variables.pool_name);
     },
     onError: (error) => {
-      setApiError(extractApiMessage(error));
+      const errorMessage = extractApiMessage(error);
+
+      setApiError(errorMessage);
+      onError?.(errorMessage);
     },
   });
 


### PR DESCRIPTION
## Summary
- show toast notifications when pools are created or deleted
- filter available disks in the create pool modal to three-character names beginning with "sd"
- expose create pool error messages to the caller for toast handling

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in existing context files)*

------
https://chatgpt.com/codex/tasks/task_b_68d7c4c64e30832fbc0ed058418a73cc