### PR TITLE
Refine block storage volume table layout

### DIFF
--- a/src/@types/volume.ts
+++ b/src/@types/volume.ts
@@ -19,11 +19,6 @@ export interface VolumeEntry {
   raw: VolumeRawEntry;
 }
 
-export interface VolumeGroup {
-  poolName: string;
-  volumes: VolumeEntry[];
-}
-
 export interface VolumeQueryResult {
   volumes: VolumeEntry[];
 }

--- a/src/components/block-storage/VolumesTable.tsx
+++ b/src/components/block-storage/VolumesTable.tsx
@@ -5,138 +5,128 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { useMemo } from 'react';
 import { MdDeleteOutline } from 'react-icons/md';
-import type { VolumeEntry, VolumeGroup } from '../../@types/volume';
+import type { VolumeEntry } from '../../@types/volume';
 import type { DataTableColumn } from '../DataTable';
 import DataTable from '../DataTable';
 
+interface VolumeTableRow extends VolumeEntry {
+  attributeMap: Record<string, string>;
+}
+
 interface VolumesTableProps {
-  groups: VolumeGroup[];
+  volumes: VolumeEntry[];
   isLoading: boolean;
   error: Error | null;
   onDeleteVolume: (volume: VolumeEntry) => void;
   isDeleteDisabled: boolean;
 }
 
-const attributeKeyStyles = {
-  color: 'var(--color-secondary)',
-  fontSize: '0.85rem',
-};
-
-const attributeValueStyles = {
-  color: 'var(--color-text)',
-  fontWeight: 600,
-};
-
-const cardStyles = {
-  border: '1px solid var(--color-input-border)',
-  borderRadius: '12px',
-  padding: 2,
-  backgroundColor: 'rgba(0, 198, 169, 0.05)',
-  display: 'flex',
-  flexDirection: 'column' as const,
-  gap: 1.5,
-};
-
 const VolumesTable = ({
-  groups,
+  volumes,
   isLoading,
   error,
   onDeleteVolume,
   isDeleteDisabled,
 }: VolumesTableProps) => {
-  const columns: DataTableColumn<VolumeGroup>[] = [
-    {
-      id: 'pool',
-      header: 'نام Pool',
-      align: 'left',
-      width: '25%',
-      renderCell: (group) => (
-        <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
-          {group.poolName}
+  const rows = useMemo<VolumeTableRow[]>(
+    () =>
+      volumes.map((volume) => ({
+        ...volume,
+        attributeMap: volume.attributes.reduce<Record<string, string>>(
+          (acc, attribute) => {
+            acc[attribute.key] = attribute.value;
+            return acc;
+          },
+          {}
+        ),
+      })),
+    [volumes]
+  );
+
+  const attributeKeys = useMemo(() => {
+    const keys = new Set<string>();
+
+    rows.forEach((row) => {
+      Object.keys(row.attributeMap).forEach((key) => {
+        if (key.trim().toLowerCase() !== 'name') {
+          keys.add(key);
+        }
+      });
+    });
+
+    return Array.from(keys).sort((a, b) => a.localeCompare(b, 'fa'));
+  }, [rows]);
+
+  const columns: DataTableColumn<VolumeTableRow>[] = useMemo(() => {
+    const baseColumns: DataTableColumn<VolumeTableRow>[] = [
+      {
+        id: 'poolName',
+        header: 'نام Pool',
+        align: 'left',
+        renderCell: (volume) => (
+          <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+            {volume.poolName}
+          </Typography>
+        ),
+      },
+      {
+        id: 'volumeName',
+        header: 'نام Volume',
+        align: 'left',
+        renderCell: (volume) => (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Typography sx={{ fontWeight: 600, color: 'var(--color-text)' }}>
+              {volume.volumeName}
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
+              {volume.fullName}
+            </Typography>
+          </Box>
+        ),
+      },
+    ];
+
+    const dynamicColumns = attributeKeys.map((key) => ({
+      id: `attr-${key}`,
+      header: key,
+      align: 'left' as const,
+      renderCell: (volume: VolumeTableRow) => (
+        <Typography sx={{ color: 'var(--color-text)' }}>
+          {volume.attributeMap[key] ?? '—'}
         </Typography>
       ),
-    },
-    {
-      id: 'volumes',
-      header: 'Volume ها',
-      align: 'left',
-      renderCell: (group) => (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {group.volumes.length === 0 && (
-            <Typography sx={{ color: 'var(--color-secondary)' }}>
-              برای این Pool حجمی ثبت نشده است.
-            </Typography>
-          )}
+    }));
 
-          {group.volumes.map((volume) => (
-            <Box key={volume.id} sx={cardStyles}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: { xs: 'column', sm: 'row' },
-                  gap: 1,
-                  alignItems: { xs: 'flex-start', sm: 'center' },
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                  <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
-                    {volume.volumeName}
-                  </Typography>
-                  <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
-                    {volume.fullName}
-                  </Typography>
-                </Box>
-                <Tooltip title="حذف Volume">
-                  <span>
-                    <IconButton
-                      color="error"
-                      size="small"
-                      onClick={() => onDeleteVolume(volume)}
-                      disabled={isDeleteDisabled}
-                    >
-                      <MdDeleteOutline size={18} />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              </Box>
-
-              {volume.attributes.length > 0 ? (
-                <Box
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: {
-                      xs: 'repeat(1, minmax(0, 1fr))',
-                      md: 'repeat(auto-fit, minmax(180px, 1fr))',
-                    },
-                    gap: 1.5,
-                  }}
-                >
-                  {volume.attributes.map((attribute) => (
-                    <Box key={`${volume.id}-${attribute.key}`} sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                      <Typography sx={attributeKeyStyles}>{attribute.key}</Typography>
-                      <Typography sx={attributeValueStyles}>{attribute.value}</Typography>
-                    </Box>
-                  ))}
-                </Box>
-              ) : (
-                <Typography sx={{ color: 'var(--color-secondary)' }}>
-                  اطلاعاتی برای این Volume ثبت نشده است.
-                </Typography>
-              )}
-            </Box>
-          ))}
-        </Box>
+    const actionColumn: DataTableColumn<VolumeTableRow> = {
+      id: 'actions',
+      header: 'عملیات',
+      align: 'center',
+      renderCell: (volume) => (
+        <Tooltip title="حذف Volume">
+          <span>
+            <IconButton
+              color="error"
+              size="small"
+              onClick={() => onDeleteVolume(volume)}
+              disabled={isDeleteDisabled}
+            >
+              <MdDeleteOutline size={18} />
+            </IconButton>
+          </span>
+        </Tooltip>
       ),
-    },
-  ];
+    };
+
+    return [...baseColumns, ...dynamicColumns, actionColumn];
+  }, [attributeKeys, isDeleteDisabled, onDeleteVolume]);
 
   return (
-    <DataTable<VolumeGroup>
+    <DataTable<VolumeTableRow>
       columns={columns}
-      data={groups}
-      getRowId={(group) => group.poolName}
+      data={rows}
+      getRowId={(volume) => volume.id}
       isLoading={isLoading}
       error={error}
       renderLoadingState={() => (


### PR DESCRIPTION
## Summary
- derive pool names for volumes from their full identifiers and keep the create modal options in sync
- redesign the block storage table to use the shared data-table layout with per-attribute columns and a dedicated حجم Volume column
- remove the unused grouped volume type now that the table works with flat volume rows

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d801ec4c54832f86a1aac41337771a