### PR TITLE
feat: enhance os and samba user management

### DIFF
--- a/src/components/users/OsUsersTable.tsx
+++ b/src/components/users/OsUsersTable.tsx
@@ -1,6 +1,11 @@
 import { Box, IconButton, Tooltip, Typography } from '@mui/material';
 import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
-import { MdDeleteOutline } from 'react-icons/md';
+import {
+  MdCancel,
+  MdCheckCircle,
+  MdDeleteOutline,
+  MdPersonAdd,
+} from 'react-icons/md';
 import type { DataTableColumn } from '../../@types/dataTable.ts';
 import type { OsUserTableItem } from '../../@types/users';
 import DataTable from '../DataTable';
@@ -9,11 +14,24 @@ interface OsUsersTableProps {
   users: OsUserTableItem[];
   isLoading: boolean;
   error: Error | null;
+  sambaUsernames: string[];
+  onCreateSambaUser: (user: OsUserTableItem) => void;
 }
 
-const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
+const OsUsersTable = ({
+  users,
+  isLoading,
+  error,
+  sambaUsernames,
+  onCreateSambaUser,
+}: OsUsersTableProps) => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  const sambaUsersSet = useMemo(
+    () => new Set(sambaUsernames.map((username) => username.trim())),
+    [sambaUsernames]
+  );
 
   useEffect(() => {
     if (page > 0 && page * rowsPerPage >= users.length) {
@@ -64,34 +82,92 @@ const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
         ),
       },
       {
+        id: 'samba-user',
+        header: 'کاربر Samba',
+        align: 'center',
+        width: 120,
+        renderCell: (row) => {
+          const hasSambaUser = sambaUsersSet.has(row.username);
+
+          return (
+            <Tooltip
+              title={
+                hasSambaUser
+                  ? 'این کاربر دارای حساب Samba است.'
+                  : 'این کاربر حساب Samba ندارد.'
+              }
+              arrow
+            >
+              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                {hasSambaUser ? (
+                  <MdCheckCircle size={20} color="var(--color-success)" />
+                ) : (
+                  <MdCancel size={20} color="var(--color-error)" />
+                )}
+              </Box>
+            </Tooltip>
+          );
+        },
+      },
+      {
         id: 'actions',
         header: 'عملیات',
         align: 'center',
-        width: 120,
-        renderCell: () => (
-          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-            <Tooltip title="حذف" arrow>
-              <span>
-                <IconButton
-                  size="small"
-                  disabled
-                  sx={{
-                    color: 'var(--color-error)',
-                    '&.Mui-disabled': {
-                      color: 'var(--color-secondary)',
-                      opacity: 0.6,
-                    },
-                  }}
-                >
-                  <MdDeleteOutline size={18} />
-                </IconButton>
-              </span>
-            </Tooltip>
-          </Box>
-        ),
+        width: 168,
+        renderCell: (row) => {
+          const hasSambaUser = sambaUsersSet.has(row.username);
+
+          return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5 }}>
+              <Tooltip title="حذف" arrow>
+                <span>
+                  <IconButton
+                    size="small"
+                    disabled
+                    sx={{
+                      color: 'var(--color-error)',
+                      '&.Mui-disabled': {
+                        color: 'var(--color-secondary)',
+                        opacity: 0.6,
+                      },
+                    }}
+                  >
+                    <MdDeleteOutline size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+
+              <Tooltip
+                title={
+                  hasSambaUser
+                    ? 'کاربر Samba موجود است'
+                    : 'ایجاد کاربر Samba'
+                }
+                arrow
+              >
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => onCreateSambaUser(row)}
+                    disabled={hasSambaUser}
+                    sx={{
+                      color: 'var(--color-primary)',
+                      '&.Mui-disabled': {
+                        color: 'var(--color-secondary)',
+                        opacity: 0.7,
+                      },
+                    }}
+                  >
+                    <MdPersonAdd size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          );
+        },
       },
     ],
-    [page, rowsPerPage]
+    [onCreateSambaUser, page, rowsPerPage, sambaUsersSet]
   );
 
   return (

--- a/src/components/users/SambaUserCreateModal.tsx
+++ b/src/components/users/SambaUserCreateModal.tsx
@@ -1,4 +1,12 @@
-import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { type FormEvent, useEffect, useState } from 'react';
 import type { CreateSambaUserPayload } from '../../@types/samba';
 import BlurModal from '../BlurModal';
@@ -6,9 +14,10 @@ import BlurModal from '../BlurModal';
 interface SambaUserCreateModalProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (payload: CreateSambaUserPayload) => void;
+  onSubmit: (payload: CreateSambaUserPayload & { createOsUser: boolean }) => void;
   isSubmitting: boolean;
   errorMessage: string | null;
+  initialUsername?: string;
 }
 
 const SambaUserCreateModal = ({
@@ -17,16 +26,19 @@ const SambaUserCreateModal = ({
   onSubmit,
   isSubmitting,
   errorMessage,
+  initialUsername = '',
 }: SambaUserCreateModalProps) => {
-  const [username, setUsername] = useState('');
+  const [username, setUsername] = useState(initialUsername);
   const [password, setPassword] = useState('');
+  const [createOsUser, setCreateOsUser] = useState(false);
 
   useEffect(() => {
     if (open) {
-      setUsername('');
+      setUsername(initialUsername ?? '');
       setPassword('');
+      setCreateOsUser(false);
     }
-  }, [open]);
+  }, [initialUsername, open]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -38,6 +50,7 @@ const SambaUserCreateModal = ({
     onSubmit({
       username: username.trim(),
       password,
+      createOsUser,
     });
   };
 
@@ -123,6 +136,31 @@ const SambaUserCreateModal = ({
             {errorMessage}
           </Alert>
         ) : null}
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={createOsUser}
+              onChange={(event) => setCreateOsUser(event.target.checked)}
+              color="primary"
+              disabled={isSubmitting}
+              sx={{
+                color: 'var(--color-secondary)',
+                '&.Mui-checked': {
+                  color: 'var(--color-primary)',
+                },
+              }}
+            />
+          }
+          label="ابتدا کاربر سیستم عامل ایجاد شود"
+          sx={{
+            alignSelf: 'flex-start',
+            '& .MuiTypography-root': {
+              color: 'var(--color-secondary)',
+              fontWeight: 600,
+            },
+          }}
+        />
       </Box>
     </BlurModal>
   );

--- a/src/components/users/SambaUsersTable.tsx
+++ b/src/components/users/SambaUsersTable.tsx
@@ -25,6 +25,16 @@ interface SambaUsersTableProps {
 
 const valueOrDash = (value?: string) => (value && value.trim() ? value : '-');
 
+const findLogonTimeInDetails = (details: Record<string, string>) => {
+  for (const [key, value] of Object.entries(details)) {
+    if (key.trim().toLowerCase() === 'logon time') {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
 const SambaUsersTable = ({
   users,
   isLoading,
@@ -118,13 +128,18 @@ const SambaUsersTable = ({
       },
       {
         id: 'logon-time',
-        header: 'زمان ورود',
+        header: 'Logon time',
         align: 'left',
-        renderCell: (user) => (
-          <Typography sx={{ color: 'var(--color-text)' }}>
-            {valueOrDash(user.logonTime)}
-          </Typography>
-        ),
+        renderCell: (user) => {
+          const logonTime =
+            findLogonTimeInDetails(user.details) ?? user.logonTime;
+
+          return (
+            <Typography sx={{ color: 'var(--color-text)' }}>
+              {valueOrDash(logonTime)}
+            </Typography>
+          );
+        },
       },
       {
         id: 'actions',


### PR DESCRIPTION
## Summary
- add samba account status indicators and a samba creation action to the OS users table
- allow opening the samba creation modal pre-filled from OS users and support optional OS account creation
- surface the "Logon time" detail in the samba users table and adjust modal UX accordingly

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68da93d5f424832f8f903b26883e62f6