### PR TITLE
Add user management table and creation modal

### DIFF
--- a/src/@types/user.ts
+++ b/src/@types/user.ts
@@ -1,0 +1,17 @@
+export type UserPrimitiveValue = string | number | boolean | null | undefined;
+
+export type UserValue = UserPrimitiveValue | UserPrimitiveValue[];
+
+export interface UserRecord {
+  username?: string | null;
+  [key: string]: UserValue;
+}
+
+export interface UsersResponse {
+  data?: UserRecord[];
+}
+
+export interface CreateUserPayload {
+  username: string;
+  login_shell: string;
+}

--- a/src/components/users/CreateUserModal.tsx
+++ b/src/components/users/CreateUserModal.tsx
@@ -1,0 +1,128 @@
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import type { ChangeEvent } from 'react';
+import type { UseCreateUserReturn } from '../../hooks/useCreateUser';
+import BlurModal from '../BlurModal';
+
+interface CreateUserModalProps {
+  controller: UseCreateUserReturn;
+}
+
+const buttonBaseStyles = {
+  borderRadius: '3px',
+  fontWeight: 600,
+};
+
+const inputBaseStyles = {
+  backgroundColor: 'var(--color-input-bg)',
+  borderRadius: '5px',
+  color: 'var(--color-text)',
+  '& fieldset': {
+    borderColor: 'var(--color-input-border)',
+  },
+  '&:hover fieldset': {
+    borderColor: 'var(--color-input-focus-border)',
+  },
+  '&.Mui-focused fieldset': {
+    borderColor: 'var(--color-input-focus-border)',
+  },
+};
+
+const CreateUserModal = ({ controller }: CreateUserModalProps) => {
+  const {
+    isOpen,
+    closeCreateModal,
+    handleSubmit,
+    username,
+    setUsername,
+    loginShell,
+    usernameError,
+    apiError,
+    isCreating,
+  } = controller;
+
+  const handleUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUsername(event.target.value);
+  };
+
+  return (
+    <BlurModal
+      open={isOpen}
+      onClose={closeCreateModal}
+      title="ایجاد کاربر جدید"
+      actions={
+        <>
+          <Button
+            onClick={closeCreateModal}
+            variant="outlined"
+            color="inherit"
+            disabled={isCreating}
+            sx={{ ...buttonBaseStyles, px: 3 }}
+          >
+            انصراف
+          </Button>
+          <Button
+            type="submit"
+            form="create-user-form"
+            variant="contained"
+            disabled={isCreating}
+            sx={{
+              ...buttonBaseStyles,
+              px: 4,
+              background:
+                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+              boxShadow: '0 14px 28px -18px rgba(0, 198, 169, 0.8)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+              },
+            }}
+          >
+            {isCreating ? 'در حال ایجاد…' : 'ایجاد'}
+          </Button>
+        </>
+      }
+    >
+      <Box component="form" id="create-user-form" onSubmit={handleSubmit}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <TextField
+            label="نام کاربری"
+            value={username}
+            onChange={handleUsernameChange}
+            autoFocus
+            fullWidth
+            size="small"
+            error={Boolean(usernameError)}
+            helperText={
+              usernameError ?? 'نام کاربری جدید را وارد کنید (مانند user10).'
+            }
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ sx: inputBaseStyles }}
+          />
+
+          <TextField
+            label="پوسته ورود"
+            value={loginShell}
+            disabled
+            fullWidth
+            size="small"
+            helperText="پوسته پیش‌فرض کاربر جدید تغییرپذیر نیست."
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ sx: inputBaseStyles }}
+          />
+
+          {apiError ? (
+            <Alert severity="error" sx={{ direction: 'rtl' }}>
+              {apiError}
+            </Alert>
+          ) : (
+            <Typography variant="body2" sx={{ color: 'var(--color-secondary)' }}>
+              پس از ایجاد کاربر، جدول کاربران به صورت خودکار به‌روزرسانی می‌شود.
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default CreateUserModal;

--- a/src/components/users/UsersTable.tsx
+++ b/src/components/users/UsersTable.tsx
@@ -1,0 +1,160 @@
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import type { ChangeEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { FiTrash2 } from 'react-icons/fi';
+import type { DataTableColumn } from '../../@types/dataTable';
+import type { UserValue } from '../../@types/user';
+import DataTable from '../DataTable';
+
+interface UserTableRow {
+  id: string;
+  data: Record<string, UserValue>;
+}
+
+interface UsersTableProps {
+  users: UserTableRow[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const formatUserValue = (value: UserValue) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'بله' : 'خیر';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => (item ?? '—').toString()).join(', ');
+  }
+
+  return String(value);
+};
+
+const UsersTable = ({ users, isLoading, error }: UsersTableProps) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  const columnKeys = useMemo(() => {
+    const keys = new Set<string>();
+
+    users.forEach((user) => {
+      Object.keys(user.data).forEach((key) => {
+        keys.add(key);
+      });
+    });
+
+    return Array.from(keys).sort((a, b) => a.localeCompare(b, 'fa'));
+  }, [users]);
+
+  useEffect(() => {
+    if (page > 0 && page * rowsPerPage >= users.length) {
+      const lastPage = Math.max(Math.ceil(users.length / rowsPerPage) - 1, 0);
+      setPage(lastPage);
+    }
+  }, [page, rowsPerPage, users.length]);
+
+  const paginatedUsers = useMemo(() => {
+    const start = page * rowsPerPage;
+    const end = start + rowsPerPage;
+
+    return users.slice(start, end);
+  }, [page, rowsPerPage, users]);
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(Number(event.target.value));
+    setPage(0);
+  };
+
+  const columns = useMemo<DataTableColumn<UserTableRow>[]>(() => {
+    const indexColumn: DataTableColumn<UserTableRow> = {
+      id: 'user-index',
+      header: '#',
+      align: 'center',
+      width: 64,
+      renderCell: (_row, index) => (
+        <Typography component="span" sx={{ fontWeight: 500 }}>
+          {(page * rowsPerPage + index + 1).toLocaleString('fa-IR')}
+        </Typography>
+      ),
+    };
+
+    const dynamicColumns = columnKeys.map<DataTableColumn<UserTableRow>>((key) => ({
+      id: key,
+      header: key,
+      renderCell: (row) => (
+        <Typography component="span" sx={{ color: 'var(--color-text)' }}>
+          {formatUserValue(row.data[key])}
+        </Typography>
+      ),
+    }));
+
+    const actionColumn: DataTableColumn<UserTableRow> = {
+      id: 'user-actions',
+      header: 'عملیات',
+      align: 'center',
+      width: 96,
+      renderCell: () => (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Tooltip title="حذف" arrow>
+            <span>
+              <IconButton
+                size="small"
+                disabled
+                sx={{ color: 'var(--color-error)', opacity: 0.6 }}
+              >
+                <FiTrash2 size={18} />
+              </IconButton>
+            </span>
+          </Tooltip>
+        </Box>
+      ),
+    };
+
+    return [indexColumn, ...dynamicColumns, actionColumn];
+  }, [columnKeys, page, rowsPerPage]);
+
+  return (
+    <DataTable<UserTableRow>
+      columns={columns}
+      data={paginatedUsers}
+      getRowId={(row) => row.id}
+      isLoading={isLoading}
+      error={error}
+      pagination={{
+        page,
+        rowsPerPage,
+        count: users.length,
+        onPageChange: handleChangePage,
+        onRowsPerPageChange: handleChangeRowsPerPage,
+        rowsPerPageOptions: [5, 10, 25],
+        labelRowsPerPage: 'ردیف در هر صفحه',
+        labelDisplayedRows: ({ from, to, count }) => {
+          const localizedFrom = from.toLocaleString('fa-IR');
+          const localizedTo = to.toLocaleString('fa-IR');
+          const localizedCount =
+            count !== -1 ? count.toLocaleString('fa-IR') : `بیش از ${localizedTo}`;
+
+          return `${localizedFrom}–${localizedTo} از ${localizedCount}`;
+        },
+        rowCountFormatter: (count) =>
+          `تعداد کل کاربران: ${count.toLocaleString('fa-IR')}`,
+      }}
+    />
+  );
+};
+
+export type { UserTableRow };
+export default UsersTable;

--- a/src/hooks/useCreateUser.ts
+++ b/src/hooks/useCreateUser.ts
@@ -1,0 +1,109 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { FormEvent } from 'react';
+import { useCallback, useState } from 'react';
+import type { CreateUserPayload } from '../@types/user';
+import axiosInstance from '../lib/axiosInstance';
+import { extractApiErrorMessage } from '../utils/apiError';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { usersQueryKey } from './useUsers';
+
+interface UseCreateUserOptions {
+  onSuccess?: (username: string) => void;
+  onError?: (errorMessage: string) => void;
+}
+
+const defaultLoginShell = '/usr/sbin/nologin';
+
+const createUserRequest = async (payload: CreateUserPayload) => {
+  await axiosInstance.post('/api/os/user/create/', payload);
+};
+
+export const useCreateUser = ({
+  onSuccess,
+  onError,
+}: UseCreateUserOptions = {}) => {
+  const queryClient = useQueryClient();
+  const [isOpen, setIsOpen] = useState(false);
+  const [username, setUsername] = useState('');
+  const [loginShell, setLoginShell] = useState(defaultLoginShell);
+  const [usernameError, setUsernameError] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setUsername('');
+    setLoginShell(defaultLoginShell);
+    setUsernameError(null);
+    setApiError(null);
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    resetForm();
+    setIsOpen(true);
+  }, [resetForm]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    resetForm();
+  }, [resetForm]);
+
+  const createUserMutation = useMutation<
+    unknown,
+    AxiosError<ApiErrorResponse>,
+    CreateUserPayload
+  >({
+    mutationFn: createUserRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: usersQueryKey });
+      handleClose();
+      onSuccess?.(variables.username);
+    },
+    onError: (error) => {
+      const message = extractApiErrorMessage(error);
+      setApiError(message);
+      onError?.(message);
+    },
+  });
+
+  const closeCreateModal = useCallback(() => {
+    createUserMutation.reset();
+    handleClose();
+  }, [createUserMutation, handleClose]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setUsernameError(null);
+      setApiError(null);
+
+      const trimmedUsername = username.trim();
+
+      if (!trimmedUsername) {
+        setUsernameError('لطفاً نام کاربری را وارد کنید.');
+        return;
+      }
+
+      createUserMutation.mutate({
+        username: trimmedUsername,
+        login_shell: loginShell,
+      });
+    },
+    [createUserMutation, loginShell, username]
+  );
+
+  return {
+    isOpen,
+    username,
+    loginShell,
+    usernameError,
+    apiError,
+    isCreating: createUserMutation.isPending,
+    openCreateModal: handleOpen,
+    closeCreateModal,
+    setUsername,
+    setLoginShell,
+    handleSubmit,
+  };
+};
+
+export type UseCreateUserReturn = ReturnType<typeof useCreateUser>;

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import type { UsersResponse } from '../@types/user';
+import axiosInstance from '../lib/axiosInstance';
+
+export const usersQueryKey = ['users'] as const;
+
+const fetchUsers = async () => {
+  const { data } = await axiosInstance.get<UsersResponse>('/api/os/user');
+  return data;
+};
+
+export const useUsers = () =>
+  useQuery<UsersResponse, Error>({
+    queryKey: usersQueryKey,
+    queryFn: fetchUsers,
+    refetchInterval: 5000,
+  });
+
+export type UseUsersReturn = ReturnType<typeof useUsers>;

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,12 +1,105 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import { useCallback, useMemo } from 'react';
+import { toast } from 'react-hot-toast';
+import type { UserValue } from '../@types/user';
+import CreateUserModal from '../components/users/CreateUserModal';
+import UsersTable from '../components/users/UsersTable';
+import { useCreateUser } from '../hooks/useCreateUser';
+import { useUsers } from '../hooks/useUsers';
 
-const Users = () => (
-  <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-    <Typography variant="h5" sx={{ color: 'var(--color-primary)' }}>
-      مدیریت کاربران
-    </Typography>
-  </Box>
-);
+const Users = () => {
+  const usersQuery = useUsers();
+
+  const createUser = useCreateUser({
+    onSuccess: (username) => {
+      toast.success(`کاربر ${username} با موفقیت ایجاد شد.`);
+    },
+    onError: (message) => {
+      toast.error(`ایجاد کاربر با خطا مواجه شد: ${message}`);
+    },
+  });
+  const { openCreateModal } = createUser;
+
+  const users = useMemo(() => {
+    const data = usersQuery.data?.data ?? [];
+
+    return data.map((entry, index) => {
+      const normalizedEntry = Object.entries(entry ?? {}).reduce<
+        Record<string, UserValue>
+      >((accumulator, [key, value]) => {
+        accumulator[key] = value;
+        return accumulator;
+      }, {});
+
+      const username = normalizedEntry.username;
+      const rowId =
+        typeof username === 'string' && username.trim()
+          ? username.trim()
+          : `user-${index + 1}`;
+
+      return {
+        id: rowId,
+        data: normalizedEntry,
+      };
+    });
+  }, [usersQuery.data?.data]);
+
+  const handleOpenCreate = useCallback(() => {
+    openCreateModal();
+  }, [openCreateModal]);
+
+  return (
+    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: 2,
+          }}
+        >
+          <Typography
+            variant="h5"
+            sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+          >
+            مدیریت کاربران
+          </Typography>
+
+          <Button
+            onClick={handleOpenCreate}
+            variant="contained"
+            sx={{
+              px: 3,
+              py: 1.25,
+              borderRadius: '3px',
+              fontWeight: 700,
+              fontSize: '0.95rem',
+              background:
+                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+              color: 'var(--color-bg)',
+              boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+              },
+            }}
+          >
+            ایجاد کاربر جدید
+          </Button>
+        </Box>
+
+        <UsersTable
+          users={users}
+          isLoading={usersQuery.isLoading}
+          error={usersQuery.error ?? null}
+        />
+      </Box>
+
+      <CreateUserModal controller={createUser} />
+    </Box>
+  );
+};
 
 export default Users;
-

--- a/src/utils/apiError.ts
+++ b/src/utils/apiError.ts
@@ -1,0 +1,42 @@
+import type { AxiosError } from 'axios';
+
+export interface ApiErrorResponse {
+  detail?: string;
+  message?: string;
+  errors?: string | string[];
+  [key: string]: unknown;
+}
+
+export const extractApiErrorMessage = (
+  error: AxiosError<ApiErrorResponse>
+): string => {
+  const payload = error.response?.data;
+
+  if (!payload) {
+    return error.message;
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload.detail && typeof payload.detail === 'string') {
+    return payload.detail;
+  }
+
+  if (payload.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  if (payload.errors) {
+    if (Array.isArray(payload.errors)) {
+      return payload.errors.join('، ');
+    }
+
+    if (typeof payload.errors === 'string') {
+      return payload.errors;
+    }
+  }
+
+  return error.message;
+};


### PR DESCRIPTION
## Summary
- add user domain types and shared API error helper
- implement hooks and UI components to display users in a table with delete action placeholder
- update the users page with a create-user modal that submits new accounts

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components errors in contexts)*

------
https://chatgpt.com/codex/tasks/task_b_68da61ca4ef0832f992c56f9b9cf6bc8