### PR TITLE
Add services management table

### DIFF
--- a/src/@types/service.ts
+++ b/src/@types/service.ts
@@ -1,0 +1,14 @@
+export type ServicePrimitiveValue = string | number | boolean | null | undefined;
+
+export type ServiceValue = ServicePrimitiveValue | ServicePrimitiveValue[];
+
+export interface ServiceDetails {
+  unit?: string | null;
+  [key: string]: ServiceValue;
+}
+
+export interface ServicesResponse {
+  data?: Record<string, ServiceDetails>;
+}
+
+export type ServiceActionType = 'start' | 'stop' | 'restart';

--- a/src/components/services/ServicesTable.tsx
+++ b/src/components/services/ServicesTable.tsx
@@ -1,0 +1,148 @@
+import { Box, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import type { IconType } from 'react-icons';
+import { FiPlay, FiRefreshCw, FiStopCircle } from 'react-icons/fi';
+import type { DataTableColumn } from '../../@types/dataTable';
+import type { ServiceActionType, ServiceValue } from '../../@types/service';
+import DataTable from '../DataTable';
+
+interface ServiceTableRow {
+  name: string;
+  details: Record<string, ServiceValue>;
+}
+
+interface ServicesTableProps {
+  services: ServiceTableRow[];
+  isLoading: boolean;
+  error: Error | null;
+  onAction: (serviceName: string, action: ServiceActionType) => void;
+  isActionLoading?: boolean;
+  activeServiceName?: string | null;
+}
+
+const actionConfigs: Array<{
+  action: ServiceActionType;
+  label: string;
+  icon: IconType;
+  color: string;
+}> = [
+  { action: 'start', label: 'شروع', icon: FiPlay, color: 'var(--color-success)' },
+  {
+    action: 'restart',
+    label: 'راه‌اندازی مجدد',
+    icon: FiRefreshCw,
+    color: 'var(--color-primary)',
+  },
+  { action: 'stop', label: 'توقف', icon: FiStopCircle, color: 'var(--color-error)' },
+];
+
+const formatServiceValue = (value: ServiceValue) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'بله' : 'خیر';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => (item ?? '—').toString()).join(', ');
+  }
+
+  return String(value);
+};
+
+const ServicesTable = ({
+  services,
+  isLoading,
+  error,
+  onAction,
+  isActionLoading = false,
+  activeServiceName = null,
+}: ServicesTableProps) => {
+  const detailKeys = useMemo(() => {
+    const keys = new Set<string>();
+
+    services.forEach((service) => {
+      Object.keys(service.details).forEach((key) => {
+        if (key !== 'unit') {
+          keys.add(key);
+        }
+      });
+    });
+
+    return Array.from(keys).sort((a, b) => a.localeCompare(b, 'fa'));
+  }, [services]);
+
+  const columns = useMemo<DataTableColumn<ServiceTableRow>[]>(() => {
+    const baseColumn: DataTableColumn<ServiceTableRow> = {
+      id: 'service-name',
+      header: 'سرویس',
+      renderCell: (row) => (
+        <Typography component="span" sx={{ fontWeight: 600 }}>
+          {row.name}
+        </Typography>
+      ),
+    };
+
+    const dynamicColumns = detailKeys.map<DataTableColumn<ServiceTableRow>>((key) => ({
+      id: key,
+      header: key,
+      renderCell: (row) => formatServiceValue(row.details[key]),
+    }));
+
+    const actionColumn: DataTableColumn<ServiceTableRow> = {
+      id: 'actions',
+      header: 'عملیات',
+      align: 'center',
+      renderCell: (row) => {
+        const isPending = isActionLoading && activeServiceName === row.name;
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.5 }}>
+            {actionConfigs.map(({ action, label, icon: Icon, color }) => (
+              <Tooltip key={action} title={label} arrow>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => onAction(row.name, action)}
+                    disabled={isPending}
+                    sx={{
+                      color,
+                      '&:hover': {
+                        backgroundColor: 'rgba(0, 0, 0, 0.04)',
+                      },
+                      '&.Mui-disabled': {
+                        color: 'var(--color-secondary)',
+                        opacity: 0.5,
+                      },
+                    }}
+                  >
+                    <Icon size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            ))}
+
+            {isPending ? <CircularProgress size={18} sx={{ color: 'var(--color-primary)' }} /> : null}
+          </Box>
+        );
+      },
+    };
+
+    return [baseColumn, ...dynamicColumns, actionColumn];
+  }, [activeServiceName, detailKeys, isActionLoading, onAction]);
+
+  return (
+    <DataTable<ServiceTableRow>
+      columns={columns}
+      data={services}
+      getRowId={(row) => row.name}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+};
+
+export type { ServiceTableRow };
+export default ServicesTable;

--- a/src/hooks/useServiceAction.ts
+++ b/src/hooks/useServiceAction.ts
@@ -1,0 +1,90 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type {
+  ServiceActionType,
+  ServicesResponse,
+} from '../@types/service';
+import axiosInstance from '../lib/axiosInstance';
+import { servicesQueryKey } from './useServices';
+
+type ApiErrorResponse =
+  | string
+  | {
+      detail?: string;
+      message?: string;
+      error?: string;
+      errors?: string | string[];
+      [key: string]: unknown;
+    };
+
+export interface ServiceActionPayload {
+  action: ServiceActionType;
+  service: string;
+}
+
+interface UseServiceActionOptions {
+  onSuccess?: (payload: ServiceActionPayload) => void;
+  onError?: (message: string, payload: ServiceActionPayload) => void;
+}
+
+const extractErrorMessage = (error: AxiosError<ApiErrorResponse>) => {
+  const payload = error.response?.data;
+
+  if (!payload) {
+    return error.message;
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload.detail && typeof payload.detail === 'string') {
+    return payload.detail;
+  }
+
+  if (payload.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  if (payload.error && typeof payload.error === 'string') {
+    return payload.error;
+  }
+
+  if (payload.errors) {
+    if (Array.isArray(payload.errors)) {
+      return payload.errors.join('، ');
+    }
+
+    if (typeof payload.errors === 'string') {
+      return payload.errors;
+    }
+  }
+
+  return error.message;
+};
+
+export const useServiceAction = (
+  options: UseServiceActionOptions = {}
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<ServicesResponse, AxiosError<ApiErrorResponse>, ServiceActionPayload>({
+    mutationFn: async (payload) => {
+      const { data } = await axiosInstance.post<ServicesResponse>(
+        '/api/service/',
+        payload
+      );
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: servicesQueryKey });
+      options.onSuccess?.(variables);
+    },
+    onError: (error, variables) => {
+      const message = extractErrorMessage(error);
+      options.onError?.(message, variables);
+    },
+  });
+};
+
+export type UseServiceActionReturn = ReturnType<typeof useServiceAction>;

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ServicesResponse } from '../@types/service';
+import axiosInstance from '../lib/axiosInstance';
+
+export const servicesQueryKey = ['services'] as const;
+
+const fetchServices = async () => {
+  const { data } = await axiosInstance.get<ServicesResponse>('/api/service/');
+  return data;
+};
+
+export const useServices = () =>
+  useQuery<ServicesResponse, Error>({
+    queryKey: servicesQueryKey,
+    queryFn: fetchServices,
+    refetchInterval: 5000,
+  });
+
+export type UseServicesReturn = ReturnType<typeof useServices>;

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,8 @@
     --color-input-bg: rgba(255, 255, 255, 0.95);
     --color-input-border: rgba(0, 0, 0, 0.12);
     --color-input-focus-border: var(--color-primary);
-    --color-error : #ef4444
+    --color-error : #ef4444;
+    --color-success: #10b981;
 }
 
 [data-theme="dark"] {
@@ -41,7 +42,8 @@
     --color-input-bg: rgba(45, 45, 45, 0.95);
     --color-input-border: rgba(255, 255, 255, 0.12);
     --color-input-focus-border: var(--color-primary);
-    --color-error : #ef4444
+    --color-error : #ef4444;
+    --color-success: #10b981;
 }
 
 html {

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,11 +1,73 @@
 import { Box, Typography } from '@mui/material';
+import { useCallback, useMemo } from 'react';
+import { toast } from 'react-hot-toast';
+import type { ServiceActionType, ServiceValue } from '../@types/service';
+import ServicesTable from '../components/services/ServicesTable';
+import { useServiceAction } from '../hooks/useServiceAction';
+import { useServices } from '../hooks/useServices';
 
-const Services = () => (
-  <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-    <Typography variant="h5" sx={{ color: 'var(--color-primary)' }}>
-      سرویس ها
-    </Typography>
-  </Box>
-);
+const actionLabels: Record<ServiceActionType, string> = {
+  start: 'شروع',
+  restart: 'راه‌اندازی مجدد',
+  stop: 'توقف',
+};
+
+const Services = () => {
+  const servicesQuery = useServices();
+
+  const serviceAction = useServiceAction({
+    onSuccess: ({ action, service }) => {
+      toast.success(
+        `عملیات ${actionLabels[action]} برای ${service} با موفقیت انجام شد.`
+      );
+    },
+    onError: (message, { action, service }) => {
+      toast.error(
+        `اجرای ${actionLabels[action]} برای ${service} با خطا مواجه شد: ${message}`
+      );
+    },
+  });
+
+  const services = useMemo(
+    () =>
+      Object.entries(servicesQuery.data?.data ?? {}).map(([name, details]) => {
+        const normalizedDetails: Record<string, ServiceValue> = {
+          ...(details ?? {}),
+        };
+
+        return {
+          name,
+          details: normalizedDetails,
+        };
+      }),
+    [servicesQuery.data?.data]
+  );
+
+  const handleAction = useCallback(
+    (serviceName: string, action: ServiceActionType) => {
+      serviceAction.mutate({ service: serviceName, action });
+    },
+    [serviceAction]
+  );
+
+  return (
+    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography variant="h5" sx={{ color: 'var(--color-primary)', fontWeight: 700 }}>
+          سرویس ها
+        </Typography>
+
+        <ServicesTable
+          services={services}
+          isLoading={servicesQuery.isLoading}
+          error={servicesQuery.error ?? null}
+          onAction={handleAction}
+          isActionLoading={serviceAction.isPending}
+          activeServiceName={serviceAction.variables?.service ?? null}
+        />
+      </Box>
+    </Box>
+  );
+};
 
 export default Services;


### PR DESCRIPTION
## Summary
- add type definitions and data fetching hooks for managing services
- implement a reusable services table with dynamic columns and action icons
- update the services page to display service data and trigger start, stop, and restart requests while expanding theme colors

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68da38c44a8c832fa0019487f4ad33f2