### PR TITLE
feat: add os user management interface

### DIFF
--- a/src/@types/users.ts
+++ b/src/@types/users.ts
@@ -1,0 +1,24 @@
+export interface RawOsUserDetails {
+  [key: string]: unknown;
+}
+
+export interface OsUsersResponse {
+  data?: RawOsUserDetails[] | Record<string, RawOsUserDetails>;
+  [key: string]: unknown;
+}
+
+export interface CreateOsUserPayload {
+  username: string;
+  login_shell: string;
+}
+
+export interface OsUserTableItem {
+  id: string;
+  username: string;
+  fullName?: string;
+  uid?: string;
+  gid?: string;
+  homeDirectory?: string;
+  loginShell?: string;
+  raw: RawOsUserDetails;
+}

--- a/src/components/users/OsUserCreateModal.tsx
+++ b/src/components/users/OsUserCreateModal.tsx
@@ -1,0 +1,105 @@
+import {
+  Alert,
+  Box,
+  Button,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { type FormEvent, useEffect, useState } from 'react';
+import type { CreateOsUserPayload } from '../../@types/users';
+import { DEFAULT_LOGIN_SHELL } from '../../constants/users';
+import BlurModal from '../BlurModal';
+
+interface OsUserCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: CreateOsUserPayload) => void;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+}
+
+const OsUserCreateModal = ({
+  open,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+}: OsUserCreateModalProps) => {
+  const [username, setUsername] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setUsername('');
+    }
+  }, [open]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!username.trim()) {
+      return;
+    }
+
+    onSubmit({
+      username: username.trim(),
+      login_shell: DEFAULT_LOGIN_SHELL,
+    });
+  };
+
+  return (
+    <BlurModal
+      open={open}
+      onClose={onClose}
+      title="ایجاد کاربر جدید"
+      actions={
+        <Button
+          type="submit"
+          form="os-user-create-form"
+          variant="contained"
+          disabled={isSubmitting || !username.trim()}
+        >
+          {isSubmitting ? 'در حال ایجاد...' : 'ایجاد کاربر'}
+        </Button>
+      }
+    >
+      <Box
+        component="form"
+        id="os-user-create-form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      >
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          لطفاً اطلاعات کاربر جدید را وارد کنید. پوسته ورود به صورت پیش‌فرض تنظیم
+          شده است.
+        </Typography>
+
+        <TextField
+          label="نام کاربری"
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+          required
+          autoFocus
+          fullWidth
+        />
+
+        <TextField
+          label="پوسته ورود"
+          value={DEFAULT_LOGIN_SHELL}
+          fullWidth
+          disabled
+          InputProps={{
+            sx: { direction: 'ltr' },
+          }}
+        />
+
+        {errorMessage ? (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {errorMessage}
+          </Alert>
+        ) : null}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default OsUserCreateModal;

--- a/src/components/users/OsUsersTable.tsx
+++ b/src/components/users/OsUsersTable.tsx
@@ -1,0 +1,96 @@
+import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import { MdDeleteOutline } from 'react-icons/md';
+import type { DataTableColumn } from '../../@types/dataTable.ts';
+import type { OsUserTableItem } from '../../@types/users';
+import DataTable from '../DataTable';
+
+interface OsUsersTableProps {
+  users: OsUserTableItem[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
+  const columns: DataTableColumn<OsUserTableItem>[] = useMemo(
+    () => [
+      {
+        id: 'index',
+        header: 'ردیف',
+        align: 'center',
+        width: 80,
+        renderCell: (_row, index) => index + 1,
+      },
+      {
+        id: 'username',
+        header: 'نام کاربری',
+        renderCell: (row) => (
+          <Typography sx={{ fontWeight: 600, color: 'var(--color-text)' }}>
+            {row.username}
+          </Typography>
+        ),
+      },
+      {
+        id: 'fullName',
+        header: 'نام کامل',
+        renderCell: (row) => row.fullName ?? '—',
+      },
+      {
+        id: 'uid',
+        header: 'UID',
+        renderCell: (row) => row.uid ?? '—',
+      },
+      {
+        id: 'gid',
+        header: 'GID',
+        renderCell: (row) => row.gid ?? '—',
+      },
+      {
+        id: 'homeDirectory',
+        header: 'مسیر خانه',
+        renderCell: (row) => (
+          <Typography sx={{ direction: 'ltr', textAlign: 'left' }}>
+            {row.homeDirectory ?? '—'}
+          </Typography>
+        ),
+      },
+      {
+        id: 'loginShell',
+        header: 'پوسته ورود',
+        renderCell: (row) => (
+          <Typography sx={{ direction: 'ltr', textAlign: 'left' }}>
+            {row.loginShell ?? '—'}
+          </Typography>
+        ),
+      },
+      {
+        id: 'actions',
+        header: 'عملیات',
+        align: 'center',
+        width: 120,
+        renderCell: () => (
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <Tooltip title="حذف">
+              <IconButton size="small" color="error" disabled>
+                <MdDeleteOutline size={18} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        ),
+      },
+    ],
+    []
+  );
+
+  return (
+    <DataTable<OsUserTableItem>
+      columns={columns}
+      data={users}
+      getRowId={(row) => row.id}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+};
+
+export default OsUsersTable;

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_LOGIN_SHELL = '/usr/sbin/nologin';
+
+export const USERS_TABS = {
+  os: 'os-users',
+  samba: 'samba-users',
+  other: 'other-users',
+} as const;
+
+type UsersTabKeys = keyof typeof USERS_TABS;
+
+export type UsersTabValue = typeof USERS_TABS[UsersTabKeys];

--- a/src/hooks/useCreateOsUser.ts
+++ b/src/hooks/useCreateOsUser.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { CreateOsUserPayload } from '../@types/users';
+import axiosInstance from '../lib/axiosInstance';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { extractApiErrorMessage } from '../utils/apiError';
+import { osUsersBaseQueryKey } from './useOsUsers';
+
+const createOsUserRequest = async (payload: CreateOsUserPayload) => {
+  await axiosInstance.post('/api/os/user/create/', payload);
+};
+
+interface UseCreateOsUserOptions {
+  onSuccess?: (username: string) => void;
+  onError?: (errorMessage: string) => void;
+}
+
+export const useCreateOsUser = ({
+  onSuccess,
+  onError,
+}: UseCreateOsUserOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, AxiosError<ApiErrorResponse>, CreateOsUserPayload>({
+    mutationFn: createOsUserRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: osUsersBaseQueryKey });
+      onSuccess?.(variables.username);
+    },
+    onError: (error) => {
+      const message = extractApiErrorMessage(error);
+      onError?.(message);
+    },
+  });
+};
+
+export type UseCreateOsUserReturn = ReturnType<typeof useCreateOsUser>;

--- a/src/hooks/useOsUsers.ts
+++ b/src/hooks/useOsUsers.ts
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import type { QueryKey } from '@tanstack/react-query';
+import type { OsUsersResponse } from '../@types/users';
+import axiosInstance from '../lib/axiosInstance';
+
+export const osUsersBaseQueryKey = ['os-users'] as const;
+
+export const osUsersQueryKey = (includeSystem: boolean): QueryKey => [
+  ...osUsersBaseQueryKey,
+  { includeSystem },
+];
+
+interface FetchOsUsersParams {
+  includeSystem: boolean;
+  signal?: AbortSignal;
+}
+
+const fetchOsUsers = async ({
+  includeSystem,
+  signal,
+}: FetchOsUsersParams): Promise<OsUsersResponse> => {
+  const { data } = await axiosInstance.request<OsUsersResponse>({
+    url: '/api/os/user',
+    method: 'GET',
+    data: { include_system: includeSystem },
+    signal,
+  });
+
+  return data;
+};
+
+interface UseOsUsersOptions {
+  includeSystem: boolean;
+  enabled?: boolean;
+}
+
+export const useOsUsers = ({
+  includeSystem,
+  enabled = true,
+}: UseOsUsersOptions) =>
+  useQuery<OsUsersResponse, Error>({
+    queryKey: osUsersQueryKey(includeSystem),
+    queryFn: ({ signal }) => fetchOsUsers({ includeSystem, signal }),
+    enabled,
+    staleTime: 15000,
+  });
+
+export type UseOsUsersReturn = ReturnType<typeof useOsUsers>;

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,12 +1,194 @@
-import { Box, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
+import {
+  type ChangeEvent,
+  type ReactNode,
+  type SyntheticEvent,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import { toast } from 'react-hot-toast';
+import type { CreateOsUserPayload } from '../@types/users';
+import { USERS_TABS, type UsersTabValue } from '../constants/users';
+import OsUserCreateModal from '../components/users/OsUserCreateModal';
+import OsUsersTable from '../components/users/OsUsersTable';
+import { useCreateOsUser } from '../hooks/useCreateOsUser';
+import { useOsUsers } from '../hooks/useOsUsers';
+import { normalizeOsUsers } from '../utils/osUsers';
 
-const Users = () => (
-  <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-    <Typography variant="h5" sx={{ color: 'var(--color-primary)' }}>
-      مدیریت کاربران
-    </Typography>
-  </Box>
-);
+const TabPanel = ({
+  value,
+  currentValue,
+  children,
+}: {
+  value: UsersTabValue;
+  currentValue: UsersTabValue;
+  children: ReactNode;
+}) => {
+  if (value !== currentValue) {
+    return null;
+  }
+
+  return <Box sx={{ mt: 3 }}>{children}</Box>;
+};
+
+const Users = () => {
+  const [activeTab, setActiveTab] = useState<UsersTabValue>(USERS_TABS.os);
+  const [includeSystem, setIncludeSystem] = useState(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const osUsersQuery = useOsUsers({
+    includeSystem,
+    enabled: activeTab === USERS_TABS.os,
+  });
+
+  const osUsers = useMemo(
+    () => normalizeOsUsers(osUsersQuery.data?.data),
+    [osUsersQuery.data?.data]
+  );
+
+  const createOsUser = useCreateOsUser({
+    onSuccess: (username) => {
+      toast.success(`کاربر ${username} با موفقیت ایجاد شد.`);
+      setIsCreateModalOpen(false);
+      setCreateError(null);
+    },
+    onError: (message) => {
+      setCreateError(message);
+      toast.error(`ایجاد کاربر با خطا مواجه شد: ${message}`);
+    },
+  });
+
+  const handleTabChange = useCallback(
+    (_: SyntheticEvent, value: UsersTabValue) => {
+      setActiveTab(value);
+    },
+    []
+  );
+
+  const handleToggleIncludeSystem = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setIncludeSystem(event.target.checked);
+    },
+    []
+  );
+
+  const handleOpenCreateModal = useCallback(() => {
+    setCreateError(null);
+    createOsUser.reset();
+    setIsCreateModalOpen(true);
+  }, [createOsUser]);
+
+  const handleCloseCreateModal = useCallback(() => {
+    setIsCreateModalOpen(false);
+    setCreateError(null);
+    createOsUser.reset();
+  }, [createOsUser]);
+
+  const handleSubmitCreateUser = useCallback(
+    (payload: CreateOsUserPayload) => {
+      createOsUser.mutate(payload);
+    },
+    [createOsUser]
+  );
+
+  return (
+    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
+      <Typography variant="h5" sx={{ color: 'var(--color-primary)', fontWeight: 700 }}>
+        مدیریت کاربران
+      </Typography>
+
+      <Tabs
+        value={activeTab}
+        onChange={handleTabChange}
+        sx={{ mt: 2 }}
+        textColor="primary"
+        indicatorColor="primary"
+      >
+        <Tab label="کاربران سیستم عامل" value={USERS_TABS.os} />
+        <Tab label="کاربران samba" value={USERS_TABS.samba} />
+        <Tab label="سایر کاربران" value={USERS_TABS.other} />
+      </Tabs>
+
+      <TabPanel value={USERS_TABS.os} currentValue={activeTab}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+            }}
+          >
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={includeSystem}
+                  onChange={handleToggleIncludeSystem}
+                  color="primary"
+                />
+              }
+              label="نمایش کاربران سیستمی"
+            />
+
+            <Button
+              onClick={handleOpenCreateModal}
+              variant="contained"
+              sx={{
+                px: 3,
+                py: 1.25,
+                borderRadius: '3px',
+                fontWeight: 700,
+                fontSize: '0.95rem',
+                background:
+                  'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+                color: 'var(--color-bg)',
+                boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
+              }}
+            >
+              ایجاد کاربر جدید
+            </Button>
+          </Box>
+
+          <OsUsersTable
+            users={osUsers}
+            isLoading={osUsersQuery.isLoading || osUsersQuery.isFetching}
+            error={osUsersQuery.error ?? null}
+          />
+        </Box>
+      </TabPanel>
+
+      <TabPanel value={USERS_TABS.samba} currentValue={activeTab}>
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          مدیریت کاربران Samba به‌زودی افزوده می‌شود.
+        </Typography>
+      </TabPanel>
+
+      <TabPanel value={USERS_TABS.other} currentValue={activeTab}>
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          بخش سایر کاربران در دست توسعه است.
+        </Typography>
+      </TabPanel>
+
+      <OsUserCreateModal
+        open={isCreateModalOpen}
+        onClose={handleCloseCreateModal}
+        onSubmit={handleSubmitCreateUser}
+        isSubmitting={createOsUser.isPending}
+        errorMessage={createError}
+      />
+    </Box>
+  );
+};
 
 export default Users;
-

--- a/src/utils/apiError.ts
+++ b/src/utils/apiError.ts
@@ -1,0 +1,42 @@
+import type { AxiosError } from 'axios';
+
+export interface ApiErrorResponse {
+  detail?: string;
+  message?: string;
+  errors?: string | string[];
+  [key: string]: unknown;
+}
+
+export const extractApiErrorMessage = (
+  error: AxiosError<ApiErrorResponse>
+): string => {
+  const payload = error.response?.data;
+
+  if (!payload) {
+    return error.message;
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload.detail && typeof payload.detail === 'string') {
+    return payload.detail;
+  }
+
+  if (payload.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  if (payload.errors) {
+    if (Array.isArray(payload.errors)) {
+      return payload.errors.join('، ');
+    }
+
+    if (typeof payload.errors === 'string') {
+      return payload.errors;
+    }
+  }
+
+  return error.message;
+};

--- a/src/utils/osUsers.ts
+++ b/src/utils/osUsers.ts
@@ -1,0 +1,94 @@
+import type { OsUserTableItem, RawOsUserDetails } from '../@types/users';
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() ? value : undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+};
+
+const pickFirstValue = (
+  record: RawOsUserDetails,
+  keys: string[]
+): string | undefined => {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      const value = record[key];
+      const normalized = toOptionalString(value);
+
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const normalizeRecord = (
+  identifier: string,
+  value: unknown,
+  index: number
+): OsUserTableItem => {
+  const record =
+    typeof value === 'object' && value !== null
+      ? (value as RawOsUserDetails)
+      : ({} as RawOsUserDetails);
+
+  const resolvedUsername =
+    pickFirstValue(record, ['username', 'user', 'name']) ?? identifier;
+
+  const username = resolvedUsername || `user-${index + 1}`;
+  const uid = pickFirstValue(record, ['uid', 'user_id', 'userId']);
+  const gid = pickFirstValue(record, ['gid', 'group_id', 'groupId']);
+  const fullName = pickFirstValue(record, ['full_name', 'gecos', 'displayName']);
+  const homeDirectory = pickFirstValue(record, [
+    'home_directory',
+    'homeDirectory',
+    'home',
+    'directory',
+    'homeDir',
+  ]);
+  const loginShell = pickFirstValue(record, [
+    'login_shell',
+    'loginShell',
+    'shell',
+    'shell_path',
+  ]);
+
+  return {
+    id: username || `user-${index + 1}`,
+    username,
+    fullName,
+    uid,
+    gid,
+    homeDirectory,
+    loginShell,
+    raw: record,
+  };
+};
+
+export const normalizeOsUsers = (
+  data: RawOsUserDetails[] | Record<string, RawOsUserDetails> | undefined
+): OsUserTableItem[] => {
+  if (!data) {
+    return [];
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((entry, index) => normalizeRecord(String(index + 1), entry, index));
+  }
+
+  return Object.entries(data).map(([key, entry], index) =>
+    normalizeRecord(key, entry, index)
+  );
+};


### PR DESCRIPTION
## Summary
- add a tabbed layout to the Users page with an OS user table and management controls
- introduce hooks and utilities for loading and creating OS users with optional system entries
- add a modal workflow for creating OS users with the default login shell preset

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in contexts present before this change)*

------
https://chatgpt.com/codex/tasks/task_b_68da6684d3e8832f866779f96f58d8d7