### PR TITLE
feat: add samba user management

### DIFF
--- a/src/@types/samba.ts
+++ b/src/@types/samba.ts
@@ -20,3 +20,42 @@ export interface CreateSambaSharePayload {
   full_path: string;
   valid_users: string;
 }
+
+export type RawSambaUserDetails = Record<string, unknown>;
+
+export type SambaUsersResponseData =
+  | RawSambaUserDetails[]
+  | Record<string, RawSambaUserDetails>;
+
+export interface SambaUsersResponse {
+  data?: SambaUsersResponseData;
+  [key: string]: unknown;
+}
+
+export interface SambaUserTableItem {
+  id: string;
+  username: string;
+  domain?: string;
+  profilePath?: string;
+  passwordMustChange?: string;
+  logonTime?: string;
+  logoffTime?: string;
+  kickoffTime?: string;
+  passwordLastSet?: string;
+  passwordCanChange?: string;
+  details: Record<string, string>;
+}
+
+export interface CreateSambaUserPayload {
+  username: string;
+  password: string;
+}
+
+export interface EnableSambaUserPayload {
+  username: string;
+}
+
+export interface UpdateSambaUserPasswordPayload {
+  username: string;
+  new_password: string;
+}

--- a/src/components/users/SambaUserCreateModal.tsx
+++ b/src/components/users/SambaUserCreateModal.tsx
@@ -1,0 +1,131 @@
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import { type FormEvent, useEffect, useState } from 'react';
+import type { CreateSambaUserPayload } from '../../@types/samba';
+import BlurModal from '../BlurModal';
+
+interface SambaUserCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: CreateSambaUserPayload) => void;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+}
+
+const SambaUserCreateModal = ({
+  open,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+}: SambaUserCreateModalProps) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setUsername('');
+      setPassword('');
+    }
+  }, [open]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!username.trim() || !password) {
+      return;
+    }
+
+    onSubmit({
+      username: username.trim(),
+      password,
+    });
+  };
+
+  return (
+    <BlurModal
+      open={open}
+      onClose={onClose}
+      title="ایجاد کاربر Samba"
+      actions={
+        <Button
+          type="submit"
+          form="samba-user-create-form"
+          variant="contained"
+          disabled={isSubmitting || !username.trim() || !password}
+          sx={{
+            px: 3,
+            py: 1,
+            fontWeight: 600,
+            background:
+              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+            color: 'var(--color-bg)',
+            '&:hover': {
+              background:
+                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+            },
+            '&.Mui-disabled': {
+              backgroundColor:
+                'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+              color: 'var(--color-secondary)',
+            },
+          }}
+        >
+          {isSubmitting ? 'در حال ایجاد...' : 'ایجاد کاربر'}
+        </Button>
+      }
+    >
+      <Box
+        component="form"
+        id="samba-user-create-form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      >
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          برای ایجاد کاربر Samba جدید، نام کاربری و گذرواژه را وارد کنید.
+        </Typography>
+
+        <TextField
+          label="نام کاربری"
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+          required
+          fullWidth
+          autoFocus
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
+        />
+
+        <TextField
+          label="گذرواژه"
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+          fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
+        />
+
+        {errorMessage ? (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {errorMessage}
+          </Alert>
+        ) : null}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default SambaUserCreateModal;

--- a/src/components/users/SambaUserPasswordModal.tsx
+++ b/src/components/users/SambaUserPasswordModal.tsx
@@ -1,0 +1,130 @@
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import { type FormEvent, useEffect, useState } from 'react';
+import type { UpdateSambaUserPasswordPayload } from '../../@types/samba';
+import BlurModal from '../BlurModal';
+
+interface SambaUserPasswordModalProps {
+  open: boolean;
+  username: string | null;
+  onClose: () => void;
+  onSubmit: (payload: UpdateSambaUserPasswordPayload) => void;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+}
+
+const SambaUserPasswordModal = ({
+  open,
+  username,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+}: SambaUserPasswordModalProps) => {
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setPassword('');
+    }
+  }, [open]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!username || !password) {
+      return;
+    }
+
+    onSubmit({
+      username,
+      new_password: password,
+    });
+  };
+
+  return (
+    <BlurModal
+      open={open}
+      onClose={onClose}
+      title="تغییر گذرواژه کاربر"
+      actions={
+        <Button
+          type="submit"
+          form="samba-user-password-form"
+          variant="contained"
+          disabled={isSubmitting || !username || !password}
+          sx={{
+            px: 3,
+            py: 1,
+            fontWeight: 600,
+            background:
+              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+            color: 'var(--color-bg)',
+            '&:hover': {
+              background:
+                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+            },
+            '&.Mui-disabled': {
+              backgroundColor:
+                'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+              color: 'var(--color-secondary)',
+            },
+          }}
+        >
+          {isSubmitting ? 'در حال بروزرسانی...' : 'ثبت گذرواژه جدید'}
+        </Button>
+      }
+    >
+      <Box
+        component="form"
+        id="samba-user-password-form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      >
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          گذرواژه جدید برای کاربر انتخاب‌شده را وارد کنید. نام کاربری قابل تغییر
+          نیست.
+        </Typography>
+
+        <TextField
+          label="نام کاربری"
+          value={username ?? ''}
+          disabled
+          fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-secondary)' },
+            },
+          }}
+        />
+
+        <TextField
+          label="گذرواژه جدید"
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+          fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
+        />
+
+        {errorMessage ? (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {errorMessage}
+          </Alert>
+        ) : null}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default SambaUserPasswordModal;

--- a/src/components/users/SambaUsersTable.tsx
+++ b/src/components/users/SambaUsersTable.tsx
@@ -1,0 +1,238 @@
+import { Box, Checkbox, IconButton, Tooltip, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import {
+  MdDeleteOutline,
+  MdLockOpen,
+  MdLockReset,
+} from 'react-icons/md';
+import type { DataTableColumn } from '../../@types/dataTable';
+import type { SambaUserTableItem } from '../../@types/samba';
+import DataTable from '../DataTable';
+
+interface SambaUsersTableProps {
+  users: SambaUserTableItem[];
+  isLoading: boolean;
+  error: Error | null;
+  selectedUsers: string[];
+  onToggleSelect: (user: SambaUserTableItem, checked: boolean) => void;
+  onEnable: (user: SambaUserTableItem) => void;
+  onEditPassword: (user: SambaUserTableItem) => void;
+  pendingEnableUsername: string | null;
+  isEnabling: boolean;
+  pendingPasswordUsername: string | null;
+  isUpdatingPassword: boolean;
+}
+
+const valueOrDash = (value?: string) => (value && value.trim() ? value : '-');
+
+const SambaUsersTable = ({
+  users,
+  isLoading,
+  error,
+  selectedUsers,
+  onToggleSelect,
+  onEnable,
+  onEditPassword,
+  pendingEnableUsername,
+  isEnabling,
+  pendingPasswordUsername,
+  isUpdatingPassword,
+}: SambaUsersTableProps) => {
+  const columns = useMemo<DataTableColumn<SambaUserTableItem>[]>(() => {
+    return [
+      {
+        id: 'select',
+        header: '',
+        align: 'center',
+        padding: 'checkbox',
+        width: 52,
+        headerSx: { width: 52 },
+        cellSx: { width: 52 },
+        getCellProps: () => ({ padding: 'checkbox' }),
+        renderCell: (user) => (
+          <Checkbox
+            checked={selectedUsers.includes(user.username)}
+            onChange={(event) => onToggleSelect(user, event.target.checked)}
+            color="primary"
+            inputProps={{ 'aria-label': `انتخاب ${user.username}` }}
+          />
+        ),
+      },
+      {
+        id: 'index',
+        header: '#',
+        align: 'center',
+        width: 60,
+        renderCell: (_user, index) => (
+          <Typography sx={{ fontWeight: 600, color: 'var(--color-text)' }}>
+            {index + 1}
+          </Typography>
+        ),
+      },
+      {
+        id: 'username',
+        header: 'نام کاربری',
+        align: 'left',
+        renderCell: (user) => (
+          <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+            {user.username}
+          </Typography>
+        ),
+      },
+      {
+        id: 'domain',
+        header: 'دامنه',
+        align: 'left',
+        renderCell: (user) => (
+          <Typography sx={{ color: 'var(--color-text)' }}>
+            {valueOrDash(user.domain)}
+          </Typography>
+        ),
+      },
+      {
+        id: 'profile-path',
+        header: 'مسیر پروفایل',
+        align: 'left',
+        renderCell: (user) => (
+          <Typography
+            sx={{
+              color: 'var(--color-text)',
+              direction: 'ltr',
+              wordBreak: 'break-all',
+              fontFamily: 'var(--font-vazir)',
+            }}
+          >
+            {valueOrDash(user.profilePath)}
+          </Typography>
+        ),
+      },
+      {
+        id: 'password-must-change',
+        header: 'تغییر اجباری گذرواژه',
+        align: 'left',
+        renderCell: (user) => (
+          <Typography sx={{ color: 'var(--color-text)' }}>
+            {valueOrDash(user.passwordMustChange)}
+          </Typography>
+        ),
+      },
+      {
+        id: 'logon-time',
+        header: 'زمان ورود',
+        align: 'left',
+        renderCell: (user) => (
+          <Typography sx={{ color: 'var(--color-text)' }}>
+            {valueOrDash(user.logonTime)}
+          </Typography>
+        ),
+      },
+      {
+        id: 'actions',
+        header: 'عملیات',
+        align: 'center',
+        width: 168,
+        renderCell: (user) => {
+          const isEnablePending = isEnabling && pendingEnableUsername === user.username;
+          const isPasswordPending =
+            isUpdatingPassword && pendingPasswordUsername === user.username;
+
+          return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5 }}>
+              <Tooltip title="حذف" arrow>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled
+                    sx={{
+                      color: 'var(--color-error)',
+                      '&.Mui-disabled': {
+                        color: 'var(--color-secondary)',
+                        opacity: 0.6,
+                      },
+                    }}
+                  >
+                    <MdDeleteOutline size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+
+              <Tooltip title="فعال‌سازی کاربر" arrow>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => onEnable(user)}
+                    disabled={isEnablePending}
+                    sx={{
+                      color: 'var(--color-success)',
+                      '&.Mui-disabled': {
+                        color: 'var(--color-secondary)',
+                        opacity: 0.7,
+                      },
+                    }}
+                  >
+                    <MdLockOpen size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+
+              <Tooltip title="تغییر گذرواژه" arrow>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => onEditPassword(user)}
+                    disabled={isPasswordPending}
+                    sx={{
+                      color: 'var(--color-primary)',
+                      '&.Mui-disabled': {
+                        color: 'var(--color-secondary)',
+                        opacity: 0.7,
+                      },
+                    }}
+                  >
+                    <MdLockReset size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          );
+        },
+      },
+    ];
+  }, [
+    isEnabling,
+    isUpdatingPassword,
+    onEditPassword,
+    onEnable,
+    onToggleSelect,
+    pendingEnableUsername,
+    pendingPasswordUsername,
+    selectedUsers,
+  ]);
+
+  return (
+    <DataTable<SambaUserTableItem>
+      columns={columns}
+      data={users}
+      getRowId={(user) => user.id}
+      isLoading={isLoading}
+      error={error}
+      renderLoadingState={() => (
+        <Typography sx={{ color: 'var(--color-secondary)', py: 3 }}>
+          در حال دریافت اطلاعات کاربران Samba...
+        </Typography>
+      )}
+      renderErrorState={(tableError) => (
+        <Typography sx={{ color: 'var(--color-error)', py: 3 }}>
+          خطا در دریافت کاربران Samba: {tableError.message}
+        </Typography>
+      )}
+      renderEmptyState={() => (
+        <Typography sx={{ color: 'var(--color-secondary)', py: 3 }}>
+          کاربری برای نمایش وجود ندارد.
+        </Typography>
+      )}
+    />
+  );
+};
+
+export default SambaUsersTable;

--- a/src/components/users/SelectedSambaUsersDetailsPanel.tsx
+++ b/src/components/users/SelectedSambaUsersDetailsPanel.tsx
@@ -1,0 +1,181 @@
+import { Box, IconButton, Typography, useTheme } from '@mui/material';
+import { MdClose } from 'react-icons/md';
+import type { SambaUserTableItem } from '../../@types/samba';
+import formatDetailValue from '../../utils/formatDetailValue';
+
+interface SelectedSambaUsersDetailsPanelProps {
+  items: SambaUserTableItem[];
+  onRemove: (username: string) => void;
+}
+
+const SelectedSambaUsersDetailsPanel = ({
+  items,
+  onRemove,
+}: SelectedSambaUsersDetailsPanelProps) => {
+  const theme = useTheme();
+  const dividerColor =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.08)'
+      : 'rgba(0, 0, 0, 0.08)';
+  const listBackground =
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.04)'
+      : 'rgba(0, 0, 0, 0.03)';
+
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        mt: 3,
+        borderRadius: 3,
+        border: '1px solid var(--color-input-border)',
+        backgroundColor: 'var(--color-card-bg)',
+        boxShadow: '0 20px 45px -25px rgba(0, 0, 0, 0.35)',
+        p: 3,
+      }}
+    >
+      <Typography
+        variant="h6"
+        sx={{
+          mb: 3,
+          fontWeight: 700,
+          color: 'var(--color-primary)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        مقایسه جزئیات کاربران Samba
+      </Typography>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2.5,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+        }}
+      >
+        {items.map((item) => {
+          const entries = Object.entries(item.details ?? {}).sort(([a], [b]) =>
+            a.localeCompare(b, 'fa-IR')
+          );
+
+          return (
+            <Box
+              key={item.username}
+              sx={{
+                borderRadius: 2,
+                border: `1px solid ${dividerColor}`,
+                backgroundColor:
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(0, 0, 0, 0.35)'
+                    : 'rgba(255, 255, 255, 0.9)',
+                p: 2.5,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1.5,
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    color: 'var(--color-text)',
+                    fontSize: '1rem',
+                  }}
+                >
+                  {item.username}
+                </Typography>
+
+                <IconButton
+                  aria-label={`حذف ${item.username} از مقایسه`}
+                  size="small"
+                  onClick={() => onRemove(item.username)}
+                  sx={{ color: 'var(--color-secondary)' }}
+                >
+                  <MdClose size={18} />
+                </IconButton>
+              </Box>
+
+              {entries.length === 0 && (
+                <Typography sx={{ color: 'var(--color-secondary)' }}>
+                  اطلاعاتی برای نمایش وجود ندارد.
+                </Typography>
+              )}
+
+              {entries.length > 0 && (
+                <Box
+                  sx={{
+                    width: '100%',
+                    bgcolor: listBackground,
+                    borderRadius: 2,
+                    px: 2,
+                    py: 2,
+                    border: `1px solid ${dividerColor}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                  }}
+                >
+                  {entries.map(([key, value], index) => (
+                    <Box
+                      key={key}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                        py: 0.75,
+                        borderBottom:
+                          index === entries.length - 1
+                            ? 'none'
+                            : `1px dashed ${dividerColor}`,
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          fontWeight: 600,
+                          color: 'var(--color-secondary)',
+                          minWidth: 120,
+                        }}
+                      >
+                        {key}
+                      </Typography>
+
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: 'var(--color-text)',
+                          textAlign: 'left',
+                          direction: 'ltr',
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-word',
+                          flex: 1,
+                        }}
+                      >
+                        {typeof value === 'string' ? value : formatDetailValue(value)}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default SelectedSambaUsersDetailsPanel;

--- a/src/hooks/useCreateSambaUser.ts
+++ b/src/hooks/useCreateSambaUser.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { CreateSambaUserPayload } from '../@types/samba';
+import axiosInstance from '../lib/axiosInstance';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { extractApiErrorMessage } from '../utils/apiError';
+import { sambaUsersQueryKey } from './useSambaUsers';
+
+const createSambaUserRequest = async (payload: CreateSambaUserPayload) => {
+  await axiosInstance.post('/api/samba/user/add/', payload);
+};
+
+interface UseCreateSambaUserOptions {
+  onSuccess?: (username: string) => void;
+  onError?: (message: string) => void;
+}
+
+export const useCreateSambaUser = ({
+  onSuccess,
+  onError,
+}: UseCreateSambaUserOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, AxiosError<ApiErrorResponse>, CreateSambaUserPayload>({
+    mutationFn: createSambaUserRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: sambaUsersQueryKey });
+      onSuccess?.(variables.username);
+    },
+    onError: (error) => {
+      const message = extractApiErrorMessage(error);
+      onError?.(message);
+    },
+  });
+};
+
+export type UseCreateSambaUserReturn = ReturnType<typeof useCreateSambaUser>;

--- a/src/hooks/useEnableSambaUser.ts
+++ b/src/hooks/useEnableSambaUser.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { EnableSambaUserPayload } from '../@types/samba';
+import axiosInstance from '../lib/axiosInstance';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { extractApiErrorMessage } from '../utils/apiError';
+import { sambaUsersQueryKey } from './useSambaUsers';
+
+const enableSambaUserRequest = async (payload: EnableSambaUserPayload) => {
+  await axiosInstance.post('/api/samba/user/enable/', payload);
+};
+
+interface UseEnableSambaUserOptions {
+  onSuccess?: (username: string) => void;
+  onError?: (message: string) => void;
+}
+
+export const useEnableSambaUser = ({
+  onSuccess,
+  onError,
+}: UseEnableSambaUserOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, AxiosError<ApiErrorResponse>, EnableSambaUserPayload>({
+    mutationFn: enableSambaUserRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: sambaUsersQueryKey });
+      onSuccess?.(variables.username);
+    },
+    onError: (error) => {
+      const message = extractApiErrorMessage(error);
+      onError?.(message);
+    },
+  });
+};
+
+export type UseEnableSambaUserReturn = ReturnType<typeof useEnableSambaUser>;

--- a/src/hooks/useSambaUsers.ts
+++ b/src/hooks/useSambaUsers.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import type { SambaUsersResponse } from '../@types/samba';
+import axiosInstance from '../lib/axiosInstance';
+
+export const sambaUsersQueryKey = ['samba-users'] as const;
+
+const fetchSambaUsers = async ({
+  signal,
+}: {
+  signal?: AbortSignal;
+}): Promise<SambaUsersResponse> => {
+  const { data } = await axiosInstance.get<SambaUsersResponse>(
+    '/api/samba/user/list/',
+    {
+      signal,
+    }
+  );
+
+  return data;
+};
+
+export const useSambaUsers = ({ enabled = true } = {}) =>
+  useQuery<SambaUsersResponse, Error>({
+    queryKey: sambaUsersQueryKey,
+    queryFn: ({ signal }) => fetchSambaUsers({ signal }),
+    enabled,
+    staleTime: 15000,
+  });
+
+export type UseSambaUsersReturn = ReturnType<typeof useSambaUsers>;

--- a/src/hooks/useUpdateSambaUserPassword.ts
+++ b/src/hooks/useUpdateSambaUserPassword.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { UpdateSambaUserPasswordPayload } from '../@types/samba';
+import axiosInstance from '../lib/axiosInstance';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { extractApiErrorMessage } from '../utils/apiError';
+import { sambaUsersQueryKey } from './useSambaUsers';
+
+const updatePasswordRequest = async (payload: UpdateSambaUserPasswordPayload) => {
+  await axiosInstance.post('/api/samba/user/passwd/', payload);
+};
+
+interface UseUpdateSambaUserPasswordOptions {
+  onSuccess?: (username: string) => void;
+  onError?: (message: string) => void;
+}
+
+export const useUpdateSambaUserPassword = ({
+  onSuccess,
+  onError,
+}: UseUpdateSambaUserPasswordOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, AxiosError<ApiErrorResponse>, UpdateSambaUserPasswordPayload>({
+    mutationFn: updatePasswordRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: sambaUsersQueryKey });
+      onSuccess?.(variables.username);
+    },
+    onError: (error) => {
+      const message = extractApiErrorMessage(error);
+      onError?.(message);
+    },
+  });
+};
+
+export type UseUpdateSambaUserPasswordReturn = ReturnType<
+  typeof useUpdateSambaUserPassword
+>;

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -1,0 +1,85 @@
+const IRAN_TIME_ZONE = 'Asia/Tehran';
+
+const IRAN_DATE_TIME_FORMATTER = new Intl.DateTimeFormat('fa-IR', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+  hourCycle: 'h23',
+  timeZone: IRAN_TIME_ZONE,
+});
+
+const NEVER_REGEX = /^never$/i;
+
+const toDate = (value: string | number | Date): Date | null => {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const timestamp = Math.abs(value) < 1_000_000_000_000 ? value * 1000 : value;
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) {
+      return toDate(numeric);
+    }
+
+    const parsedDirect = Date.parse(trimmed);
+    if (!Number.isNaN(parsedDirect)) {
+      return new Date(parsedDirect);
+    }
+
+    const parsedWithUtc = Date.parse(`${trimmed}Z`);
+    if (!Number.isNaN(parsedWithUtc)) {
+      return new Date(parsedWithUtc);
+    }
+  }
+
+  return null;
+};
+
+export const formatUtcDateTimeToIran = (value: unknown): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return undefined;
+    }
+
+    if (NEVER_REGEX.test(trimmed)) {
+      return 'هرگز';
+    }
+
+    const date = toDate(trimmed);
+
+    if (date) {
+      return IRAN_DATE_TIME_FORMATTER.format(date);
+    }
+
+    return trimmed;
+  }
+
+  if (typeof value === 'number' || value instanceof Date) {
+    const date = toDate(value);
+
+    if (date) {
+      return IRAN_DATE_TIME_FORMATTER.format(date);
+    }
+  }
+
+  return undefined;
+};
+
+export default formatUtcDateTimeToIran;

--- a/src/utils/sambaUsers.ts
+++ b/src/utils/sambaUsers.ts
@@ -1,0 +1,219 @@
+import type {
+  RawSambaUserDetails,
+  SambaUserTableItem,
+  SambaUsersResponseData,
+} from '../@types/samba';
+import formatDetailValue from './formatDetailValue';
+import { formatUtcDateTimeToIran } from './dateTime';
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+};
+
+const normalizeKey = (key: string): string => key.replace(/[\s_-]+/g, '').toLowerCase();
+
+const findValue = (
+  record: RawSambaUserDetails,
+  keys: string[]
+): { key: string; value: unknown } | undefined => {
+  if (!record) {
+    return undefined;
+  }
+
+  const normalizedTargets = keys.map(normalizeKey);
+
+  for (const [currentKey, value] of Object.entries(record)) {
+    if (normalizedTargets.includes(normalizeKey(currentKey))) {
+      return { key: currentKey, value };
+    }
+  }
+
+  return undefined;
+};
+
+const BOOLEAN_TRUE_VALUES = new Set([
+  'true',
+  'yes',
+  'y',
+  '1',
+  'enabled',
+  'enable',
+  'active',
+  'on',
+]);
+
+const BOOLEAN_FALSE_VALUES = new Set([
+  'false',
+  'no',
+  'n',
+  '0',
+  'disabled',
+  'disable',
+  'inactive',
+  'off',
+]);
+
+const toOptionalBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return undefined;
+    }
+
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+
+    if (!normalized) {
+      return undefined;
+    }
+
+    if (BOOLEAN_TRUE_VALUES.has(normalized)) {
+      return true;
+    }
+
+    if (BOOLEAN_FALSE_VALUES.has(normalized)) {
+      return false;
+    }
+  }
+
+  return undefined;
+};
+
+const formatBooleanOrDate = (value: unknown): string | undefined => {
+  const booleanValue = toOptionalBoolean(value);
+
+  if (booleanValue !== undefined) {
+    return booleanValue ? 'بله' : 'خیر';
+  }
+
+  const formattedDate = formatUtcDateTimeToIran(value);
+
+  if (formattedDate) {
+    return formattedDate;
+  }
+
+  return toOptionalString(value);
+};
+
+const formatDateValue = (value: unknown): string | undefined =>
+  formatUtcDateTimeToIran(value) ?? toOptionalString(value);
+
+const TIME_KEYS = new Set([
+  'logontime',
+  'logofftime',
+  'kickofftime',
+  'passwordlastset',
+  'passwordcanchange',
+]);
+
+const enhanceDetailsRecord = (record: RawSambaUserDetails): Record<string, string> => {
+  const enhanced: Record<string, string> = {};
+
+  Object.entries(record ?? {}).forEach(([key, value]) => {
+    const normalizedKey = normalizeKey(key);
+    let displayValue: string | undefined;
+
+    if (normalizedKey === 'passwordmustchange') {
+      displayValue = formatBooleanOrDate(value);
+    } else if (TIME_KEYS.has(normalizedKey)) {
+      displayValue = formatDateValue(value);
+    } else {
+      displayValue = toOptionalString(value);
+    }
+
+    enhanced[key] = displayValue ?? formatDetailValue(value);
+  });
+
+  return enhanced;
+};
+
+const normalizeSambaUser = (
+  identifier: string,
+  value: unknown,
+  index: number
+): SambaUserTableItem => {
+  const record: RawSambaUserDetails =
+    typeof value === 'object' && value !== null ? (value as RawSambaUserDetails) : {};
+
+  const usernameEntry =
+    findValue(record, ['username', 'user', 'accountname', 'name']) ??
+    (typeof value === 'string'
+      ? { key: 'username', value }
+      : undefined);
+
+  const resolvedIdentifier = toOptionalString(identifier);
+  const username =
+    toOptionalString(usernameEntry?.value) || resolvedIdentifier || `samba-user-${index + 1}`;
+
+  const domainEntry = findValue(record, ['domain', 'workgroup']);
+  const profilePathEntry = findValue(record, ['profilepath', 'profile_path', 'profile']);
+  const passwordMustChangeEntry = findValue(record, ['passwordmustchange', 'pwdmustchange']);
+  const logonTimeEntry = findValue(record, ['logontime', 'lastlogon', 'logon_time']);
+  const logoffTimeEntry = findValue(record, ['logofftime', 'logoff_time']);
+  const kickoffTimeEntry = findValue(record, ['kickofftime', 'kickoff_time']);
+  const passwordLastSetEntry = findValue(record, ['passwordlastset', 'pwdlastset']);
+  const passwordCanChangeEntry = findValue(record, ['passwordcanchange', 'pwdcanchange']);
+
+  const details = enhanceDetailsRecord(record);
+
+  const hasUsernameInDetails = Object.keys(details).some(
+    (key) => normalizeKey(key) === 'username'
+  );
+
+  if (!hasUsernameInDetails && username) {
+    details['Username'] = username;
+  }
+
+  return {
+    id: username,
+    username,
+    domain: toOptionalString(domainEntry?.value),
+    profilePath: toOptionalString(profilePathEntry?.value),
+    passwordMustChange: formatBooleanOrDate(passwordMustChangeEntry?.value),
+    logonTime: formatDateValue(logonTimeEntry?.value),
+    logoffTime: formatDateValue(logoffTimeEntry?.value),
+    kickoffTime: formatDateValue(kickoffTimeEntry?.value),
+    passwordLastSet: formatDateValue(passwordLastSetEntry?.value),
+    passwordCanChange: formatDateValue(passwordCanChangeEntry?.value),
+    details,
+  };
+};
+
+export const normalizeSambaUsers = (
+  data: SambaUsersResponseData | undefined
+): SambaUserTableItem[] => {
+  if (!data) {
+    return [];
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((entry, index) =>
+      normalizeSambaUser(String(index + 1), entry, index)
+    );
+  }
+
+  return Object.entries(data).map(([key, entry], index) =>
+    normalizeSambaUser(key, entry, index)
+  );
+};
+
+export default normalizeSambaUsers;


### PR DESCRIPTION
## Summary
- add a Samba users tab with table, selection panel, and action buttons for managing Samba accounts
- provide modals and hooks to create users, enable accounts, and change passwords via the Samba API
- normalize Samba user payloads and convert UTC timestamps to Iran time for display consistency

## Testing
- npm run build *(fails: existing TypeScript configuration issues outside the touched scope)*

------
https://chatgpt.com/codex/tasks/task_b_68da7e705f58832f94ae8473699e6c36