### PR TITLE
Add block storage volume management page

### DIFF
--- a/src/@types/volume.ts
+++ b/src/@types/volume.ts
@@ -1,0 +1,29 @@
+export interface VolumeApiResponse {
+  data?: Record<string, VolumeRawEntry>;
+  [key: string]: unknown;
+}
+
+export type VolumeRawEntry = Record<string, unknown>;
+
+export interface VolumeAttribute {
+  key: string;
+  value: string;
+}
+
+export interface VolumeEntry {
+  id: string;
+  fullName: string;
+  poolName: string;
+  volumeName: string;
+  attributes: VolumeAttribute[];
+  raw: VolumeRawEntry;
+}
+
+export interface VolumeGroup {
+  poolName: string;
+  volumes: VolumeEntry[];
+}
+
+export interface VolumeQueryResult {
+  volumes: VolumeEntry[];
+}

--- a/src/components/block-storage/ConfirmDeleteVolumeModal.tsx
+++ b/src/components/block-storage/ConfirmDeleteVolumeModal.tsx
@@ -1,0 +1,73 @@
+import { Box, Button, Typography } from '@mui/material';
+import type { UseDeleteVolumeReturn } from '../../hooks/useDeleteVolume';
+import BlurModal from '../BlurModal';
+
+interface ConfirmDeleteVolumeModalProps {
+  controller: UseDeleteVolumeReturn;
+}
+
+const buttonStyles = {
+  borderRadius: '10px',
+  fontWeight: 600,
+};
+
+const ConfirmDeleteVolumeModal = ({
+  controller,
+}: ConfirmDeleteVolumeModalProps) => {
+  const {
+    isOpen,
+    targetVolume,
+    closeModal,
+    confirmDelete,
+    isDeleting,
+    errorMessage,
+  } = controller;
+
+  return (
+    <BlurModal
+      open={isOpen}
+      onClose={closeModal}
+      title="حذف Volume"
+      actions={
+        <>
+          <Button
+            onClick={closeModal}
+            color="inherit"
+            variant="outlined"
+            disabled={isDeleting}
+            sx={buttonStyles}
+          >
+            انصراف
+          </Button>
+          <Button
+            onClick={confirmDelete}
+            variant="contained"
+            color="error"
+            disabled={isDeleting}
+            sx={buttonStyles}
+          >
+            {isDeleting ? 'در حال حذف…' : 'حذف'}
+          </Button>
+        </>
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography sx={{ color: 'var(--color-text)' }}>
+          آیا از حذف Volume{' '}
+          <Typography component="span" sx={{ fontWeight: 700 }}>
+            {targetVolume?.fullName}
+          </Typography>{' '}
+          مطمئن هستید؟ این عملیات قابل بازگشت نیست.
+        </Typography>
+
+        {errorMessage && (
+          <Typography sx={{ color: 'var(--color-error)', fontWeight: 600 }}>
+            {errorMessage}
+          </Typography>
+        )}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default ConfirmDeleteVolumeModal;

--- a/src/components/block-storage/CreateVolumeModal.tsx
+++ b/src/components/block-storage/CreateVolumeModal.tsx
@@ -1,0 +1,220 @@
+import {
+  Box,
+  Button,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import type { ChangeEvent } from 'react';
+import type { UseCreateVolumeReturn } from '../../hooks/useCreateVolume';
+import BlurModal from '../BlurModal';
+
+interface CreateVolumeModalProps {
+  controller: UseCreateVolumeReturn;
+  poolOptions: string[];
+}
+
+const buttonBaseStyles = {
+  borderRadius: '10px',
+  fontWeight: 600,
+};
+
+const inputBaseStyles = {
+  backgroundColor: 'var(--color-input-bg)',
+  borderRadius: '10px',
+  color: 'var(--color-text)',
+  '& fieldset': {
+    borderColor: 'var(--color-input-border)',
+  },
+  '&:hover fieldset': {
+    borderColor: 'var(--color-input-focus-border)',
+  },
+  '&.Mui-focused fieldset': {
+    borderColor: 'var(--color-input-focus-border)',
+  },
+};
+
+const CreateVolumeModal = ({ controller, poolOptions }: CreateVolumeModalProps) => {
+  const {
+    isOpen,
+    closeCreateModal,
+    handleSubmit,
+    selectedPool,
+    setSelectedPool,
+    poolError,
+    volumeName,
+    setVolumeName,
+    nameError,
+    sizeValue,
+    setSizeValue,
+    sizeUnit,
+    setSizeUnit,
+    sizeError,
+    apiError,
+    isCreating,
+  } = controller;
+
+  const handlePoolChange = (event: SelectChangeEvent<string>) => {
+    setSelectedPool(event.target.value);
+  };
+
+  const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setVolumeName(event.target.value);
+  };
+
+  const handleSizeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSizeValue(event.target.value.replace(/[^\d.]/g, ''));
+  };
+
+  const handleUnitChange = (event: SelectChangeEvent<'GB' | 'TB'>) => {
+    setSizeUnit(event.target.value as 'GB' | 'TB');
+  };
+
+  return (
+    <BlurModal
+      open={isOpen}
+      onClose={closeCreateModal}
+      title="ایجاد Volume جدید"
+      actions={
+        <>
+          <Button
+            onClick={closeCreateModal}
+            variant="outlined"
+            color="inherit"
+            disabled={isCreating}
+            sx={{ ...buttonBaseStyles, px: 3 }}
+          >
+            انصراف
+          </Button>
+          <Button
+            type="submit"
+            form="create-volume-form"
+            variant="contained"
+            disabled={isCreating}
+            sx={{
+              ...buttonBaseStyles,
+              px: 4,
+              background:
+                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+              boxShadow: '0 14px 28px -18px rgba(0, 198, 169, 0.8)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+              },
+            }}
+          >
+            {isCreating ? 'در حال ایجاد…' : 'ایجاد'}
+          </Button>
+        </>
+      }
+    >
+      <Box component="form" id="create-volume-form" onSubmit={handleSubmit}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <FormControl fullWidth error={Boolean(poolError)}>
+            <InputLabel id="volume-pool-select" sx={{ color: 'var(--color-text)' }}>
+              انتخاب Pool
+            </InputLabel>
+            <Select
+              labelId="volume-pool-select"
+              label="انتخاب Pool"
+              value={selectedPool}
+              onChange={handlePoolChange}
+              sx={inputBaseStyles}
+              MenuProps={{
+                PaperProps: {
+                  sx: {
+                    backgroundColor: 'var(--color-card-bg)',
+                    color: 'var(--color-text)',
+                  },
+                },
+              }}
+            >
+              {poolOptions.length === 0 && (
+                <MenuItem value="" disabled>
+                  Poolی برای ایجاد Volume موجود نیست.
+                </MenuItem>
+              )}
+              {poolOptions.map((pool) => (
+                <MenuItem key={pool} value={pool}>
+                  {pool}
+                </MenuItem>
+              ))}
+            </Select>
+            {poolError && <FormHelperText>{poolError}</FormHelperText>}
+          </FormControl>
+
+          <TextField
+            label="نام Volume"
+            value={volumeName}
+            onChange={handleNameChange}
+            fullWidth
+            autoComplete="off"
+            error={Boolean(nameError)}
+            helperText={nameError ?? 'نامی یکتا برای Volume وارد کنید.'}
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ sx: inputBaseStyles }}
+          />
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: '2fr 1fr' },
+              gap: 2,
+              alignItems: 'center',
+            }}
+          >
+            <TextField
+              label="حجم"
+              value={sizeValue}
+              onChange={handleSizeChange}
+              fullWidth
+              type="text"
+              inputMode="decimal"
+              error={Boolean(sizeError)}
+              helperText={sizeError ?? 'مقدار حجم را وارد کنید.'}
+              InputLabelProps={{ shrink: true }}
+              InputProps={{ sx: inputBaseStyles }}
+            />
+
+            <FormControl fullWidth>
+              <InputLabel id="volume-size-unit" sx={{ color: 'var(--color-text)' }}>
+                واحد
+              </InputLabel>
+              <Select
+                labelId="volume-size-unit"
+                label="واحد"
+                value={sizeUnit}
+                onChange={handleUnitChange}
+                sx={inputBaseStyles}
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      backgroundColor: 'var(--color-card-bg)',
+                      color: 'var(--color-text)',
+                    },
+                  },
+                }}
+              >
+                <MenuItem value="GB">GB</MenuItem>
+                <MenuItem value="TB">TB</MenuItem>
+              </Select>
+            </FormControl>
+          </Box>
+
+          {apiError && (
+            <Typography sx={{ color: 'var(--color-error)', fontWeight: 600 }}>
+              {apiError}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default CreateVolumeModal;

--- a/src/components/block-storage/VolumesTable.tsx
+++ b/src/components/block-storage/VolumesTable.tsx
@@ -1,0 +1,171 @@
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { MdDeleteOutline } from 'react-icons/md';
+import type { VolumeEntry, VolumeGroup } from '../../@types/volume';
+import type { DataTableColumn } from '../DataTable';
+import DataTable from '../DataTable';
+
+interface VolumesTableProps {
+  groups: VolumeGroup[];
+  isLoading: boolean;
+  error: Error | null;
+  onDeleteVolume: (volume: VolumeEntry) => void;
+  isDeleteDisabled: boolean;
+}
+
+const attributeKeyStyles = {
+  color: 'var(--color-secondary)',
+  fontSize: '0.85rem',
+};
+
+const attributeValueStyles = {
+  color: 'var(--color-text)',
+  fontWeight: 600,
+};
+
+const cardStyles = {
+  border: '1px solid var(--color-input-border)',
+  borderRadius: '12px',
+  padding: 2,
+  backgroundColor: 'rgba(0, 198, 169, 0.05)',
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: 1.5,
+};
+
+const VolumesTable = ({
+  groups,
+  isLoading,
+  error,
+  onDeleteVolume,
+  isDeleteDisabled,
+}: VolumesTableProps) => {
+  const columns: DataTableColumn<VolumeGroup>[] = [
+    {
+      id: 'pool',
+      header: 'نام Pool',
+      align: 'left',
+      width: '25%',
+      renderCell: (group) => (
+        <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+          {group.poolName}
+        </Typography>
+      ),
+    },
+    {
+      id: 'volumes',
+      header: 'Volume ها',
+      align: 'left',
+      renderCell: (group) => (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {group.volumes.length === 0 && (
+            <Typography sx={{ color: 'var(--color-secondary)' }}>
+              برای این Pool حجمی ثبت نشده است.
+            </Typography>
+          )}
+
+          {group.volumes.map((volume) => (
+            <Box key={volume.id} sx={cardStyles}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: { xs: 'column', sm: 'row' },
+                  gap: 1,
+                  alignItems: { xs: 'flex-start', sm: 'center' },
+                  justifyContent: 'space-between',
+                }}
+              >
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                  <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+                    {volume.volumeName}
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
+                    {volume.fullName}
+                  </Typography>
+                </Box>
+                <Tooltip title="حذف Volume">
+                  <span>
+                    <IconButton
+                      color="error"
+                      size="small"
+                      onClick={() => onDeleteVolume(volume)}
+                      disabled={isDeleteDisabled}
+                    >
+                      <MdDeleteOutline size={18} />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Box>
+
+              {volume.attributes.length > 0 ? (
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: {
+                      xs: 'repeat(1, minmax(0, 1fr))',
+                      md: 'repeat(auto-fit, minmax(180px, 1fr))',
+                    },
+                    gap: 1.5,
+                  }}
+                >
+                  {volume.attributes.map((attribute) => (
+                    <Box key={`${volume.id}-${attribute.key}`} sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                      <Typography sx={attributeKeyStyles}>{attribute.key}</Typography>
+                      <Typography sx={attributeValueStyles}>{attribute.value}</Typography>
+                    </Box>
+                  ))}
+                </Box>
+              ) : (
+                <Typography sx={{ color: 'var(--color-secondary)' }}>
+                  اطلاعاتی برای این Volume ثبت نشده است.
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Box>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable<VolumeGroup>
+      columns={columns}
+      data={groups}
+      getRowId={(group) => group.poolName}
+      isLoading={isLoading}
+      error={error}
+      renderLoadingState={() => (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            alignItems: 'center',
+          }}
+        >
+          <CircularProgress color="primary" size={32} />
+          <Typography sx={{ color: 'var(--color-secondary)' }}>
+            در حال دریافت اطلاعات Volume ها...
+          </Typography>
+        </Box>
+      )}
+      renderErrorState={(tableError) => (
+        <Typography sx={{ color: 'var(--color-error)' }}>
+          خطا در دریافت اطلاعات Volume ها: {tableError.message}
+        </Typography>
+      )}
+      renderEmptyState={() => (
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          هیچ Volumeی برای نمایش وجود ندارد.
+        </Typography>
+      )}
+    />
+  );
+};
+
+export default VolumesTable;

--- a/src/hooks/useCreateVolume.ts
+++ b/src/hooks/useCreateVolume.ts
@@ -1,0 +1,186 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { FormEvent } from 'react';
+import { useCallback, useState } from 'react';
+import axiosInstance from '../lib/axiosInstance';
+
+interface ApiErrorResponse {
+  detail?: string;
+  message?: string;
+  errors?: string | string[];
+  [key: string]: unknown;
+}
+
+interface CreateVolumePayload {
+  volume_name: string;
+  volsize: string;
+}
+
+interface UseCreateVolumeOptions {
+  onSuccess?: (volumeName: string) => void;
+  onError?: (errorMessage: string) => void;
+}
+
+const extractApiMessage = (error: AxiosError<ApiErrorResponse>) => {
+  const payload = error.response?.data;
+
+  if (!payload) {
+    return error.message;
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload.detail && typeof payload.detail === 'string') {
+    return payload.detail;
+  }
+
+  if (payload.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  if (payload.errors) {
+    if (Array.isArray(payload.errors)) {
+      return payload.errors.join('، ');
+    }
+
+    if (typeof payload.errors === 'string') {
+      return payload.errors;
+    }
+  }
+
+  return error.message;
+};
+
+export const useCreateVolume = ({
+  onSuccess,
+  onError,
+}: UseCreateVolumeOptions = {}) => {
+  const queryClient = useQueryClient();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedPool, setSelectedPool] = useState('');
+  const [volumeName, setVolumeName] = useState('');
+  const [sizeValue, setSizeValue] = useState('');
+  const [sizeUnit, setSizeUnit] = useState<'GB' | 'TB'>('GB');
+  const [poolError, setPoolError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [sizeError, setSizeError] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setSelectedPool('');
+    setVolumeName('');
+    setSizeValue('');
+    setSizeUnit('GB');
+    setPoolError(null);
+    setNameError(null);
+    setSizeError(null);
+    setApiError(null);
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    resetForm();
+    setIsOpen(true);
+  }, [resetForm]);
+
+  const handleClose = useCallback(() => {
+    resetForm();
+    setIsOpen(false);
+  }, [resetForm]);
+
+  const createVolumeMutation = useMutation<
+    unknown,
+    AxiosError<ApiErrorResponse>,
+    CreateVolumePayload
+  >({
+    mutationFn: async (payload) => {
+      await axiosInstance.post('/api/volume/create', payload);
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['volumes'] });
+      handleClose();
+      onSuccess?.(variables.volume_name);
+    },
+    onError: (error) => {
+      const message = extractApiMessage(error);
+      setApiError(message);
+      onError?.(message);
+    },
+  });
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setPoolError(null);
+      setNameError(null);
+      setSizeError(null);
+      setApiError(null);
+
+      const trimmedPool = selectedPool.trim();
+      const trimmedName = volumeName.trim();
+      const trimmedSize = sizeValue.trim();
+
+      let hasError = false;
+
+      if (!trimmedPool) {
+        setPoolError('لطفاً Pool مقصد را انتخاب کنید.');
+        hasError = true;
+      }
+
+      if (!trimmedName) {
+        setNameError('نام Volume را وارد کنید.');
+        hasError = true;
+      }
+
+      if (!trimmedSize) {
+        setSizeError('حجم Volume را مشخص کنید.');
+        hasError = true;
+      } else {
+        const numericSize = Number(trimmedSize);
+        if (!Number.isFinite(numericSize) || numericSize <= 0) {
+          setSizeError('مقدار حجم باید عددی بزرگ‌تر از صفر باشد.');
+          hasError = true;
+        }
+      }
+
+      if (hasError) {
+        return;
+      }
+
+      const sizeSuffix = sizeUnit === 'GB' ? 'G' : 'T';
+      const payload: CreateVolumePayload = {
+        volume_name: `${trimmedPool}/${trimmedName}`.replace(/\s+/g, ''),
+        volsize: `${trimmedSize}${sizeSuffix}`.replace(/\s+/g, ''),
+      };
+
+      createVolumeMutation.mutate(payload);
+    },
+    [createVolumeMutation, selectedPool, sizeUnit, sizeValue, volumeName]
+  );
+
+  return {
+    isOpen,
+    selectedPool,
+    setSelectedPool,
+    volumeName,
+    setVolumeName,
+    sizeValue,
+    setSizeValue,
+    sizeUnit,
+    setSizeUnit,
+    poolError,
+    nameError,
+    sizeError,
+    apiError,
+    isCreating: createVolumeMutation.isPending,
+    openCreateModal: handleOpen,
+    closeCreateModal: () => {
+      createVolumeMutation.reset();
+      handleClose();
+    },
+    handleSubmit,
+  };
+};
+
+export type UseCreateVolumeReturn = ReturnType<typeof useCreateVolume>;

--- a/src/hooks/useDeleteVolume.ts
+++ b/src/hooks/useDeleteVolume.ts
@@ -1,0 +1,112 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import type { VolumeEntry, VolumeQueryResult } from '../@types/volume';
+import axiosInstance from '../lib/axiosInstance';
+
+interface DeleteVolumePayload {
+  volume_name: string;
+}
+
+interface DeleteVolumeResponse {
+  detail?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+const deleteVolumeRequest = async ({
+  volume_name,
+}: DeleteVolumePayload): Promise<DeleteVolumeResponse> => {
+  const response = await axiosInstance.delete<DeleteVolumeResponse>(
+    '/api/volume/delete',
+    {
+      data: { volume_name },
+    }
+  );
+
+  return response.data;
+};
+
+interface UseDeleteVolumeOptions {
+  onSuccess?: (volumeName: string) => void;
+  onError?: (error: Error, volumeName: string) => void;
+}
+
+export const useDeleteVolume = ({
+  onSuccess,
+  onError,
+}: UseDeleteVolumeOptions = {}) => {
+  const queryClient = useQueryClient();
+  const [targetVolume, setTargetVolume] = useState<VolumeEntry | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const deleteMutation = useMutation<
+    DeleteVolumeResponse,
+    Error,
+    DeleteVolumePayload
+  >({
+    mutationFn: deleteVolumeRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.setQueryData<VolumeQueryResult | undefined>(
+        ['volumes'],
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          return {
+            ...current,
+            volumes: current.volumes.filter(
+              (volume) => volume.fullName !== variables.volume_name
+            ),
+          };
+        }
+      );
+
+      queryClient.invalidateQueries({ queryKey: ['volumes'] });
+    },
+  });
+
+  const requestDelete = useCallback((volume: VolumeEntry) => {
+    setErrorMessage(null);
+    setTargetVolume(volume);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setTargetVolume(null);
+    setErrorMessage(null);
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (!targetVolume || deleteMutation.isPending) {
+      return;
+    }
+
+    setErrorMessage(null);
+
+    deleteMutation.mutate(
+      { volume_name: targetVolume.fullName },
+      {
+        onSuccess: () => {
+          onSuccess?.(targetVolume.fullName);
+          closeModal();
+        },
+        onError: (error) => {
+          setErrorMessage(error.message);
+          onError?.(error, targetVolume.fullName);
+        },
+      }
+    );
+  }, [closeModal, deleteMutation, onError, onSuccess, targetVolume]);
+
+  return {
+    isOpen: Boolean(targetVolume),
+    targetVolume,
+    requestDelete,
+    closeModal,
+    confirmDelete,
+    isDeleting: deleteMutation.isPending,
+    errorMessage,
+  };
+};
+
+export type UseDeleteVolumeReturn = ReturnType<typeof useDeleteVolume>;

--- a/src/hooks/useVolumes.ts
+++ b/src/hooks/useVolumes.ts
@@ -1,0 +1,103 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '../lib/axiosInstance';
+import type {
+  VolumeApiResponse,
+  VolumeAttribute,
+  VolumeEntry,
+  VolumeQueryResult,
+  VolumeRawEntry,
+} from '../@types/volume';
+
+const VOLUME_LIST_ENDPOINT = '/api/volume/';
+
+const formatAttributeValue = (value: unknown): string => {
+  if (value == null) {
+    return '—';
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '—';
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => formatAttributeValue(item)).join('، ');
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '[object]';
+    }
+  }
+
+  return String(value);
+};
+
+const normalizeRawEntry = (raw: unknown): VolumeRawEntry => {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as VolumeRawEntry;
+  }
+
+  return {};
+};
+
+const createAttributes = (raw: VolumeRawEntry): VolumeAttribute[] =>
+  Object.entries(raw).map(([key, value]) => ({
+    key,
+    value: formatAttributeValue(value),
+  }));
+
+const normalizeVolumeEntry = (
+  fullName: string,
+  raw: unknown
+): VolumeEntry => {
+  const normalizedRaw = normalizeRawEntry(raw);
+  const [poolName, ...rest] = fullName.split('/');
+  const volumeName = rest.length > 0 ? rest.join('/') : fullName;
+
+  return {
+    id: fullName,
+    fullName,
+    poolName: poolName || 'نامشخص',
+    volumeName,
+    attributes: createAttributes(normalizedRaw),
+    raw: normalizedRaw,
+  };
+};
+
+const fetchVolumes = async (): Promise<VolumeQueryResult> => {
+  const response = await axiosInstance.post<VolumeApiResponse>(
+    VOLUME_LIST_ENDPOINT
+  );
+
+  const payload = response.data;
+  const rawVolumes = payload?.data ?? {};
+
+  const volumes = Object.entries(rawVolumes)
+    .map(([fullName, raw]) => normalizeVolumeEntry(fullName, raw))
+    .sort((a, b) => {
+      const poolCompare = a.poolName.localeCompare(b.poolName, 'fa');
+      if (poolCompare !== 0) {
+        return poolCompare;
+      }
+
+      return a.volumeName.localeCompare(b.volumeName, 'fa');
+    });
+
+  return { volumes };
+};
+
+export const useVolumes = () =>
+  useQuery<VolumeQueryResult, Error>({
+    queryKey: ['volumes'],
+    queryFn: fetchVolumes,
+    refetchInterval: 15000,
+  });
+
+export type UseVolumesReturn = ReturnType<typeof useVolumes>;

--- a/src/pages/BlockStorage.tsx
+++ b/src/pages/BlockStorage.tsx
@@ -1,11 +1,134 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import { useCallback, useMemo } from 'react';
+import { toast } from 'react-hot-toast';
+import type { VolumeEntry, VolumeGroup } from '../@types/volume';
+import ConfirmDeleteVolumeModal from '../components/block-storage/ConfirmDeleteVolumeModal';
+import CreateVolumeModal from '../components/block-storage/CreateVolumeModal';
+import VolumesTable from '../components/block-storage/VolumesTable';
+import { useCreateVolume } from '../hooks/useCreateVolume';
+import { useDeleteVolume } from '../hooks/useDeleteVolume';
+import { useVolumes } from '../hooks/useVolumes';
+import { useZpool } from '../hooks/useZpool';
 
-const BlockStorage = () => (
-  <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-    <Typography variant="h5" sx={{ color: 'var(--color-primary)' }}>
-      فضای بلاکی
-    </Typography>
-  </Box>
-);
+const BlockStorage = () => {
+  const createVolume = useCreateVolume({
+    onSuccess: (volumeName) => {
+      toast.success(`Volume ${volumeName} با موفقیت ایجاد شد.`);
+    },
+    onError: (errorMessage) => {
+      toast.error(`ایجاد Volume با خطا مواجه شد: ${errorMessage}`);
+    },
+  });
+
+  const volumeDeletion = useDeleteVolume({
+    onSuccess: (volumeName) => {
+      toast.success(`Volume ${volumeName} با موفقیت حذف شد.`);
+    },
+    onError: (error, volumeName) => {
+      toast.error(`حذف Volume ${volumeName} با خطا مواجه شد: ${error.message}`);
+    },
+  });
+
+  const { data: volumeData, isLoading, error } = useVolumes();
+  const { data: poolData } = useZpool();
+
+  const poolOptions = useMemo(
+    () =>
+      (poolData?.pools ?? [])
+        .map((pool) => pool.name)
+        .sort((a, b) => a.localeCompare(b, 'fa')),
+    [poolData?.pools]
+  );
+
+  const volumeGroups = useMemo<VolumeGroup[]>(() => {
+    const groups = new Map<string, VolumeEntry[]>();
+
+    poolOptions.forEach((poolName) => {
+      groups.set(poolName, []);
+    });
+
+    (volumeData?.volumes ?? []).forEach((volume) => {
+      const existing = groups.get(volume.poolName) ?? [];
+      existing.push(volume);
+      groups.set(volume.poolName, existing);
+    });
+
+    return Array.from(groups.entries())
+      .map(([poolName, volumes]) => ({
+        poolName,
+        volumes: volumes.sort((a, b) => a.volumeName.localeCompare(b.volumeName, 'fa')),
+      }))
+      .sort((a, b) => a.poolName.localeCompare(b.poolName, 'fa'));
+  }, [poolOptions, volumeData?.volumes]);
+
+  const handleOpenCreate = useCallback(() => {
+    createVolume.openCreateModal();
+  }, [createVolume]);
+
+  const handleDeleteRequest = useCallback(
+    (volume: VolumeEntry) => {
+      volumeDeletion.requestDelete(volume);
+    },
+    [volumeDeletion]
+  );
+
+  return (
+    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Typography
+            variant="h5"
+            sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+          >
+            فضای بلاکی
+          </Typography>
+
+          <Button
+            onClick={handleOpenCreate}
+            variant="contained"
+            sx={{
+              px: 3,
+              py: 1.25,
+              borderRadius: '3px',
+              fontWeight: 700,
+              fontSize: '0.95rem',
+              background:
+                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+              color: 'var(--color-bg)',
+              boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+                boxShadow: '0 18px 36px -18px rgba(0, 198, 169, 0.75)',
+              },
+            }}
+          >
+            ایجاد Volume
+          </Button>
+        </Box>
+      </Box>
+
+      <CreateVolumeModal controller={createVolume} poolOptions={poolOptions} />
+
+      <VolumesTable
+        groups={volumeGroups}
+        isLoading={isLoading}
+        error={error ?? null}
+        onDeleteVolume={handleDeleteRequest}
+        isDeleteDisabled={volumeDeletion.isDeleting}
+      />
+
+      <ConfirmDeleteVolumeModal controller={volumeDeletion} />
+    </Box>
+  );
+};
 
 export default BlockStorage;


### PR DESCRIPTION
## Summary
- implement the BlockStorage page so volumes are grouped under their pools with toasts and grouped querying
- add hooks and types for listing, creating, and deleting volumes against the volume API endpoints
- build volume table plus creation and deletion modals tailored to the volume data shape

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in src/contexts/AuthContext.tsx and src/contexts/ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d7f7162a18832f80ea22516423933d