### PR TITLE
Improve OS users management UI

### DIFF
--- a/src/@types/users.ts
+++ b/src/@types/users.ts
@@ -9,7 +9,8 @@ export interface OsUsersResponse {
 
 export interface CreateOsUserPayload {
   username: string;
-  login_shell: string;
+  login_shell?: string;
+  shell?: string;
 }
 
 export interface OsUserTableItem {

--- a/src/components/users/OsUserCreateModal.tsx
+++ b/src/components/users/OsUserCreateModal.tsx
@@ -43,6 +43,7 @@ const OsUserCreateModal = ({
     onSubmit({
       username: username.trim(),
       login_shell: DEFAULT_LOGIN_SHELL,
+      shell: DEFAULT_LOGIN_SHELL,
     });
   };
 
@@ -57,6 +58,22 @@ const OsUserCreateModal = ({
           form="os-user-create-form"
           variant="contained"
           disabled={isSubmitting || !username.trim()}
+          sx={{
+            px: 3,
+            py: 1,
+            fontWeight: 600,
+            background:
+              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+            color: 'var(--color-bg)',
+            '&:hover': {
+              background:
+                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+            },
+            '&.Mui-disabled': {
+              backgroundColor: 'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+              color: 'var(--color-secondary)',
+            },
+          }}
         >
           {isSubmitting ? 'در حال ایجاد...' : 'ایجاد کاربر'}
         </Button>
@@ -80,6 +97,14 @@ const OsUserCreateModal = ({
           required
           autoFocus
           fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
         />
 
         <TextField
@@ -88,8 +113,14 @@ const OsUserCreateModal = ({
           fullWidth
           disabled
           InputProps={{
-            sx: { direction: 'ltr' },
+            sx: {
+              direction: 'ltr',
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-secondary)' },
+            },
           }}
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
         />
 
         {errorMessage ? (

--- a/src/components/users/OsUsersTable.tsx
+++ b/src/components/users/OsUsersTable.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton, Tooltip, Typography } from '@mui/material';
-import { useMemo } from 'react';
+import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
 import { MdDeleteOutline } from 'react-icons/md';
 import type { DataTableColumn } from '../../@types/dataTable.ts';
 import type { OsUserTableItem } from '../../@types/users';
@@ -12,54 +12,54 @@ interface OsUsersTableProps {
 }
 
 const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  useEffect(() => {
+    if (page > 0 && page * rowsPerPage >= users.length) {
+      const lastPage = Math.max(Math.ceil(users.length / rowsPerPage) - 1, 0);
+      setPage(lastPage);
+    }
+  }, [page, rowsPerPage, users.length]);
+
+  const paginatedUsers = useMemo(() => {
+    const start = page * rowsPerPage;
+    const end = start + rowsPerPage;
+
+    return users.slice(start, end);
+  }, [page, rowsPerPage, users]);
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(Number(event.target.value));
+    setPage(0);
+  };
+
   const columns: DataTableColumn<OsUserTableItem>[] = useMemo(
     () => [
       {
         id: 'index',
-        header: 'ردیف',
+        header: '#',
         align: 'center',
-        width: 80,
-        renderCell: (_row, index) => index + 1,
+        width: 64,
+        renderCell: (_row, index) => (
+          <Typography component="span" sx={{ fontWeight: 600 }}>
+            {(page * rowsPerPage + index + 1).toLocaleString('fa-IR')}
+          </Typography>
+        ),
       },
       {
         id: 'username',
         header: 'نام کاربری',
         renderCell: (row) => (
-          <Typography sx={{ fontWeight: 600, color: 'var(--color-text)' }}>
+          <Typography
+            component="span"
+            sx={{ fontWeight: 600, color: 'var(--color-text)' }}
+          >
             {row.username}
-          </Typography>
-        ),
-      },
-      {
-        id: 'fullName',
-        header: 'نام کامل',
-        renderCell: (row) => row.fullName ?? '—',
-      },
-      {
-        id: 'uid',
-        header: 'UID',
-        renderCell: (row) => row.uid ?? '—',
-      },
-      {
-        id: 'gid',
-        header: 'GID',
-        renderCell: (row) => row.gid ?? '—',
-      },
-      {
-        id: 'homeDirectory',
-        header: 'مسیر خانه',
-        renderCell: (row) => (
-          <Typography sx={{ direction: 'ltr', textAlign: 'left' }}>
-            {row.homeDirectory ?? '—'}
-          </Typography>
-        ),
-      },
-      {
-        id: 'loginShell',
-        header: 'پوسته ورود',
-        renderCell: (row) => (
-          <Typography sx={{ direction: 'ltr', textAlign: 'left' }}>
-            {row.loginShell ?? '—'}
           </Typography>
         ),
       },
@@ -70,25 +70,58 @@ const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
         width: 120,
         renderCell: () => (
           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-            <Tooltip title="حذف">
-              <IconButton size="small" color="error" disabled>
-                <MdDeleteOutline size={18} />
-              </IconButton>
+            <Tooltip title="حذف" arrow>
+              <span>
+                <IconButton
+                  size="small"
+                  disabled
+                  sx={{
+                    color: 'var(--color-error)',
+                    '&.Mui-disabled': {
+                      color: 'var(--color-secondary)',
+                      opacity: 0.6,
+                    },
+                  }}
+                >
+                  <MdDeleteOutline size={18} />
+                </IconButton>
+              </span>
             </Tooltip>
           </Box>
         ),
       },
     ],
-    []
+    [page, rowsPerPage]
   );
 
   return (
     <DataTable<OsUserTableItem>
       columns={columns}
-      data={users}
+      data={paginatedUsers}
       getRowId={(row) => row.id}
       isLoading={isLoading}
       error={error}
+      pagination={{
+        page,
+        rowsPerPage,
+        count: users.length,
+        onPageChange: handleChangePage,
+        onRowsPerPageChange: handleChangeRowsPerPage,
+        rowsPerPageOptions: [5, 10, 25],
+        labelRowsPerPage: 'ردیف در هر صفحه',
+        labelDisplayedRows: ({ from, to, count }) => {
+          const localizedFrom = from.toLocaleString('fa-IR');
+          const localizedTo = to.toLocaleString('fa-IR');
+          const localizedCount =
+            count !== -1
+              ? count.toLocaleString('fa-IR')
+              : `بیش از ${localizedTo}`;
+
+          return `${localizedFrom}–${localizedTo} از ${localizedCount}`;
+        },
+        rowCountFormatter: (count) =>
+          `تعداد کل کاربران: ${count.toLocaleString('fa-IR')}`,
+      }}
     />
   );
 };

--- a/src/constants/dataTable.ts
+++ b/src/constants/dataTable.ts
@@ -28,7 +28,9 @@ export const defaultBodyRowSx: SxProps<Theme> = {
     fontSize: '0.92rem',
   },
   '&:hover': {
-    backgroundColor: 'rgba(0, 198, 169, 0.08)',
+    backgroundColor:
+      'color-mix(in srgb, var(--color-primary) 12%, transparent)',
+    transition: 'background-color 0.2s ease',
   },
 };
 

--- a/src/hooks/useCreateOsUser.ts
+++ b/src/hooks/useCreateOsUser.ts
@@ -6,8 +6,18 @@ import type { ApiErrorResponse } from '../utils/apiError';
 import { extractApiErrorMessage } from '../utils/apiError';
 import { osUsersBaseQueryKey } from './useOsUsers';
 
-const createOsUserRequest = async (payload: CreateOsUserPayload) => {
-  await axiosInstance.post('/api/os/user/create/', payload);
+const createOsUserRequest = async ({
+  username,
+  login_shell,
+  shell,
+}: CreateOsUserPayload) => {
+  const resolvedShell = shell ?? login_shell;
+
+  await axiosInstance.post('/api/os/user/create/', {
+    username,
+    login_shell: login_shell ?? resolvedShell,
+    shell: resolvedShell,
+  });
 };
 
 interface UseCreateOsUserOptions {

--- a/src/hooks/useOsUsers.ts
+++ b/src/hooks/useOsUsers.ts
@@ -19,10 +19,8 @@ const fetchOsUsers = async ({
   includeSystem,
   signal,
 }: FetchOsUsersParams): Promise<OsUsersResponse> => {
-  const { data } = await axiosInstance.request<OsUsersResponse>({
-    url: '/api/os/user',
-    method: 'GET',
-    data: { include_system: includeSystem },
+  const { data } = await axiosInstance.get<OsUsersResponse>('/api/os/user', {
+    params: { include_system: includeSystem },
     signal,
   });
 

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -102,17 +102,37 @@ const Users = () => {
   );
 
   return (
-    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-      <Typography variant="h5" sx={{ color: 'var(--color-primary)', fontWeight: 700 }}>
+    <Box
+      sx={{
+        p: 3,
+        fontFamily: 'var(--font-vazir)',
+        backgroundColor: 'var(--color-background)',
+        minHeight: '100%',
+      }}
+    >
+      <Typography
+        variant="h5"
+        sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+      >
         مدیریت کاربران
       </Typography>
 
       <Tabs
         value={activeTab}
         onChange={handleTabChange}
-        sx={{ mt: 2 }}
-        textColor="primary"
-        indicatorColor="primary"
+        sx={{
+          mt: 2,
+          '& .MuiTab-root': {
+            color: 'var(--color-secondary)',
+            fontWeight: 600,
+            '&.Mui-selected': {
+              color: 'var(--color-primary)',
+            },
+          },
+          '& .MuiTabs-indicator': {
+            backgroundColor: 'var(--color-primary)',
+          },
+        }}
       >
         <Tab label="کاربران سیستم عامل" value={USERS_TABS.os} />
         <Tab label="کاربران samba" value={USERS_TABS.samba} />
@@ -135,10 +155,21 @@ const Users = () => {
                 <Checkbox
                   checked={includeSystem}
                   onChange={handleToggleIncludeSystem}
-                  color="primary"
+                  sx={{
+                    color: 'var(--color-secondary)',
+                    '&.Mui-checked': {
+                      color: 'var(--color-primary)',
+                    },
+                  }}
                 />
               }
               label="نمایش کاربران سیستمی"
+              sx={{
+                '& .MuiTypography-root': {
+                  color: 'var(--color-secondary)',
+                  fontWeight: 600,
+                },
+              }}
             />
 
             <Button
@@ -151,9 +182,14 @@ const Users = () => {
                 fontWeight: 700,
                 fontSize: '0.95rem',
                 background:
-                  'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+                  'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
                 color: 'var(--color-bg)',
-                boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
+                boxShadow:
+                  '0 16px 32px -18px color-mix(in srgb, var(--color-primary) 55%, transparent)',
+                '&:hover': {
+                  background:
+                    'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+                },
               }}
             >
               ایجاد کاربر جدید


### PR DESCRIPTION
## Summary
- redesign the OS users tab to use the shared table component with pagination and styling that matches the rest of the app
- send the include_system flag via query parameters and align the create user payload and modal styling with the defined color palette

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68da6cb55484832fbcb5003d5265bed1