### PR TITLE
Refine block storage table to mirror integrated storage layout

### DIFF
--- a/src/@types/volume.ts
+++ b/src/@types/volume.ts
@@ -16,6 +16,7 @@ export interface VolumeEntry {
   poolName: string;
   volumeName: string;
   attributes: VolumeAttribute[];
+  attributeMap: Record<string, string>;
   raw: VolumeRawEntry;
 }
 

--- a/src/components/block-storage/VolumesTable.tsx
+++ b/src/components/block-storage/VolumesTable.tsx
@@ -5,138 +5,104 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { useMemo } from 'react';
 import { MdDeleteOutline } from 'react-icons/md';
-import type { VolumeEntry, VolumeGroup } from '../../@types/volume';
+import type { VolumeEntry } from '../../@types/volume';
 import type { DataTableColumn } from '../DataTable';
 import DataTable from '../DataTable';
 
 interface VolumesTableProps {
-  groups: VolumeGroup[];
+  volumes: VolumeEntry[];
+  attributeKeys: string[];
   isLoading: boolean;
   error: Error | null;
   onDeleteVolume: (volume: VolumeEntry) => void;
   isDeleteDisabled: boolean;
 }
 
-const attributeKeyStyles = {
-  color: 'var(--color-secondary)',
-  fontSize: '0.85rem',
-};
-
-const attributeValueStyles = {
-  color: 'var(--color-text)',
+const valueTypographySx = {
   fontWeight: 600,
-};
-
-const cardStyles = {
-  border: '1px solid var(--color-input-border)',
-  borderRadius: '12px',
-  padding: 2,
-  backgroundColor: 'rgba(0, 198, 169, 0.05)',
-  display: 'flex',
-  flexDirection: 'column' as const,
-  gap: 1.5,
+  color: 'var(--color-text)',
 };
 
 const VolumesTable = ({
-  groups,
+  volumes,
+  attributeKeys,
   isLoading,
   error,
   onDeleteVolume,
   isDeleteDisabled,
 }: VolumesTableProps) => {
-  const columns: DataTableColumn<VolumeGroup>[] = [
-    {
-      id: 'pool',
-      header: 'نام Pool',
-      align: 'left',
-      width: '25%',
-      renderCell: (group) => (
-        <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
-          {group.poolName}
-        </Typography>
-      ),
-    },
-    {
-      id: 'volumes',
-      header: 'Volume ها',
-      align: 'left',
-      renderCell: (group) => (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {group.volumes.length === 0 && (
-            <Typography sx={{ color: 'var(--color-secondary)' }}>
-              برای این Pool حجمی ثبت نشده است.
+  const columns = useMemo<DataTableColumn<VolumeEntry>[]>(() => {
+    const baseColumns: DataTableColumn<VolumeEntry>[] = [
+      {
+        id: 'pool',
+        header: 'نام Pool',
+        align: 'left',
+        renderCell: (volume) => (
+          <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+            {volume.poolName}
+          </Typography>
+        ),
+      },
+      {
+        id: 'volume',
+        header: 'نام Volume',
+        align: 'left',
+        renderCell: (volume) => (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+            <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+              {volume.volumeName}
             </Typography>
-          )}
+            <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
+              {volume.fullName}
+            </Typography>
+          </Box>
+        ),
+      },
+    ];
 
-          {group.volumes.map((volume) => (
-            <Box key={volume.id} sx={cardStyles}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: { xs: 'column', sm: 'row' },
-                  gap: 1,
-                  alignItems: { xs: 'flex-start', sm: 'center' },
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                  <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
-                    {volume.volumeName}
-                  </Typography>
-                  <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
-                    {volume.fullName}
-                  </Typography>
-                </Box>
-                <Tooltip title="حذف Volume">
-                  <span>
-                    <IconButton
-                      color="error"
-                      size="small"
-                      onClick={() => onDeleteVolume(volume)}
-                      disabled={isDeleteDisabled}
-                    >
-                      <MdDeleteOutline size={18} />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              </Box>
+    const dynamicColumns = attributeKeys.map<DataTableColumn<VolumeEntry>>(
+      (key) => ({
+        id: `attribute-${key}`,
+        header: key,
+        align: 'left',
+        renderCell: (volume) => (
+          <Typography sx={valueTypographySx}>
+            {volume.attributeMap[key] ?? '—'}
+          </Typography>
+        ),
+      })
+    );
 
-              {volume.attributes.length > 0 ? (
-                <Box
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: {
-                      xs: 'repeat(1, minmax(0, 1fr))',
-                      md: 'repeat(auto-fit, minmax(180px, 1fr))',
-                    },
-                    gap: 1.5,
-                  }}
-                >
-                  {volume.attributes.map((attribute) => (
-                    <Box key={`${volume.id}-${attribute.key}`} sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                      <Typography sx={attributeKeyStyles}>{attribute.key}</Typography>
-                      <Typography sx={attributeValueStyles}>{attribute.value}</Typography>
-                    </Box>
-                  ))}
-                </Box>
-              ) : (
-                <Typography sx={{ color: 'var(--color-secondary)' }}>
-                  اطلاعاتی برای این Volume ثبت نشده است.
-                </Typography>
-              )}
-            </Box>
-          ))}
-        </Box>
+    const actionColumn: DataTableColumn<VolumeEntry> = {
+      id: 'actions',
+      header: 'عملیات',
+      align: 'center',
+      renderCell: (volume) => (
+        <Tooltip title="حذف Volume">
+          <span>
+            <IconButton
+              size="small"
+              color="error"
+              onClick={() => onDeleteVolume(volume)}
+              disabled={isDeleteDisabled}
+            >
+              <MdDeleteOutline size={18} />
+            </IconButton>
+          </span>
+        </Tooltip>
       ),
-    },
-  ];
+    };
+
+    return [...baseColumns, ...dynamicColumns, actionColumn];
+  }, [attributeKeys, isDeleteDisabled, onDeleteVolume]);
 
   return (
-    <DataTable<VolumeGroup>
+    <DataTable<VolumeEntry>
       columns={columns}
-      data={groups}
-      getRowId={(group) => group.poolName}
+      data={volumes}
+      getRowId={(volume) => volume.id}
       isLoading={isLoading}
       error={error}
       renderLoadingState={() => (

--- a/src/hooks/useVolumes.ts
+++ b/src/hooks/useVolumes.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '../lib/axiosInstance';
 import type {
   VolumeApiResponse,
-  VolumeAttribute,
   VolumeEntry,
   VolumeQueryResult,
   VolumeRawEntry,
@@ -47,27 +46,83 @@ const normalizeRawEntry = (raw: unknown): VolumeRawEntry => {
   return {};
 };
 
-const createAttributes = (raw: VolumeRawEntry): VolumeAttribute[] =>
-  Object.entries(raw).map(([key, value]) => ({
+const createAttributeEntries = (raw: VolumeRawEntry) => {
+  const entries = Object.entries(raw).map(([key, value]) => ({
     key,
     value: formatAttributeValue(value),
   }));
 
+  const map = entries.reduce<Record<string, string>>((accumulator, attribute) => {
+    accumulator[attribute.key] = attribute.value;
+    return accumulator;
+  }, {});
+
+  return { entries, map };
+};
+
+const ensureNameInRaw = (
+  raw: VolumeRawEntry,
+  fallbackName: string
+): VolumeRawEntry => {
+  const rawName = raw['name'];
+
+  if (typeof rawName === 'string' && rawName.trim().length > 0) {
+    return raw;
+  }
+
+  return { ...raw, name: fallbackName };
+};
+
+const extractVolumeNames = (
+  fullNameHint: string | undefined,
+  raw: VolumeRawEntry,
+  index: number
+) => {
+  const rawName = raw['name'];
+  const fallbackName = `volume-${index + 1}`;
+  const sourceName =
+    typeof fullNameHint === 'string' && fullNameHint.trim().length > 0
+      ? fullNameHint.trim()
+      : typeof rawName === 'string' && rawName.trim().length > 0
+        ? rawName.trim()
+        : fallbackName;
+
+  const [poolPart, ...volumeParts] = sourceName.split('/');
+  const poolName = poolPart && poolPart.trim().length > 0 ? poolPart.trim() : 'نامشخص';
+  const volumeNameSource =
+    volumeParts.length > 0 ? volumeParts.join('/') : sourceName;
+  const volumeName =
+    volumeNameSource.trim().length > 0 ? volumeNameSource.trim() : sourceName;
+
+  return {
+    fullName: sourceName,
+    poolName,
+    volumeName,
+  };
+};
+
 const normalizeVolumeEntry = (
-  fullName: string,
-  raw: unknown
+  fullNameHint: string | undefined,
+  raw: unknown,
+  index: number
 ): VolumeEntry => {
   const normalizedRaw = normalizeRawEntry(raw);
-  const [poolName, ...rest] = fullName.split('/');
-  const volumeName = rest.length > 0 ? rest.join('/') : fullName;
+  const { fullName, poolName, volumeName } = extractVolumeNames(
+    fullNameHint,
+    normalizedRaw,
+    index
+  );
+  const enrichedRaw = ensureNameInRaw(normalizedRaw, fullName);
+  const { entries, map } = createAttributeEntries(enrichedRaw);
 
   return {
     id: fullName,
     fullName,
-    poolName: poolName || 'نامشخص',
+    poolName,
     volumeName,
-    attributes: createAttributes(normalizedRaw),
-    raw: normalizedRaw,
+    attributes: entries,
+    attributeMap: map,
+    raw: enrichedRaw,
   };
 };
 
@@ -77,18 +132,30 @@ const fetchVolumes = async (): Promise<VolumeQueryResult> => {
   );
 
   const payload = response.data;
-  const rawVolumes = payload?.data ?? {};
+  const rawVolumes = payload?.data;
 
-  const volumes = Object.entries(rawVolumes)
-    .map(([fullName, raw]) => normalizeVolumeEntry(fullName, raw))
-    .sort((a, b) => {
-      const poolCompare = a.poolName.localeCompare(b.poolName, 'fa');
-      if (poolCompare !== 0) {
-        return poolCompare;
-      }
+  const volumes = (() => {
+    if (Array.isArray(rawVolumes)) {
+      return rawVolumes.map((raw, index) =>
+        normalizeVolumeEntry(undefined, raw, index)
+      );
+    }
 
-      return a.volumeName.localeCompare(b.volumeName, 'fa');
-    });
+    if (rawVolumes && typeof rawVolumes === 'object') {
+      return Object.entries(rawVolumes).map(([fullName, raw], index) =>
+        normalizeVolumeEntry(fullName, raw, index)
+      );
+    }
+
+    return [] as VolumeEntry[];
+  })().sort((a, b) => {
+    const poolCompare = a.poolName.localeCompare(b.poolName, 'fa');
+    if (poolCompare !== 0) {
+      return poolCompare;
+    }
+
+    return a.volumeName.localeCompare(b.volumeName, 'fa');
+  });
 
   return { volumes };
 };


### PR DESCRIPTION
## Summary
- enhance volume normalization to derive pool and volume names from API responses and expose attribute maps for rendering
- update the block storage page to sort volumes by pool and generate dynamic attribute columns
- rebuild the block storage table component using the shared DataTable for an integrated-storage style layout

## Testing
- npm run build *(fails: existing TypeScript issues in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_b_68d805155488832f8dfaf58f95fb0e3d