### PR TITLE
Handle OS user API responses with username string arrays

### DIFF
--- a/src/@types/users.ts
+++ b/src/@types/users.ts
@@ -1,6 +1,4 @@
-export interface RawOsUserDetails {
-  [key: string]: unknown;
-}
+export type RawOsUserDetails = string | Record<string, unknown>;
 
 export interface OsUsersResponse {
   data?: RawOsUserDetails[] | Record<string, RawOsUserDetails>;

--- a/src/utils/osUsers.ts
+++ b/src/utils/osUsers.ts
@@ -17,7 +17,7 @@ const toOptionalString = (value: unknown): string | undefined => {
 };
 
 const pickFirstValue = (
-  record: RawOsUserDetails,
+  record: Record<string, unknown>,
   keys: string[]
 ): string | undefined => {
   for (const key of keys) {
@@ -39,13 +39,20 @@ const normalizeRecord = (
   value: unknown,
   index: number
 ): OsUserTableItem => {
+  const normalizedIdentifier = toOptionalString(identifier);
+  const usernameFromValue =
+    typeof value === 'string' ? toOptionalString(value) : undefined;
+
   const record =
     typeof value === 'object' && value !== null
-      ? (value as RawOsUserDetails)
-      : ({} as RawOsUserDetails);
+      ? (value as Record<string, unknown>)
+      : {};
 
   const resolvedUsername =
-    pickFirstValue(record, ['username', 'user', 'name']) ?? identifier;
+    usernameFromValue ??
+    pickFirstValue(record, ['username', 'user', 'name']) ??
+    normalizedIdentifier ??
+    `user-${index + 1}`;
 
   const username = resolvedUsername || `user-${index + 1}`;
   const uid = pickFirstValue(record, ['uid', 'user_id', 'userId']);
@@ -65,15 +72,20 @@ const normalizeRecord = (
     'shell_path',
   ]);
 
+  const raw: RawOsUserDetails =
+    typeof value === 'object' && value !== null
+      ? record
+      : usernameFromValue ?? username;
+
   return {
-    id: username || `user-${index + 1}`,
+    id: username,
     username,
     fullName,
     uid,
     gid,
     homeDirectory,
     loginShell,
-    raw: record,
+    raw,
   };
 };
 


### PR DESCRIPTION
## Summary
- allow OS user payloads to include raw string usernames
- update OS user normalization to read usernames from string entries while preserving metadata

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components errors in context files)*

------
https://chatgpt.com/codex/tasks/task_b_68da7685a264832fabb2fad9103ae118