### PR TITLE
Add pagination to services table

### DIFF
--- a/src/@types/dataTable.ts
+++ b/src/@types/dataTable.ts
@@ -3,8 +3,9 @@ import type {
   TableContainerProps,
   TableProps,
 } from '@mui/material';
+import type { TablePaginationProps } from '@mui/material/TablePagination';
 import type { SxProps, Theme } from '@mui/material/styles';
-import type { ReactNode } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 
 export interface DataTableColumn<T> {
   id: string;
@@ -34,4 +35,15 @@ export interface DataTableProps<T> {
   bodyRowSx?: SxProps<Theme> | ((row: T, index: number) => SxProps<Theme>);
   containerProps?: TableContainerProps;
   tableProps?: TableProps;
+  pagination?: {
+    page: number;
+    rowsPerPage: number;
+    count: number;
+    onPageChange: (event: unknown, newPage: number) => void;
+    onRowsPerPageChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    rowsPerPageOptions?: number[];
+    labelRowsPerPage?: ReactNode;
+    labelDisplayedRows?: TablePaginationProps['labelDisplayedRows'];
+    rowCountFormatter?: (count: number) => ReactNode;
+  };
 }

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -6,7 +6,9 @@ import {
   TableBody,
   TableCell,
   TableContainer,
+  TableFooter,
   TableHead,
+  TablePagination,
   TableRow,
   Typography,
 } from '@mui/material';
@@ -81,6 +83,7 @@ const DataTable = <T,>({
   bodyRowSx,
   containerProps,
   tableProps,
+  pagination,
 }: DataTableProps<T>) => {
   const renderStateRow = (content: ReactNode) => (
     <TableRow>
@@ -209,6 +212,51 @@ const DataTable = <T,>({
             );
           })}
         </TableBody>
+        {pagination ? (
+          <TableFooter>
+            <TableRow>
+              <TableCell colSpan={columns.length} sx={{ py: 2 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 2,
+                  }}
+                >
+                  <Typography sx={{ color: 'var(--color-secondary)' }}>
+                    {pagination.rowCountFormatter
+                      ? pagination.rowCountFormatter(pagination.count)
+                      : `تعداد سطرها: ${pagination.count.toLocaleString('fa-IR')}`}
+                  </Typography>
+                  <TablePagination
+                    component="div"
+                    count={pagination.count}
+                    page={pagination.page}
+                    onPageChange={pagination.onPageChange}
+                    rowsPerPage={pagination.rowsPerPage}
+                    onRowsPerPageChange={pagination.onRowsPerPageChange}
+                    rowsPerPageOptions={pagination.rowsPerPageOptions}
+                    labelRowsPerPage={pagination.labelRowsPerPage}
+                    labelDisplayedRows={pagination.labelDisplayedRows}
+                    sx={{
+                      '& .MuiTablePagination-displayedRows': {
+                        fontFamily: 'var(--font-vazir)',
+                      },
+                      '& .MuiTablePagination-selectLabel': {
+                        fontFamily: 'var(--font-vazir)',
+                      },
+                      '& .MuiTablePagination-input': {
+                        fontFamily: 'var(--font-vazir)',
+                      },
+                    }}
+                  />
+                </Box>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        ) : null}
       </Table>
     </TableContainer>
   );

--- a/src/components/services/ServicesTable.tsx
+++ b/src/components/services/ServicesTable.tsx
@@ -1,5 +1,6 @@
 import { Box, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import type { IconType } from 'react-icons';
 import { FiPlay, FiRefreshCw, FiStopCircle } from 'react-icons/fi';
 import type { DataTableColumn } from '../../@types/dataTable';
@@ -60,6 +61,9 @@ const ServicesTable = ({
   isActionLoading = false,
   activeServiceName = null,
 }: ServicesTableProps) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
   const detailKeys = useMemo(() => {
     const keys = new Set<string>();
 
@@ -74,7 +78,42 @@ const ServicesTable = ({
     return Array.from(keys).sort((a, b) => a.localeCompare(b, 'fa'));
   }, [services]);
 
+  useEffect(() => {
+    if (page > 0 && page * rowsPerPage >= services.length) {
+      const lastPage = Math.max(Math.ceil(services.length / rowsPerPage) - 1, 0);
+      setPage(lastPage);
+    }
+  }, [page, rowsPerPage, services.length]);
+
+  const paginatedServices = useMemo(() => {
+    const start = page * rowsPerPage;
+    const end = start + rowsPerPage;
+
+    return services.slice(start, end);
+  }, [page, rowsPerPage, services]);
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(Number(event.target.value));
+    setPage(0);
+  };
+
   const columns = useMemo<DataTableColumn<ServiceTableRow>[]>(() => {
+    const indexColumn: DataTableColumn<ServiceTableRow> = {
+      id: 'service-index',
+      header: '#',
+      align: 'center',
+      width: 64,
+      renderCell: (_, index) => (
+        <Typography component="span" sx={{ fontWeight: 500 }}>
+          {(page * rowsPerPage + index + 1).toLocaleString('fa-IR')}
+        </Typography>
+      ),
+    };
+
     const baseColumn: DataTableColumn<ServiceTableRow> = {
       id: 'service-name',
       header: 'سرویس',
@@ -130,16 +169,37 @@ const ServicesTable = ({
       },
     };
 
-    return [baseColumn, ...dynamicColumns, actionColumn];
-  }, [activeServiceName, detailKeys, isActionLoading, onAction]);
+    return [indexColumn, baseColumn, ...dynamicColumns, actionColumn];
+  }, [activeServiceName, detailKeys, isActionLoading, onAction, page, rowsPerPage]);
 
   return (
     <DataTable<ServiceTableRow>
       columns={columns}
-      data={services}
+      data={paginatedServices}
       getRowId={(row) => row.name}
       isLoading={isLoading}
       error={error}
+      pagination={{
+        page,
+        rowsPerPage,
+        count: services.length,
+        onPageChange: handleChangePage,
+        onRowsPerPageChange: handleChangeRowsPerPage,
+        rowsPerPageOptions: [5, 10, 25],
+        labelRowsPerPage: 'ردیف در هر صفحه',
+        labelDisplayedRows: ({ from, to, count }) => {
+          const localizedFrom = from.toLocaleString('fa-IR');
+          const localizedTo = to.toLocaleString('fa-IR');
+          const localizedCount =
+            count !== -1
+              ? count.toLocaleString('fa-IR')
+              : `بیش از ${localizedTo}`;
+
+          return `${localizedFrom}–${localizedTo} از ${localizedCount}`;
+        },
+        rowCountFormatter: (count) =>
+          `تعداد کل سرویس‌ها: ${count.toLocaleString('fa-IR')}`,
+      }}
     />
   );
 };


### PR DESCRIPTION
## Summary
- extend the shared `DataTable` to support pagination controls and a footer row count summary
- paginate the services table data set, add localized row numbering, and expose total service count in the footer

## Testing
- npm run build *(fails: existing type errors in unrelated components such as charts and AuthPage)*

------
https://chatgpt.com/codex/tasks/task_b_68da3d1af424832fb089e9db1312a317