### PR TITLE
Enhance Samba user management workflow

### DIFF
--- a/src/@types/users.ts
+++ b/src/@types/users.ts
@@ -19,5 +19,6 @@ export interface OsUserTableItem {
   gid?: string;
   homeDirectory?: string;
   loginShell?: string;
+  hasSambaUser?: boolean;
   raw: RawOsUserDetails;
 }

--- a/src/components/users/OsUsersTable.tsx
+++ b/src/components/users/OsUsersTable.tsx
@@ -1,6 +1,12 @@
-import { Box, IconButton, Tooltip, Typography } from '@mui/material';
+import { Box, CircularProgress, IconButton, Tooltip, Typography } from '@mui/material';
 import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
-import { MdDeleteOutline } from 'react-icons/md';
+import {
+  MdCancel,
+  MdCheckCircle,
+  MdDeleteOutline,
+  MdHelpOutline,
+  MdPersonAddAlt1,
+} from 'react-icons/md';
 import type { DataTableColumn } from '../../@types/dataTable.ts';
 import type { OsUserTableItem } from '../../@types/users';
 import DataTable from '../DataTable';
@@ -9,9 +15,17 @@ interface OsUsersTableProps {
   users: OsUserTableItem[];
   isLoading: boolean;
   error: Error | null;
+  isSambaStatusLoading: boolean;
+  onCreateSambaUser: (user: OsUserTableItem) => void;
 }
 
-const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
+const OsUsersTable = ({
+  users,
+  isLoading,
+  error,
+  isSambaStatusLoading,
+  onCreateSambaUser,
+}: OsUsersTableProps) => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
@@ -64,12 +78,89 @@ const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
         ),
       },
       {
+        id: 'samba-status',
+        header: 'وضعیت Samba',
+        align: 'center',
+        width: 120,
+        renderCell: (row) => {
+          if (isSambaStatusLoading && row.hasSambaUser === undefined) {
+            return (
+              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                <CircularProgress size={18} sx={{ color: 'var(--color-secondary)' }} />
+              </Box>
+            );
+          }
+
+          const iconProps = {
+            size: 20,
+          };
+
+          if (row.hasSambaUser) {
+            return (
+              <Tooltip title="کاربر Samba موجود است" arrow>
+                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                  <MdCheckCircle
+                    {...iconProps}
+                    color="var(--color-success)"
+                    aria-label="دارای کاربر Samba"
+                  />
+                </Box>
+              </Tooltip>
+            );
+          }
+
+          if (row.hasSambaUser === false) {
+            return (
+              <Tooltip title="کاربر Samba موجود نیست" arrow>
+                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                  <MdCancel
+                    {...iconProps}
+                    color="var(--color-error)"
+                    aria-label="فاقد کاربر Samba"
+                  />
+                </Box>
+              </Tooltip>
+            );
+          }
+
+          return (
+            <Tooltip title="نامشخص" arrow>
+              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                <MdHelpOutline
+                  {...iconProps}
+                  color="var(--color-secondary)"
+                  aria-label="وضعیت نامشخص"
+                />
+              </Box>
+            </Tooltip>
+          );
+        },
+      },
+      {
         id: 'actions',
         header: 'عملیات',
         align: 'center',
-        width: 120,
-        renderCell: () => (
-          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        width: 180,
+        renderCell: (row) => (
+          <Box sx={{ display: 'flex', justifyContent: 'center', gap: 0.5 }}>
+            <Tooltip title="ایجاد کاربر Samba" arrow>
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={() => onCreateSambaUser(row)}
+                  disabled={Boolean(row.hasSambaUser) || isSambaStatusLoading}
+                  sx={{
+                    color: 'var(--color-primary)',
+                    '&.Mui-disabled': {
+                      color: 'var(--color-secondary)',
+                      opacity: 0.7,
+                    },
+                  }}
+                >
+                  <MdPersonAddAlt1 size={18} />
+                </IconButton>
+              </span>
+            </Tooltip>
             <Tooltip title="حذف" arrow>
               <span>
                 <IconButton
@@ -91,7 +182,7 @@ const OsUsersTable = ({ users, isLoading, error }: OsUsersTableProps) => {
         ),
       },
     ],
-    [page, rowsPerPage]
+    [isSambaStatusLoading, onCreateSambaUser, page, rowsPerPage]
   );
 
   return (

--- a/src/components/users/SambaUserCreateModal.tsx
+++ b/src/components/users/SambaUserCreateModal.tsx
@@ -1,4 +1,12 @@
-import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  TextField,
+  Typography,
+} from '@mui/material';
 import { type FormEvent, useEffect, useState } from 'react';
 import type { CreateSambaUserPayload } from '../../@types/samba';
 import BlurModal from '../BlurModal';
@@ -6,9 +14,10 @@ import BlurModal from '../BlurModal';
 interface SambaUserCreateModalProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (payload: CreateSambaUserPayload) => void;
+  onSubmit: (payload: CreateSambaUserPayload & { createOsUserFirst: boolean }) => void;
   isSubmitting: boolean;
   errorMessage: string | null;
+  initialUsername?: string;
 }
 
 const SambaUserCreateModal = ({
@@ -17,16 +26,19 @@ const SambaUserCreateModal = ({
   onSubmit,
   isSubmitting,
   errorMessage,
+  initialUsername,
 }: SambaUserCreateModalProps) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [createOsUserFirst, setCreateOsUserFirst] = useState(false);
 
   useEffect(() => {
     if (open) {
-      setUsername('');
+      setUsername(initialUsername ?? '');
       setPassword('');
+      setCreateOsUserFirst(false);
     }
-  }, [open]);
+  }, [initialUsername, open]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -38,6 +50,7 @@ const SambaUserCreateModal = ({
     onSubmit({
       username: username.trim(),
       password,
+      createOsUserFirst,
     });
   };
 
@@ -114,6 +127,24 @@ const SambaUserCreateModal = ({
               backgroundColor: 'var(--color-input-bg)',
               borderRadius: 1,
               '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
+        />
+
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={createOsUserFirst}
+              onChange={(event) => setCreateOsUserFirst(event.target.checked)}
+              color="primary"
+            />
+          }
+          label="ابتدا کاربر سیستم عامل ایجاد شود"
+          sx={{
+            alignSelf: 'flex-start',
+            '& .MuiTypography-root': {
+              color: 'var(--color-secondary)',
+              fontWeight: 500,
             },
           }}
         />

--- a/src/components/users/SambaUsersTable.tsx
+++ b/src/components/users/SambaUsersTable.tsx
@@ -118,7 +118,7 @@ const SambaUsersTable = ({
       },
       {
         id: 'logon-time',
-        header: 'زمان ورود',
+        header: 'Logon time',
         align: 'left',
         renderCell: (user) => (
           <Typography sx={{ color: 'var(--color-text)' }}>

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -7,6 +7,7 @@ import {
   Tabs,
   Typography,
 } from '@mui/material';
+import { isAxiosError } from 'axios';
 import {
   type ChangeEvent,
   type ReactNode,
@@ -17,8 +18,13 @@ import {
   useState,
 } from 'react';
 import { toast } from 'react-hot-toast';
+import type { CreateSambaUserPayload } from '../@types/samba';
 import type { CreateOsUserPayload } from '../@types/users';
-import { USERS_TABS, type UsersTabValue } from '../constants/users';
+import {
+  DEFAULT_LOGIN_SHELL,
+  USERS_TABS,
+  type UsersTabValue,
+} from '../constants/users';
 import OsUserCreateModal from '../components/users/OsUserCreateModal';
 import OsUsersTable from '../components/users/OsUsersTable';
 import SelectedSambaUsersDetailsPanel from '../components/users/SelectedSambaUsersDetailsPanel';
@@ -33,6 +39,8 @@ import { useSambaUsers } from '../hooks/useSambaUsers';
 import { useUpdateSambaUserPassword } from '../hooks/useUpdateSambaUserPassword';
 import { normalizeOsUsers } from '../utils/osUsers';
 import { normalizeSambaUsers } from '../utils/sambaUsers';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { extractApiErrorMessage } from '../utils/apiError';
 
 const TabPanel = ({
   value,
@@ -59,10 +67,16 @@ const Users = () => {
   const [sambaCreateError, setSambaCreateError] = useState<string | null>(null);
   const [selectedSambaUsers, setSelectedSambaUsers] = useState<string[]>([]);
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
-  const [passwordModalUsername, setPasswordModalUsername] = useState<string | null>(null);
+  const [passwordModalUsername, setPasswordModalUsername] =
+    useState<string | null>(null);
   const [passwordModalError, setPasswordModalError] = useState<string | null>(null);
-  const [pendingEnableUsername, setPendingEnableUsername] = useState<string | null>(null);
-  const [pendingPasswordUsername, setPendingPasswordUsername] = useState<string | null>(null);
+  const [pendingEnableUsername, setPendingEnableUsername] =
+    useState<string | null>(null);
+  const [pendingPasswordUsername, setPendingPasswordUsername] =
+    useState<string | null>(null);
+  const [sambaModalInitialUsername, setSambaModalInitialUsername] = useState<
+    string | null
+  >(null);
 
   const osUsersQuery = useOsUsers({
     includeSystem,
@@ -75,12 +89,31 @@ const Users = () => {
   );
 
   const sambaUsersQuery = useSambaUsers({
-    enabled: activeTab === USERS_TABS.samba,
+    enabled: activeTab !== USERS_TABS.other,
   });
 
   const sambaUsers = useMemo(
     () => normalizeSambaUsers(sambaUsersQuery.data?.data),
     [sambaUsersQuery.data?.data]
+  );
+
+  const isSambaStatusLoading = sambaUsersQuery.isLoading || sambaUsersQuery.isFetching;
+
+  const sambaUsernamesSet = useMemo(
+    () => new Set(sambaUsers.map((user) => user.username)),
+    [sambaUsers]
+  );
+
+  const osUsersWithSambaStatus = useMemo(
+    () =>
+      osUsers.map((user) => ({
+        ...user,
+        hasSambaUser:
+          sambaUsernamesSet.size > 0 || !isSambaStatusLoading
+            ? sambaUsernamesSet.has(user.username)
+            : undefined,
+      })),
+    [isSambaStatusLoading, osUsers, sambaUsernamesSet]
   );
 
   const createOsUser = useCreateOsUser({
@@ -100,6 +133,7 @@ const Users = () => {
       toast.success(`کاربر Samba ${username} با موفقیت ایجاد شد.`);
       setIsSambaCreateModalOpen(false);
       setSambaCreateError(null);
+      setSambaModalInitialUsername(null);
     },
     onError: (message) => {
       setSambaCreateError(message);
@@ -162,23 +196,60 @@ const Users = () => {
     [createOsUser]
   );
 
-  const handleOpenSambaCreateModal = useCallback(() => {
-    setSambaCreateError(null);
-    createSambaUser.reset();
-    setIsSambaCreateModalOpen(true);
-  }, [createSambaUser]);
+  const handleOpenSambaCreateModal = useCallback(
+    (initialUsername?: string) => {
+      setSambaCreateError(null);
+      createSambaUser.reset();
+      setSambaModalInitialUsername(initialUsername ?? null);
+      setIsSambaCreateModalOpen(true);
+    },
+    [createSambaUser]
+  );
 
   const handleCloseSambaCreateModal = useCallback(() => {
     setIsSambaCreateModalOpen(false);
     setSambaCreateError(null);
     createSambaUser.reset();
+    setSambaModalInitialUsername(null);
   }, [createSambaUser]);
 
   const handleSubmitCreateSambaUser = useCallback(
-    (payload: { username: string; password: string }) => {
-      createSambaUser.mutate(payload);
+    async ({
+      username,
+      password,
+      createOsUserFirst,
+    }: CreateSambaUserPayload & { createOsUserFirst: boolean }) => {
+      setSambaCreateError(null);
+      const trimmedUsername = username.trim();
+
+      if (createOsUserFirst) {
+        try {
+          await createOsUser.mutateAsync({
+            username: trimmedUsername,
+            login_shell: DEFAULT_LOGIN_SHELL,
+            shell: DEFAULT_LOGIN_SHELL,
+          });
+        } catch (error) {
+          if (isAxiosError<ApiErrorResponse>(error)) {
+            setSambaCreateError(extractApiErrorMessage(error));
+          } else {
+            setSambaCreateError('خطای ناشناخته‌ای رخ داد.');
+          }
+
+          return;
+        }
+      }
+
+      createSambaUser.mutate({ username: trimmedUsername, password });
     },
-    [createSambaUser]
+    [createOsUser, createSambaUser]
+  );
+
+  const handleCreateSambaForOsUser = useCallback(
+    (user: { username: string }) => {
+      handleOpenSambaCreateModal(user.username);
+    },
+    [handleOpenSambaCreateModal]
   );
 
   const handleToggleSelectSambaUser = useCallback(
@@ -355,9 +426,11 @@ const Users = () => {
           </Box>
 
           <OsUsersTable
-            users={osUsers}
+            users={osUsersWithSambaStatus}
             isLoading={osUsersQuery.isLoading || osUsersQuery.isFetching}
             error={osUsersQuery.error ?? null}
+            isSambaStatusLoading={isSambaStatusLoading}
+            onCreateSambaUser={handleCreateSambaForOsUser}
           />
         </Box>
       </TabPanel>
@@ -381,7 +454,7 @@ const Users = () => {
             </Typography>
 
             <Button
-              onClick={handleOpenSambaCreateModal}
+              onClick={() => handleOpenSambaCreateModal()}
               variant="contained"
               sx={{
                 px: 3,
@@ -448,8 +521,9 @@ const Users = () => {
         open={isSambaCreateModalOpen}
         onClose={handleCloseSambaCreateModal}
         onSubmit={handleSubmitCreateSambaUser}
-        isSubmitting={createSambaUser.isPending}
+        isSubmitting={createSambaUser.isPending || createOsUser.isPending}
         errorMessage={sambaCreateError}
+        initialUsername={sambaModalInitialUsername ?? undefined}
       />
 
       <SambaUserPasswordModal


### PR DESCRIPTION
## Summary
- add Samba status indicator and direct creation action to OS users table
- allow prefilling usernames and optional OS user provisioning when creating Samba users
- rename Samba logon time column to match backend wording

## Testing
- `npm run build` *(fails: existing TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68da93d5f424832f8f903b26883e62f6