### PR TITLE
Handle optional OS user creation for Samba users

### DIFF
--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -24,7 +24,11 @@ import SambaUserCreateModal from '../components/users/SambaUserCreateModal';
 import SambaUserPasswordModal from '../components/users/SambaUserPasswordModal';
 import SambaUsersTable from '../components/users/SambaUsersTable';
 import SelectedSambaUsersDetailsPanel from '../components/users/SelectedSambaUsersDetailsPanel';
-import { USERS_TABS, type UsersTabValue } from '../constants/users';
+import {
+  DEFAULT_LOGIN_SHELL,
+  USERS_TABS,
+  type UsersTabValue,
+} from '../constants/users';
 import { useCreateOsUser } from '../hooks/useCreateOsUser';
 import { useCreateSambaUser } from '../hooks/useCreateSambaUser';
 import { useEnableSambaUser } from '../hooks/useEnableSambaUser';
@@ -199,10 +203,34 @@ const Users = () => {
   );
 
   const handleSubmitCreateSambaUser = useCallback(
-    (payload: { username: string; password: string }) => {
-      createSambaUser.mutate(payload);
+    ({
+      username,
+      password,
+      createOsUserFirst,
+    }: {
+      username: string;
+      password: string;
+      createOsUserFirst: boolean;
+    }) => {
+      const run = async () => {
+        if (createOsUserFirst) {
+          try {
+            await createOsUser.mutateAsync({
+              username,
+              login_shell: DEFAULT_LOGIN_SHELL,
+              shell: DEFAULT_LOGIN_SHELL,
+            });
+          } catch {
+            return;
+          }
+        }
+
+        createSambaUser.mutate({ username, password });
+      };
+
+      void run();
     },
-    [createSambaUser]
+    [createOsUser, createSambaUser]
   );
 
   const handleToggleSelectSambaUser = useCallback(


### PR DESCRIPTION
## Summary
- import the default login shell constant into the users page
- update Samba user creation to optionally create a matching OS user before creating the Samba account
- ensure Samba creation only submits username and password after any required OS user creation succeeds

## Testing
- `npm run lint` *(fails: existing react-refresh/only-export-components violations in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68db7dd51784832fb2cfb5ad866e4fe2