### PR TITLE
Add responsive variants for navigation drawer

### DIFF
--- a/src/@types/navigationDrawer.ts
+++ b/src/@types/navigationDrawer.ts
@@ -1,8 +1,11 @@
 import type { ReactNode } from 'react';
 
 export interface NavigationDrawerProps {
+  variant: 'temporary' | 'permanent';
   open: boolean;
   onClose: () => void;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 export interface NavigationItem {

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -9,9 +9,9 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { IoPersonCircleOutline } from 'react-icons/io5';
-import { MdClose, MdLogout, MdMenu, MdSearch } from 'react-icons/md';
+import { MdClose, MdLogout, MdMenu, MdMenuOpen, MdSearch } from 'react-icons/md';
 import { Outlet } from 'react-router';
 import { useAuth } from '../contexts/AuthContext';
 import '../index.css';
@@ -22,8 +22,42 @@ const MainLayout: React.FC = () => {
   const { logout, username } = useAuth();
   const [searchQuery, setSearchQuery] = useState('');
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+
+  useEffect(() => {
+    if (isDesktop) {
+      setDrawerOpen(false);
+    } else {
+      setIsCollapsed(false);
+    }
+  }, [isDesktop]);
+
+  const handleDrawerToggle = () => {
+    if (isDesktop) {
+      setIsCollapsed((prev) => !prev);
+    } else {
+      setDrawerOpen((prev) => !prev);
+    }
+  };
+
+  const toggleButtonIcon = isDesktop
+    ? isCollapsed
+      ? <MdMenu />
+      : <MdMenuOpen />
+    : drawerOpen
+      ? <MdClose />
+      : <MdMenu />;
+
+  const toggleButtonAriaLabel = isDesktop
+    ? isCollapsed
+      ? 'باز کردن منو'
+      : 'جمع کردن منو'
+    : drawerOpen
+      ? 'بستن منو'
+      : 'باز کردن منو';
 
   const handleLogout = async () => {
     await logout();
@@ -62,10 +96,11 @@ const MainLayout: React.FC = () => {
           }}
         >
           <IconButton
-            onClick={() => setDrawerOpen((prev) => !prev)}
+            aria-label={toggleButtonAriaLabel}
+            onClick={handleDrawerToggle}
             sx={{ color: 'var(--color-bg-primary)' }}
           >
-            {drawerOpen ? <MdClose /> : <MdMenu />}
+            {toggleButtonIcon}
           </IconButton>
           <Box
             component="img"
@@ -182,8 +217,11 @@ const MainLayout: React.FC = () => {
         </Toolbar>
       </AppBar>
       <NavigationDrawer
+        variant={isDesktop ? 'permanent' : 'temporary'}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
+        isCollapsed={isDesktop ? isCollapsed : false}
+        onToggleCollapse={() => setIsCollapsed((prev) => !prev)}
       />
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -7,60 +7,126 @@ import {
   ListItemIcon,
   ListItemText,
   Toolbar,
+  Tooltip,
 } from '@mui/material';
 import React from 'react';
-import { MdClose } from 'react-icons/md';
+import { MdClose, MdMenu, MdMenuOpen } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import type { NavigationDrawerProps } from '../@types/navigationDrawer';
-import { drawerWidth, navItems } from '../constants/navigationDrawer';
+import {
+  collapsedDrawerWidth,
+  drawerWidth,
+  navItems,
+} from '../constants/navigationDrawer';
 
 const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
+  variant,
   open,
   onClose,
-}) => (
-  <Drawer
-    anchor="left"
-    open={open}
-    onClose={onClose}
-    slotProps={{ transition: { direction: 'left' } }}
-    sx={{
-      '& .MuiDrawer-paper': {
-        width: drawerWidth,
-        boxSizing: 'border-box',
-        backgroundColor: 'var(--color-card-bg)',
-        backdropFilter: 'saturate(140%) blur(8px)',
-      },
-    }}
-  >
-    <Toolbar sx={{ justifyContent: 'space-between' }}>
-      <IconButton onClick={onClose} sx={{ color: 'var(--color-bg-primary)' }}>
-        <MdClose />
-      </IconButton>
-    </Toolbar>
-    <List>
-      {navItems.map((item) => (
-        <ListItem key={item.text} disablePadding>
-          <ListItemButton
-            component={Link}
-            to={item.path}
-            onClick={onClose}
-            sx={{
-              color: 'var(--color-bg-primary)',
-              '&:hover': { backgroundColor: 'var(--color-primary)' },
-            }}
+  isCollapsed,
+  onToggleCollapse,
+}) => {
+  const isPermanent = variant === 'permanent';
+
+  const paperWidth = isCollapsed ? collapsedDrawerWidth : drawerWidth;
+
+  return (
+    <Drawer
+      anchor="left"
+      variant={variant}
+      open={isPermanent ? true : open}
+      onClose={isPermanent ? undefined : onClose}
+      slotProps={
+        variant === 'temporary' ? { transition: { direction: 'left' } } : undefined
+      }
+      sx={{
+        '& .MuiDrawer-paper': {
+          width: paperWidth,
+          boxSizing: 'border-box',
+          backgroundColor: 'var(--color-card-bg)',
+          backdropFilter: 'saturate(140%) blur(8px)',
+          overflowX: 'hidden',
+          transition: (theme) =>
+            theme.transitions.create('width', {
+              easing: theme.transitions.easing.sharp,
+              duration: theme.transitions.duration.shorter,
+            }),
+        },
+      }}
+    >
+      <Toolbar
+        sx={{
+          justifyContent: isPermanent ? 'flex-end' : 'space-between',
+          px: isPermanent ? 1 : 2,
+        }}
+      >
+        {isPermanent ? (
+          <IconButton
+            aria-label={isCollapsed ? 'باز کردن منو' : 'جمع کردن منو'}
+            onClick={onToggleCollapse}
+            sx={{ color: 'var(--color-bg-primary)' }}
           >
-            <ListItemIcon>{item.icon}</ListItemIcon>
-            <ListItemText
-              primary={item.text}
-              slotProps={{
-                primary: { sx: { fontFamily: 'var(--font-vazir)' } },
-              }}
-            />
-          </ListItemButton>
-        </ListItem>
-      ))}
-    </List>
-  </Drawer>
-);
+            {isCollapsed ? <MdMenu /> : <MdMenuOpen />}
+          </IconButton>
+        ) : (
+          <IconButton
+            aria-label="بستن منو"
+            onClick={onClose}
+            sx={{ color: 'var(--color-bg-primary)' }}
+          >
+            <MdClose />
+          </IconButton>
+        )}
+      </Toolbar>
+      <List disablePadding>
+        {navItems.map((item) => (
+          <ListItem key={item.text} disablePadding sx={{ display: 'block' }}>
+            <Tooltip
+              title={item.text}
+              placement="right"
+              disableHoverListener={!isCollapsed}
+            >
+              <ListItemButton
+                component={Link}
+                to={item.path}
+                onClick={() => {
+                  if (!isPermanent) {
+                    onClose();
+                  }
+                }}
+                aria-label={isCollapsed ? item.text : undefined}
+                sx={{
+                  color: 'var(--color-bg-primary)',
+                  justifyContent: isCollapsed ? 'center' : 'flex-start',
+                  px: isCollapsed ? 1 : 2,
+                  '&:hover': { backgroundColor: 'var(--color-primary)' },
+                }}
+              >
+                <ListItemIcon
+                  sx={{
+                    minWidth: isCollapsed ? 'auto' : 40,
+                    display: 'flex',
+                    justifyContent: 'center',
+                    color: 'inherit',
+                  }}
+                >
+                  {item.icon}
+                </ListItemIcon>
+                {!isCollapsed && (
+                  <ListItemText
+                    primary={item.text}
+                    slotProps={{
+                      primary: { sx: { fontFamily: 'var(--font-vazir)' } },
+                    }}
+                  />
+                )}
+              </ListItemButton>
+            </Tooltip>
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+};
 
 export default NavigationDrawer;

--- a/src/constants/navigationDrawer.ts
+++ b/src/constants/navigationDrawer.ts
@@ -8,6 +8,7 @@ import { RiSettings3Fill } from 'react-icons/ri';
 import type { NavigationItem } from '../@types/navigationDrawer';
 
 export const drawerWidth = 200;
+export const collapsedDrawerWidth = 72;
 
 export const navItems: NavigationItem[] = [
   {


### PR DESCRIPTION
## Summary
- differentiate the main layout drawer logic between mobile and desktop, adding collapse support on larger viewports
- refactor the navigation drawer to support permanent and temporary variants with collapsed styling and icon-only mode
- expose a collapsed drawer width constant and expand the drawer prop types to cover the new behavior

## Testing
- npm run lint *(fails: pre-existing react-refresh lint errors in context files)*
- npm run build *(fails: pre-existing TypeScript errors in unrelated chart and page files)*

------
https://chatgpt.com/codex/tasks/task_b_68db77e22a54832fa424ec276908213e