### PR TITLE
Refine block storage volume table

### DIFF
--- a/src/components/block-storage/VolumesTable.tsx
+++ b/src/components/block-storage/VolumesTable.tsx
@@ -5,140 +5,150 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { useMemo } from 'react';
 import { MdDeleteOutline } from 'react-icons/md';
-import type { VolumeEntry, VolumeGroup } from '../../@types/volume';
+import type { VolumeEntry } from '../../@types/volume';
 import type { DataTableColumn } from '../DataTable';
 import DataTable from '../DataTable';
 
 interface VolumesTableProps {
-  groups: VolumeGroup[];
+  volumes: VolumeEntry[];
+  attributeKeys: string[];
   isLoading: boolean;
   error: Error | null;
   onDeleteVolume: (volume: VolumeEntry) => void;
   isDeleteDisabled: boolean;
 }
 
-const attributeKeyStyles = {
-  color: 'var(--color-secondary)',
-  fontSize: '0.85rem',
-};
-
-const attributeValueStyles = {
-  color: 'var(--color-text)',
-  fontWeight: 600,
-};
-
-const cardStyles = {
-  border: '1px solid var(--color-input-border)',
-  borderRadius: '12px',
-  padding: 2,
-  backgroundColor: 'rgba(0, 198, 169, 0.05)',
-  display: 'flex',
-  flexDirection: 'column' as const,
-  gap: 1.5,
-};
-
 const VolumesTable = ({
-  groups,
+  volumes,
+  attributeKeys,
   isLoading,
   error,
   onDeleteVolume,
   isDeleteDisabled,
 }: VolumesTableProps) => {
-  const columns: DataTableColumn<VolumeGroup>[] = [
-    {
-      id: 'pool',
-      header: 'نام Pool',
-      align: 'left',
-      width: '25%',
-      renderCell: (group) => (
-        <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
-          {group.poolName}
-        </Typography>
-      ),
-    },
-    {
-      id: 'volumes',
-      header: 'Volume ها',
-      align: 'left',
-      renderCell: (group) => (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {group.volumes.length === 0 && (
-            <Typography sx={{ color: 'var(--color-secondary)' }}>
-              برای این Pool حجمی ثبت نشده است.
+  const poolFirstRowIndex = useMemo(() => {
+    const map = new Map<string, number>();
+
+    volumes.forEach((volume, index) => {
+      if (!map.has(volume.poolName)) {
+        map.set(volume.poolName, index);
+      }
+    });
+
+    return map;
+  }, [volumes]);
+
+  const columns: DataTableColumn<VolumeEntry>[] = useMemo(() => {
+    const baseColumns: DataTableColumn<VolumeEntry>[] = [
+      {
+        id: 'pool',
+        header: 'نام Pool',
+        align: 'left',
+        width: 160,
+        renderCell: (volume, index) => {
+          const firstIndex = poolFirstRowIndex.get(volume.poolName);
+          const isFirst = firstIndex === index;
+
+          return (
+            <Typography
+              sx={{
+                fontWeight: isFirst ? 700 : 500,
+                color: 'var(--color-text)',
+                opacity: isFirst ? 1 : 0.7,
+              }}
+            >
+              {volume.poolName}
             </Typography>
-          )}
+          );
+        },
+      },
+      {
+        id: 'volume',
+        header: 'نام Volume',
+        align: 'left',
+        width: 200,
+        renderCell: (volume) => (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+              {volume.volumeName}
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
+              {volume.fullName}
+            </Typography>
+          </Box>
+        ),
+      },
+    ];
 
-          {group.volumes.map((volume) => (
-            <Box key={volume.id} sx={cardStyles}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: { xs: 'column', sm: 'row' },
-                  gap: 1,
-                  alignItems: { xs: 'flex-start', sm: 'center' },
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                  <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
-                    {volume.volumeName}
-                  </Typography>
-                  <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
-                    {volume.fullName}
-                  </Typography>
-                </Box>
-                <Tooltip title="حذف Volume">
-                  <span>
-                    <IconButton
-                      color="error"
-                      size="small"
-                      onClick={() => onDeleteVolume(volume)}
-                      disabled={isDeleteDisabled}
-                    >
-                      <MdDeleteOutline size={18} />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              </Box>
+    const dynamicColumns: DataTableColumn<VolumeEntry>[] = attributeKeys.map(
+      (key) => ({
+        id: `attr-${key}`,
+        header: key,
+        align: 'left',
+        renderCell: (volume) => {
+          const attribute = volume.attributes.find((item) => item.key === key);
 
-              {volume.attributes.length > 0 ? (
-                <Box
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: {
-                      xs: 'repeat(1, minmax(0, 1fr))',
-                      md: 'repeat(auto-fit, minmax(180px, 1fr))',
-                    },
-                    gap: 1.5,
-                  }}
-                >
-                  {volume.attributes.map((attribute) => (
-                    <Box key={`${volume.id}-${attribute.key}`} sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                      <Typography sx={attributeKeyStyles}>{attribute.key}</Typography>
-                      <Typography sx={attributeValueStyles}>{attribute.value}</Typography>
-                    </Box>
-                  ))}
-                </Box>
-              ) : (
-                <Typography sx={{ color: 'var(--color-secondary)' }}>
-                  اطلاعاتی برای این Volume ثبت نشده است.
-                </Typography>
-              )}
-            </Box>
-          ))}
-        </Box>
+          return (
+            <Typography sx={{ color: 'var(--color-text)', fontWeight: 500 }}>
+              {attribute?.value ?? '—'}
+            </Typography>
+          );
+        },
+      })
+    );
+
+    const actionColumn: DataTableColumn<VolumeEntry> = {
+      id: 'actions',
+      header: 'عملیات',
+      align: 'center',
+      width: 120,
+      renderCell: (volume) => (
+        <Tooltip title="حذف Volume">
+          <span>
+            <IconButton
+              color="error"
+              size="small"
+              onClick={() => onDeleteVolume(volume)}
+              disabled={isDeleteDisabled}
+            >
+              <MdDeleteOutline size={18} />
+            </IconButton>
+          </span>
+        </Tooltip>
       ),
-    },
-  ];
+    };
+
+    return [...baseColumns, ...dynamicColumns, actionColumn];
+  }, [
+    attributeKeys,
+    isDeleteDisabled,
+    onDeleteVolume,
+    poolFirstRowIndex,
+  ]);
 
   return (
-    <DataTable<VolumeGroup>
+    <DataTable<VolumeEntry>
       columns={columns}
-      data={groups}
-      getRowId={(group) => group.poolName}
+      data={volumes}
+      getRowId={(volume) => volume.id}
       isLoading={isLoading}
       error={error}
+      bodyRowSx={(volume, index) => {
+        const firstIndex = poolFirstRowIndex.get(volume.poolName);
+        const isFirst = firstIndex === index;
+
+        if (isFirst && index !== 0) {
+          return {
+            '& .MuiTableCell-root': {
+              borderTop: '2px solid rgba(0, 0, 0, 0.08)',
+            },
+          };
+        }
+
+        return {};
+      }}
       renderLoadingState={() => (
         <Box
           sx={{

--- a/src/hooks/useVolumes.ts
+++ b/src/hooks/useVolumes.ts
@@ -53,19 +53,56 @@ const createAttributes = (raw: VolumeRawEntry): VolumeAttribute[] =>
     value: formatAttributeValue(value),
   }));
 
+const extractNames = (fullName: string) => {
+  const trimmedFullName = fullName.trim();
+  const spacedSeparator = ' / ';
+
+  if (trimmedFullName.includes(spacedSeparator)) {
+    const separatorIndex = trimmedFullName.indexOf(spacedSeparator);
+    const poolName = trimmedFullName.slice(0, separatorIndex).trim();
+    const remaining = trimmedFullName
+      .slice(separatorIndex + spacedSeparator.length)
+      .trim();
+
+    return {
+      poolName: poolName.length > 0 ? poolName : 'نامشخص',
+      volumeName: remaining.length > 0 ? remaining : trimmedFullName,
+    };
+  }
+
+  const slashIndex = trimmedFullName.indexOf('/');
+
+  if (slashIndex !== -1) {
+    const poolName = trimmedFullName.slice(0, slashIndex).trim();
+    const remaining = trimmedFullName.slice(slashIndex + 1).trim();
+
+    return {
+      poolName: poolName.length > 0 ? poolName : 'نامشخص',
+      volumeName: remaining.length > 0 ? remaining : trimmedFullName,
+    };
+  }
+
+  const fallbackName = trimmedFullName.length > 0 ? trimmedFullName : 'نامشخص';
+
+  return {
+    poolName: 'نامشخص',
+    volumeName: fallbackName,
+  };
+};
+
 const normalizeVolumeEntry = (
   fullName: string,
   raw: unknown
 ): VolumeEntry => {
   const normalizedRaw = normalizeRawEntry(raw);
-  const [poolName, ...rest] = fullName.split('/');
-  const volumeName = rest.length > 0 ? rest.join('/') : fullName;
+  const { poolName, volumeName } = extractNames(fullName);
+  const safeVolumeName = volumeName.length > 0 ? volumeName : 'نامشخص';
 
   return {
     id: fullName,
-    fullName,
-    poolName: poolName || 'نامشخص',
-    volumeName,
+    fullName: fullName.trim(),
+    poolName,
+    volumeName: safeVolumeName,
     attributes: createAttributes(normalizedRaw),
     raw: normalizedRaw,
   };

--- a/src/pages/BlockStorage.tsx
+++ b/src/pages/BlockStorage.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Typography } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import { toast } from 'react-hot-toast';
-import type { VolumeEntry, VolumeGroup } from '../@types/volume';
+import type { VolumeEntry } from '../@types/volume';
 import ConfirmDeleteVolumeModal from '../components/block-storage/ConfirmDeleteVolumeModal';
 import CreateVolumeModal from '../components/block-storage/CreateVolumeModal';
 import VolumesTable from '../components/block-storage/VolumesTable';
@@ -40,26 +40,23 @@ const BlockStorage = () => {
     [poolData?.pools]
   );
 
-  const volumeGroups = useMemo<VolumeGroup[]>(() => {
-    const groups = new Map<string, VolumeEntry[]>();
+  const volumes = useMemo(() => volumeData?.volumes ?? [], [volumeData?.volumes]);
 
-    poolOptions.forEach((poolName) => {
-      groups.set(poolName, []);
+  const attributeKeys = useMemo(() => {
+    const keys: string[] = [];
+    const seen = new Set<string>();
+
+    volumes.forEach((volume) => {
+      volume.attributes.forEach((attribute) => {
+        if (!seen.has(attribute.key)) {
+          seen.add(attribute.key);
+          keys.push(attribute.key);
+        }
+      });
     });
 
-    (volumeData?.volumes ?? []).forEach((volume) => {
-      const existing = groups.get(volume.poolName) ?? [];
-      existing.push(volume);
-      groups.set(volume.poolName, existing);
-    });
-
-    return Array.from(groups.entries())
-      .map(([poolName, volumes]) => ({
-        poolName,
-        volumes: volumes.sort((a, b) => a.volumeName.localeCompare(b.volumeName, 'fa')),
-      }))
-      .sort((a, b) => a.poolName.localeCompare(b.poolName, 'fa'));
-  }, [poolOptions, volumeData?.volumes]);
+    return keys;
+  }, [volumes]);
 
   const handleOpenCreate = useCallback(() => {
     createVolume.openCreateModal();
@@ -119,7 +116,8 @@ const BlockStorage = () => {
       <CreateVolumeModal controller={createVolume} poolOptions={poolOptions} />
 
       <VolumesTable
-        groups={volumeGroups}
+        volumes={volumes}
+        attributeKeys={attributeKeys}
         isLoading={isLoading}
         error={error ?? null}
         onDeleteVolume={handleDeleteRequest}


### PR DESCRIPTION
## Summary
- derive pool names from volume identifiers using trimmed separators so categorisation matches pool prefixes
- update the block storage page to build a flat volume list with dynamic attribute columns for the table
- redesign the block storage volumes table to mirror the integrated storage layout with per-attribute columns and delete actions

## Testing
- npm run lint *(fails: react-refresh/only-export-components violations in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68d7fe194f18832f84e227441282780d