### PR TITLE
Implement mini-variant navigation drawer

### DIFF
--- a/src/@types/navigationDrawer.ts
+++ b/src/@types/navigationDrawer.ts
@@ -2,7 +2,9 @@ import type { ReactNode } from 'react';
 
 export interface NavigationDrawerProps {
   open: boolean;
+  variant: 'permanent' | 'temporary';
   onClose: () => void;
+  onToggle?: () => void;
 }
 
 export interface NavigationItem {

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -9,58 +9,125 @@ import {
   Toolbar,
 } from '@mui/material';
 import React from 'react';
-import { MdClose } from 'react-icons/md';
+import { MdClose, MdMenu } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import type { NavigationDrawerProps } from '../@types/navigationDrawer';
-import { drawerWidth, navItems } from '../constants/navigationDrawer';
+import {
+  collapsedDrawerWidth,
+  drawerWidth,
+  navItems,
+} from '../constants/navigationDrawer';
 
 const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
   open,
+  variant,
   onClose,
-}) => (
-  <Drawer
-    anchor="left"
-    open={open}
-    onClose={onClose}
-    slotProps={{ transition: { direction: 'left' } }}
-    sx={{
-      '& .MuiDrawer-paper': {
-        width: drawerWidth,
-        boxSizing: 'border-box',
-        backgroundColor: 'var(--color-card-bg)',
-        backdropFilter: 'saturate(140%) blur(8px)',
-      },
-    }}
-  >
-    <Toolbar sx={{ justifyContent: 'space-between' }}>
-      <IconButton onClick={onClose} sx={{ color: 'var(--color-bg-primary)' }}>
-        <MdClose />
-      </IconButton>
-    </Toolbar>
-    <List>
-      {navItems.map((item) => (
-        <ListItem key={item.text} disablePadding>
-          <ListItemButton
-            component={Link}
-            to={item.path}
-            onClick={onClose}
-            sx={{
-              color: 'var(--color-bg-primary)',
-              '&:hover': { backgroundColor: 'var(--color-primary)' },
-            }}
-          >
-            <ListItemIcon>{item.icon}</ListItemIcon>
-            <ListItemText
-              primary={item.text}
-              slotProps={{
-                primary: { sx: { fontFamily: 'var(--font-vazir)' } },
+  onToggle,
+}) => {
+  const isPermanent = variant === 'permanent';
+
+  const ToggleIcon = isPermanent ? (open ? MdClose : MdMenu) : MdClose;
+  const handleToggle = () => {
+    if (isPermanent) {
+      onToggle?.();
+    } else {
+      onClose();
+    }
+  };
+
+  const handleItemClick = () => {
+    if (!isPermanent) {
+      onClose();
+    }
+  };
+
+  return (
+    <Drawer
+      anchor="left"
+      variant={variant}
+      open={isPermanent ? true : open}
+      onClose={onClose}
+      ModalProps={{ keepMounted: true }}
+      sx={{
+        width: isPermanent ? drawerWidth : undefined,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': (theme) => ({
+          width: isPermanent
+            ? open
+              ? drawerWidth
+              : collapsedDrawerWidth
+            : drawerWidth,
+          overflowX: 'hidden',
+          overflowY: 'auto',
+          boxSizing: 'border-box',
+          backgroundColor: 'var(--color-card-bg)',
+          backdropFilter: 'saturate(140%) blur(8px)',
+          whiteSpace: 'nowrap',
+          position: isPermanent ? 'relative' : 'fixed',
+          transition: theme.transitions.create('width', {
+            easing: theme.transitions.easing.sharp,
+            duration: open
+              ? theme.transitions.duration.enteringScreen
+              : theme.transitions.duration.leavingScreen,
+          }),
+          display: 'flex',
+          flexDirection: 'column',
+        }),
+      }}
+    >
+      <Toolbar
+        sx={{
+          justifyContent: open ? 'space-between' : 'center',
+          px: open ? 2 : 1,
+          minHeight: 56,
+        }}
+      >
+        <IconButton onClick={handleToggle} sx={{ color: 'var(--color-bg-primary)' }}>
+          <ToggleIcon />
+        </IconButton>
+      </Toolbar>
+      <List sx={{ flexGrow: 1 }}>
+        {navItems.map((item) => (
+          <ListItem key={item.text} disablePadding sx={{ display: 'block' }}>
+            <ListItemButton
+              component={Link}
+              to={item.path}
+              onClick={handleItemClick}
+              sx={{
+                minHeight: 48,
+                justifyContent: open ? 'initial' : 'center',
+                px: 2.5,
+                color: 'var(--color-bg-primary)',
+                '&:hover': { backgroundColor: 'var(--color-primary)' },
               }}
-            />
-          </ListItemButton>
-        </ListItem>
-      ))}
-    </List>
-  </Drawer>
-);
+            >
+              <ListItemIcon
+                sx={{
+                  minWidth: 0,
+                  mr: open ? 3 : 'auto',
+                  justifyContent: 'center',
+                }}
+              >
+                {item.icon}
+              </ListItemIcon>
+              <ListItemText
+                primary={item.text}
+                slotProps={{
+                  primary: {
+                    sx: {
+                      fontFamily: 'var(--font-vazir)',
+                      opacity: open ? 1 : 0,
+                      transition: 'opacity 0.2s ease',
+                    },
+                  },
+                }}
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+};
 
 export default NavigationDrawer;

--- a/src/constants/navigationDrawer.ts
+++ b/src/constants/navigationDrawer.ts
@@ -7,7 +7,8 @@ import { MdSpaceDashboard, MdStorage } from 'react-icons/md';
 import { RiSettings3Fill } from 'react-icons/ri';
 import type { NavigationItem } from '../@types/navigationDrawer';
 
-export const drawerWidth = 200;
+export const drawerWidth = 240;
+export const collapsedDrawerWidth = 72;
 
 export const navItems: NavigationItem[] = [
   {


### PR DESCRIPTION
## Summary
- convert the navigation drawer to a mini-variant implementation with width transitions and callback support
- update the main layout to shift the app bar and page content alongside the drawer for desktop and mobile breakpoints
- align navigation drawer sizing constants with expanded and collapsed widths

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated chart/AuthPage files)*

------
https://chatgpt.com/codex/tasks/task_b_68db7c6c1d94832fa4fa300ce3f45e61