### PR TITLE
Add pool comparison panel to Integrated Storage

### DIFF
--- a/src/@types/zpool.ts
+++ b/src/@types/zpool.ts
@@ -21,3 +21,11 @@ export interface ZpoolQueryResult {
   pools: ZpoolCapacityEntry[];
   failedPools: string[];
 }
+
+export interface ZpoolDetailEntry {
+  [key: string]: unknown;
+}
+
+export interface ZpoolDetailResponse {
+  data?: ZpoolDetailEntry[];
+}

--- a/src/components/integrated-storage/PoolsTable.tsx
+++ b/src/components/integrated-storage/PoolsTable.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Checkbox,
   Chip,
   CircularProgress,
   IconButton,
@@ -29,6 +30,8 @@ interface PoolsTableProps {
   onEdit: (pool: ZpoolCapacityEntry) => void;
   onDelete: (pool: ZpoolCapacityEntry) => void;
   isDeleteDisabled: boolean;
+  selectedPools: string[];
+  onToggleSelect: (pool: ZpoolCapacityEntry, checked: boolean) => void;
 }
 
 const PoolsTable = ({
@@ -38,6 +41,8 @@ const PoolsTable = ({
   onEdit,
   onDelete,
   isDeleteDisabled,
+  selectedPools,
+  onToggleSelect,
 }: PoolsTableProps) => (
   <TableContainer
     component={Paper}
@@ -64,6 +69,7 @@ const PoolsTable = ({
             },
           }}
         >
+          <TableCell padding="checkbox" sx={{ width: 52 }} />
           <TableCell align="left">نام Pool</TableCell>
           <TableCell align="left">ظرفیت کل</TableCell>
           <TableCell align="center">حجم مصرف‌شده</TableCell>
@@ -75,7 +81,7 @@ const PoolsTable = ({
       <TableBody>
         {isLoading && (
           <TableRow>
-            <TableCell colSpan={9} align="center" sx={{ py: 6 }}>
+            <TableCell colSpan={7} align="center" sx={{ py: 6 }}>
               <Box
                 sx={{
                   display: 'flex',
@@ -95,7 +101,7 @@ const PoolsTable = ({
 
         {error && !isLoading && (
           <TableRow>
-            <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
+            <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
               <Typography sx={{ color: 'var(--color-error)' }}>
                 خطا در دریافت اطلاعات Pool ها: {error.message}
               </Typography>
@@ -105,7 +111,7 @@ const PoolsTable = ({
 
         {!isLoading && !error && pools.length === 0 && (
           <TableRow>
-            <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
+            <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
               <Typography sx={{ color: 'var(--color-secondary)' }}>
                 هیچ Pool فعالی برای نمایش وجود ندارد.
               </Typography>
@@ -134,6 +140,14 @@ const PoolsTable = ({
                 },
               }}
             >
+              <TableCell padding="checkbox" align="center">
+                <Checkbox
+                  checked={selectedPools.includes(pool.name)}
+                  onChange={(event) => onToggleSelect(pool, event.target.checked)}
+                  color="primary"
+                  inputProps={{ 'aria-label': `انتخاب ${pool.name}` }}
+                />
+              </TableCell>
               <TableCell align="left">
                 <Typography
                   sx={{ fontWeight: 700, color: 'var(--color-text)' }}

--- a/src/components/integrated-storage/SelectedPoolsDetailsPanel.tsx
+++ b/src/components/integrated-storage/SelectedPoolsDetailsPanel.tsx
@@ -1,0 +1,194 @@
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import { MdClose } from 'react-icons/md';
+import type { ZpoolDetailEntry } from '../../@types/zpool';
+
+interface PoolDetailItem {
+  poolName: string;
+  detail: ZpoolDetailEntry | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+interface SelectedPoolsDetailsPanelProps {
+  items: PoolDetailItem[];
+  onRemove: (poolName: string) => void;
+}
+
+const formatDetailValue = (value: unknown): string => {
+  if (value == null) {
+    return '-';
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Intl.NumberFormat('fa-IR').format(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => formatDetailValue(item)).join(', ');
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+};
+
+const SelectedPoolsDetailsPanel = ({
+  items,
+  onRemove,
+}: SelectedPoolsDetailsPanelProps) => {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        mt: 3,
+        borderRadius: 3,
+        border: '1px solid var(--color-input-border)',
+        backgroundColor: 'var(--color-card-bg)',
+        boxShadow: '0 20px 45px -25px rgba(0, 0, 0, 0.35)',
+        p: 3,
+      }}
+    >
+      <Typography
+        variant="h6"
+        sx={{
+          mb: 3,
+          fontWeight: 700,
+          color: 'var(--color-primary)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        مقایسه جزئیات Pool ها
+      </Typography>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2.5,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+        }}
+      >
+        {items.map(({ poolName, detail, isLoading, error }) => {
+          const entries = detail ? Object.entries(detail) : [];
+
+          return (
+            <Box
+              key={poolName}
+              sx={{
+                borderRadius: 2,
+                border: '1px solid var(--color-input-border)',
+                backgroundColor: 'rgba(0, 198, 169, 0.05)',
+                p: 2.5,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1.5,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    color: 'var(--color-text)',
+                    fontSize: '1rem',
+                  }}
+                >
+                  {poolName}
+                </Typography>
+
+                <IconButton
+                  aria-label={`حذف ${poolName} از مقایسه`}
+                  size="small"
+                  onClick={() => onRemove(poolName)}
+                  sx={{ color: 'var(--color-secondary)' }}
+                >
+                  <MdClose size={18} />
+                </IconButton>
+              </Box>
+
+              {isLoading && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    py: 3,
+                  }}
+                >
+                  <CircularProgress size={28} color="primary" />
+                </Box>
+              )}
+
+              {error && !isLoading && (
+                <Typography sx={{ color: 'var(--color-error)' }}>
+                  خطا در دریافت اطلاعات این Pool: {error.message}
+                </Typography>
+              )}
+
+              {!isLoading && !error && entries.length === 0 && (
+                <Typography sx={{ color: 'var(--color-secondary)' }}>
+                  اطلاعاتی برای نمایش وجود ندارد.
+                </Typography>
+              )}
+
+              {!isLoading && !error && entries.length > 0 && (
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gap: 1.5,
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
+                  }}
+                >
+                  {entries.map(([key, value]) => (
+                    <Box
+                      key={key}
+                      sx={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 0.5,
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        sx={{ color: 'var(--color-secondary)', fontWeight: 600 }}
+                      >
+                        {key}
+                      </Typography>
+                      <Typography sx={{ color: 'var(--color-text)', fontWeight: 500 }}>
+                        {formatDetailValue(value)}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default SelectedPoolsDetailsPanel;
+

--- a/src/hooks/useZpoolDetails.ts
+++ b/src/hooks/useZpoolDetails.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ZpoolDetailEntry, ZpoolDetailResponse } from '../@types/zpool';
+import axiosInstance from '../lib/axiosInstance';
+
+export const zpoolDetailQueryKey = (poolName: string) => [
+  'zpool',
+  poolName,
+  'details',
+];
+
+export const fetchZpoolDetails = async (
+  poolName: string
+): Promise<ZpoolDetailEntry | null> => {
+  const endpoint = `/api/zpool/${encodeURIComponent(poolName)}/`;
+  const { data } = await axiosInstance.get<ZpoolDetailResponse>(endpoint);
+
+  if (!data || !Array.isArray(data.data)) {
+    return null;
+  }
+
+  const firstValidEntry = data.data.find(
+    (entry): entry is ZpoolDetailEntry => entry != null && typeof entry === 'object'
+  );
+
+  if (!firstValidEntry) {
+    return null;
+  }
+
+  const normalizedEntry: ZpoolDetailEntry = {
+    ...firstValidEntry,
+  };
+
+  const entryName = normalizedEntry.name;
+
+  if (typeof entryName !== 'string' || entryName.trim().length === 0) {
+    normalizedEntry.name = poolName;
+  }
+
+  return normalizedEntry;
+};
+
+interface UseZpoolDetailsOptions {
+  enabled?: boolean;
+}
+
+export const useZpoolDetails = (
+  poolName: string,
+  options?: UseZpoolDetailsOptions
+) => {
+  return useQuery<ZpoolDetailEntry | null, Error>({
+    queryKey: zpoolDetailQueryKey(poolName),
+    queryFn: () => fetchZpoolDetails(poolName),
+    enabled: options?.enabled ?? true,
+    staleTime: 15000,
+    refetchInterval: options?.enabled ? 15000 : undefined,
+  });
+};
+


### PR DESCRIPTION
## Summary
- add selection checkboxes to the integrated storage pool table so users can pick pools to compare
- fetch detailed zpool data for the selected pools and render a comparison panel that supports up to three pools
- add typings and hooks for the per-pool zpool API response and surface helpful error messaging

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components violations in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d7c7889480832fa44733da12cf3527