### PR TITLE
Refine pool comparison panel styling

### DIFF
--- a/src/@types/zpool.ts
+++ b/src/@types/zpool.ts
@@ -21,3 +21,11 @@ export interface ZpoolQueryResult {
   pools: ZpoolCapacityEntry[];
   failedPools: string[];
 }
+
+export interface ZpoolDetailEntry {
+  [key: string]: unknown;
+}
+
+export interface ZpoolDetailResponse {
+  data?: ZpoolDetailEntry[];
+}

--- a/src/components/integrated-storage/PoolsTable.tsx
+++ b/src/components/integrated-storage/PoolsTable.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Checkbox,
   Chip,
   CircularProgress,
   IconButton,
@@ -29,6 +30,8 @@ interface PoolsTableProps {
   onEdit: (pool: ZpoolCapacityEntry) => void;
   onDelete: (pool: ZpoolCapacityEntry) => void;
   isDeleteDisabled: boolean;
+  selectedPools: string[];
+  onToggleSelect: (pool: ZpoolCapacityEntry, checked: boolean) => void;
 }
 
 const PoolsTable = ({
@@ -38,6 +41,8 @@ const PoolsTable = ({
   onEdit,
   onDelete,
   isDeleteDisabled,
+  selectedPools,
+  onToggleSelect,
 }: PoolsTableProps) => (
   <TableContainer
     component={Paper}
@@ -64,6 +69,7 @@ const PoolsTable = ({
             },
           }}
         >
+          <TableCell padding="checkbox" sx={{ width: 52 }} />
           <TableCell align="left">نام Pool</TableCell>
           <TableCell align="left">ظرفیت کل</TableCell>
           <TableCell align="center">حجم مصرف‌شده</TableCell>
@@ -75,7 +81,7 @@ const PoolsTable = ({
       <TableBody>
         {isLoading && (
           <TableRow>
-            <TableCell colSpan={9} align="center" sx={{ py: 6 }}>
+            <TableCell colSpan={7} align="center" sx={{ py: 6 }}>
               <Box
                 sx={{
                   display: 'flex',
@@ -95,7 +101,7 @@ const PoolsTable = ({
 
         {error && !isLoading && (
           <TableRow>
-            <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
+            <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
               <Typography sx={{ color: 'var(--color-error)' }}>
                 خطا در دریافت اطلاعات Pool ها: {error.message}
               </Typography>
@@ -105,7 +111,7 @@ const PoolsTable = ({
 
         {!isLoading && !error && pools.length === 0 && (
           <TableRow>
-            <TableCell colSpan={9} align="center" sx={{ py: 4 }}>
+            <TableCell colSpan={7} align="center" sx={{ py: 4 }}>
               <Typography sx={{ color: 'var(--color-secondary)' }}>
                 هیچ Pool فعالی برای نمایش وجود ندارد.
               </Typography>
@@ -134,6 +140,14 @@ const PoolsTable = ({
                 },
               }}
             >
+              <TableCell padding="checkbox" align="center">
+                <Checkbox
+                  checked={selectedPools.includes(pool.name)}
+                  onChange={(event) => onToggleSelect(pool, event.target.checked)}
+                  color="primary"
+                  inputProps={{ 'aria-label': `انتخاب ${pool.name}` }}
+                />
+              </TableCell>
               <TableCell align="left">
                 <Typography
                   sx={{ fontWeight: 700, color: 'var(--color-text)' }}

--- a/src/components/integrated-storage/SelectedPoolsDetailsPanel.tsx
+++ b/src/components/integrated-storage/SelectedPoolsDetailsPanel.tsx
@@ -1,0 +1,230 @@
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { MdClose } from 'react-icons/md';
+import type { ZpoolDetailEntry } from '../../@types/zpool';
+
+interface PoolDetailItem {
+  poolName: string;
+  detail: ZpoolDetailEntry | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+interface SelectedPoolsDetailsPanelProps {
+  items: PoolDetailItem[];
+  onRemove: (poolName: string) => void;
+}
+
+const formatDetailValue = (value: unknown): string => {
+  if (value == null) {
+    return '-';
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Intl.NumberFormat('fa-IR').format(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => formatDetailValue(item)).join(', ');
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+};
+
+const SelectedPoolsDetailsPanel = ({
+  items,
+  onRemove,
+}: SelectedPoolsDetailsPanelProps) => {
+  const theme = useTheme();
+  const dividerColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.08)'
+      : 'rgba(0, 0, 0, 0.08)';
+  const listBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)';
+
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        mt: 3,
+        borderRadius: 3,
+        border: '1px solid var(--color-input-border)',
+        backgroundColor: 'var(--color-card-bg)',
+        boxShadow: '0 20px 45px -25px rgba(0, 0, 0, 0.35)',
+        p: 3,
+      }}
+    >
+      <Typography
+        variant="h6"
+        sx={{
+          mb: 3,
+          fontWeight: 700,
+          color: 'var(--color-primary)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        مقایسه جزئیات Pool ها
+      </Typography>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2.5,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+        }}
+      >
+        {items.map(({ poolName, detail, isLoading, error }) => {
+          const entries = detail ? Object.entries(detail) : [];
+
+          return (
+            <Box
+              key={poolName}
+              sx={{
+                borderRadius: 2,
+                border: `1px solid ${dividerColor}`,
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(0, 0, 0, 0.35)'
+                    : 'rgba(255, 255, 255, 0.9)',
+                p: 2.5,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1.5,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    color: 'var(--color-text)',
+                    fontSize: '1rem',
+                  }}
+                >
+                  {poolName}
+                </Typography>
+
+                <IconButton
+                  aria-label={`حذف ${poolName} از مقایسه`}
+                  size="small"
+                  onClick={() => onRemove(poolName)}
+                  sx={{ color: 'var(--color-secondary)' }}
+                >
+                  <MdClose size={18} />
+                </IconButton>
+              </Box>
+
+              {isLoading && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    py: 3,
+                  }}
+                >
+                  <CircularProgress size={28} color="primary" />
+                </Box>
+              )}
+
+              {error && !isLoading && (
+                <Typography sx={{ color: 'var(--color-error)' }}>
+                  خطا در دریافت اطلاعات این Pool: {error.message}
+                </Typography>
+              )}
+
+              {!isLoading && !error && entries.length === 0 && (
+                <Typography sx={{ color: 'var(--color-secondary)' }}>
+                  اطلاعاتی برای نمایش وجود ندارد.
+                </Typography>
+              )}
+
+              {!isLoading && !error && entries.length > 0 && (
+                <Box
+                  sx={{
+                    width: '100%',
+                    bgcolor: listBackground,
+                    borderRadius: 2,
+                    px: 2,
+                    py: 2,
+                    border: `1px solid ${dividerColor}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                  }}
+                >
+                  {entries.map(([key, value], index) => (
+                    <Box
+                      key={key}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                        py: 0.75,
+                        borderBottom:
+                          index === entries.length - 1
+                            ? 'none'
+                            : `1px dashed ${dividerColor}`,
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        sx={{ fontWeight: 500, color: theme.palette.text.secondary }}
+                      >
+                        {key}
+                      </Typography>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          fontWeight: 700,
+                          color: 'var(--color-primary)',
+                          textAlign: 'left',
+                          direction: 'ltr',
+                          wordBreak: 'break-word',
+                          whiteSpace: 'pre-wrap',
+                        }}
+                      >
+                        {formatDetailValue(value)}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default SelectedPoolsDetailsPanel;
+

--- a/src/hooks/useZpoolDetails.ts
+++ b/src/hooks/useZpoolDetails.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ZpoolDetailEntry, ZpoolDetailResponse } from '../@types/zpool';
+import axiosInstance from '../lib/axiosInstance';
+
+export const zpoolDetailQueryKey = (poolName: string) => [
+  'zpool',
+  poolName,
+  'details',
+];
+
+export const fetchZpoolDetails = async (
+  poolName: string
+): Promise<ZpoolDetailEntry | null> => {
+  const endpoint = `/api/zpool/${encodeURIComponent(poolName)}/`;
+  const { data } = await axiosInstance.get<ZpoolDetailResponse>(endpoint);
+
+  if (!data || !Array.isArray(data.data)) {
+    return null;
+  }
+
+  const firstValidEntry = data.data.find(
+    (entry): entry is ZpoolDetailEntry => entry != null && typeof entry === 'object'
+  );
+
+  if (!firstValidEntry) {
+    return null;
+  }
+
+  const normalizedEntry: ZpoolDetailEntry = {
+    ...firstValidEntry,
+  };
+
+  const entryName = normalizedEntry.name;
+
+  if (typeof entryName !== 'string' || entryName.trim().length === 0) {
+    normalizedEntry.name = poolName;
+  }
+
+  return normalizedEntry;
+};
+
+interface UseZpoolDetailsOptions {
+  enabled?: boolean;
+}
+
+export const useZpoolDetails = (
+  poolName: string,
+  options?: UseZpoolDetailsOptions
+) => {
+  return useQuery<ZpoolDetailEntry | null, Error>({
+    queryKey: zpoolDetailQueryKey(poolName),
+    queryFn: () => fetchZpoolDetails(poolName),
+    enabled: options?.enabled ?? true,
+    staleTime: 15000,
+    refetchInterval: options?.enabled ? 15000 : undefined,
+  });
+};
+


### PR DESCRIPTION
## Summary
- restyle the selected pool comparison panel to mirror the stat lists used in the CPU/Memory widgets
- apply theme-aware divider and background colors so pool details are easier to read across themes

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components violations in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d7c7889480832fa44733da12cf3527