### PR TITLE
Enhance pool creation modal with WWN selection

### DIFF
--- a/src/@types/disk.ts
+++ b/src/@types/disk.ts
@@ -37,6 +37,10 @@ export interface DiskResponse {
   summary: DiskSummary;
 }
 
+export interface DiskWwnMapResponse {
+  data: Record<string, string>;
+}
+
 export type NormalizedMetrics = Record<keyof DiskIOStats, number>;
 
 export type DiskMetricConfig = {

--- a/src/components/integrated-storage/CreatePoolModal.tsx
+++ b/src/components/integrated-storage/CreatePoolModal.tsx
@@ -11,6 +11,7 @@ import {
   MenuItem,
   Select,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
@@ -18,9 +19,15 @@ import type { ChangeEvent } from 'react';
 import type { UseCreatePoolReturn } from '../../hooks/useCreatePool';
 import BlurModal from '../BlurModal';
 
+export interface DeviceOption {
+  label: string;
+  value: string;
+  tooltip: string;
+}
+
 interface CreatePoolModalProps {
   controller: UseCreatePoolReturn;
-  deviceOptions: string[];
+  deviceOptions: DeviceOption[];
   isDiskLoading: boolean;
   diskError: Error | null;
 }
@@ -151,7 +158,9 @@ const CreatePoolModal = ({
                 },
               }}
             >
-              <MenuItem value="disk">disk</MenuItem>
+              <MenuItem value="disk">DISK</MenuItem>
+              <MenuItem value="mirror">MIRROR</MenuItem>
+              <MenuItem value="raidz">RAIDZ</MenuItem>
             </Select>
           </FormControl>
 
@@ -200,11 +209,11 @@ const CreatePoolModal = ({
                 >
                   {deviceOptions.map((device) => (
                     <FormControlLabel
-                      key={device}
+                      key={device.value}
                       control={
                         <Checkbox
-                          checked={selectedDevices.includes(device)}
-                          onChange={() => toggleDevice(device)}
+                          checked={selectedDevices.includes(device.value)}
+                          onChange={() => toggleDevice(device.value)}
                           sx={{
                             color: 'var(--color-secondary)',
                             '&.Mui-checked': {
@@ -213,7 +222,13 @@ const CreatePoolModal = ({
                           }}
                         />
                       }
-                      label={device}
+                      label={
+                        <Tooltip title={device.tooltip} placement="top" arrow>
+                          <Typography component="span" sx={{ color: 'var(--color-text)' }}>
+                            {device.label}
+                          </Typography>
+                        </Tooltip>
+                      }
                       sx={{
                         alignItems: 'center',
                         m: 0,

--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -101,6 +101,9 @@ export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
   });
 
   const handleDeviceToggle = useCallback((device: string) => {
+    setDevicesError(null);
+    setApiError(null);
+
     setSelectedDevices((prev) => {
       if (prev.includes(device)) {
         return prev.filter((item) => item !== device);
@@ -125,9 +128,21 @@ export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
         hasError = true;
       }
 
-      if (selectedDevices.length === 0) {
+      const deviceCount = selectedDevices.length;
+
+      if (deviceCount === 0) {
         setDevicesError('حداقل یک دیسک را انتخاب کنید.');
         hasError = true;
+      } else if (vdevType === 'mirror') {
+        if (deviceCount < 2 || deviceCount % 2 !== 0) {
+          setDevicesError('برای MIRROR تعداد دیسک‌ها باید عددی زوج و حداقل ۲ باشد.');
+          hasError = true;
+        }
+      } else if (vdevType === 'raidz') {
+        if (deviceCount < 3) {
+          setDevicesError('برای RAIDZ حداقل سه دیسک انتخاب کنید.');
+          hasError = true;
+        }
       }
 
       if (hasError) {

--- a/src/hooks/useDisk.ts
+++ b/src/hooks/useDisk.ts
@@ -1,9 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
-import type { DiskResponse } from '../@types/disk';
+import type { DiskResponse, DiskWwnMapResponse } from '../@types/disk';
 import axiosInstance from '../lib/axiosInstance';
 
 const fetchDisk = async (): Promise<DiskResponse> => {
   const { data } = await axiosInstance.get<DiskResponse>('/api/disk');
+  return data;
+};
+
+const fetchDiskWwnMap = async (): Promise<DiskWwnMapResponse> => {
+  const { data } = await axiosInstance.get<DiskWwnMapResponse>(
+    '/api/disk/wwn/map/'
+  );
   return data;
 };
 
@@ -16,6 +23,16 @@ export const useDisk = (options?: UseDiskOptions) => {
   return useQuery<DiskResponse, Error>({
     queryKey: ['disk'],
     queryFn: fetchDisk,
+    refetchInterval: options?.refetchInterval ?? 1000,
+    refetchIntervalInBackground: true,
+    enabled: options?.enabled ?? true,
+  });
+};
+
+export const useDiskWwnMap = (options?: UseDiskOptions) => {
+  return useQuery<DiskWwnMapResponse, Error>({
+    queryKey: ['disk', 'wwn', 'map'],
+    queryFn: fetchDiskWwnMap,
     refetchInterval: options?.refetchInterval ?? 1000,
     refetchIntervalInBackground: true,
     enabled: options?.enabled ?? true,


### PR DESCRIPTION
## Summary
- add MIRROR and RAIDZ options to the VDEV selector with validation rules for disk counts
- populate disk choices from the /api/disk/wwn/map/ endpoint, surface WWNs as tooltips, and submit WWNs when creating pools
- expose a disk WWN map hook to share the new API data with the modal

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components violations in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68da2dd7d338832f9af9854eb40446c4