### PR TITLE
Implement mini variant navigation drawer

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '../contexts/AuthContext';
 import '../index.css';
 import NavigationDrawer from './NavigationDrawer';
 import ThemeToggle from './ThemeToggle';
+import { drawerWidth } from '../constants/navigationDrawer';
 
 const MainLayout: React.FC = () => {
   const { logout, username } = useAuth();
@@ -24,6 +25,7 @@ const MainLayout: React.FC = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
   const handleLogout = async () => {
     await logout();
@@ -185,7 +187,22 @@ const MainLayout: React.FC = () => {
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
       />
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Box
+        component="main"
+        sx={(theme) => ({
+          flexGrow: 1,
+          p: 3,
+          transition: theme.transitions.create('margin-left', {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.enteringScreen,
+          }),
+          marginLeft: isDesktop
+            ? drawerOpen
+              ? `${drawerWidth}px`
+              : `calc(${theme.spacing(7)} + 1px)`
+            : 0,
+        })}
+      >
         <Toolbar />
         <Outlet />
       </Box>

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -1,5 +1,5 @@
 import {
-  Drawer,
+  Drawer as MuiDrawer,
   IconButton,
   List,
   ListItem,
@@ -7,60 +7,172 @@ import {
   ListItemIcon,
   ListItemText,
   Toolbar,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import type { CSSObject, Theme } from '@mui/material/styles';
 import React from 'react';
 import { MdClose } from 'react-icons/md';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import type { NavigationDrawerProps } from '../@types/navigationDrawer';
 import { drawerWidth, navItems } from '../constants/navigationDrawer';
+
+const openedMixin = (theme: Theme): CSSObject => ({
+  width: drawerWidth,
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.enteringScreen,
+  }),
+  overflowX: 'hidden',
+  backgroundColor: 'var(--color-card-bg)',
+  backdropFilter: 'saturate(140%) blur(8px)',
+  boxSizing: 'border-box' as const,
+});
+
+const closedMixin = (theme: Theme): CSSObject => ({
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  overflowX: 'hidden',
+  backgroundColor: 'var(--color-card-bg)',
+  backdropFilter: 'saturate(140%) blur(8px)',
+  boxSizing: 'border-box' as const,
+  width: `calc(${theme.spacing(7)} + 1px)`,
+  [theme.breakpoints.up('sm')]: {
+    width: `calc(${theme.spacing(8)} + 1px)`,
+  },
+});
+
+const StyledDrawer = styled(MuiDrawer, {
+  shouldForwardProp: (prop) => prop !== 'open',
+})<{ open?: boolean }>(({ theme, open }) => ({
+  width: drawerWidth,
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+  boxSizing: 'border-box',
+  ...(open && {
+    ...openedMixin(theme),
+    '& .MuiDrawer-paper': openedMixin(theme),
+  }),
+  ...(!open && {
+    ...closedMixin(theme),
+    '& .MuiDrawer-paper': closedMixin(theme),
+  }),
+}));
 
 const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
   open,
   onClose,
-}) => (
-  <Drawer
-    anchor="left"
-    open={open}
-    onClose={onClose}
-    slotProps={{ transition: { direction: 'left' } }}
-    sx={{
-      '& .MuiDrawer-paper': {
-        width: drawerWidth,
-        boxSizing: 'border-box',
-        backgroundColor: 'var(--color-card-bg)',
-        backdropFilter: 'saturate(140%) blur(8px)',
-      },
-    }}
-  >
-    <Toolbar sx={{ justifyContent: 'space-between' }}>
-      <IconButton onClick={onClose} sx={{ color: 'var(--color-bg-primary)' }}>
-        <MdClose />
-      </IconButton>
-    </Toolbar>
+}) => {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+  const location = useLocation();
+
+  const handleItemClick = () => {
+    if (!isDesktop) {
+      onClose();
+    }
+  };
+
+  const renderNavItems = () => (
     <List>
-      {navItems.map((item) => (
-        <ListItem key={item.text} disablePadding>
-          <ListItemButton
-            component={Link}
-            to={item.path}
-            onClick={onClose}
-            sx={{
-              color: 'var(--color-bg-primary)',
-              '&:hover': { backgroundColor: 'var(--color-primary)' },
-            }}
-          >
-            <ListItemIcon>{item.icon}</ListItemIcon>
-            <ListItemText
-              primary={item.text}
-              slotProps={{
-                primary: { sx: { fontFamily: 'var(--font-vazir)' } },
+      {navItems.map((item) => {
+        const isActive = location.pathname.startsWith(item.path);
+
+        return (
+          <ListItem key={item.text} disablePadding sx={{ display: 'block' }}>
+            <ListItemButton
+              component={Link}
+              to={item.path}
+              onClick={handleItemClick}
+              selected={isActive}
+              sx={{
+                color: 'var(--color-bg-primary)',
+                minHeight: 48,
+                justifyContent: open ? 'initial' : 'center',
+                px: 2.5,
+                '&.Mui-selected': {
+                  backgroundColor: 'var(--color-primary)',
+                  color: 'var(--color-card-bg)',
+                  '& .MuiListItemIcon-root': {
+                    color: 'var(--color-card-bg)',
+                  },
+                },
+                '&.Mui-selected:hover': {
+                  backgroundColor: 'var(--color-primary)',
+                },
+                '&:hover': {
+                  backgroundColor: 'var(--color-primary)',
+                  color: 'var(--color-card-bg)',
+                  '& .MuiListItemIcon-root': {
+                    color: 'var(--color-card-bg)',
+                  },
+                },
               }}
-            />
-          </ListItemButton>
-        </ListItem>
-      ))}
+            >
+              <ListItemIcon
+                sx={{
+                  minWidth: 0,
+                  mr: open ? 2 : 'auto',
+                  justifyContent: 'center',
+                  color: 'var(--color-bg-primary)',
+                }}
+              >
+                {item.icon}
+              </ListItemIcon>
+              <ListItemText
+                primary={item.text}
+                sx={{ opacity: open ? 1 : 0 }}
+                primaryTypographyProps={{ sx: { fontFamily: 'var(--font-vazir)' } }}
+              />
+            </ListItemButton>
+          </ListItem>
+        );
+      })}
     </List>
-  </Drawer>
-);
+  );
+
+  if (!isDesktop) {
+    return (
+      <MuiDrawer
+        anchor="left"
+        open={open}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        slotProps={{ transition: { direction: 'left' } }}
+        sx={{
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+            backgroundColor: 'var(--color-card-bg)',
+            backdropFilter: 'saturate(140%) blur(8px)',
+          },
+        }}
+      >
+        <Toolbar sx={{ justifyContent: 'space-between' }}>
+          <IconButton onClick={onClose} sx={{ color: 'var(--color-bg-primary)' }}>
+            <MdClose />
+          </IconButton>
+        </Toolbar>
+        {renderNavItems()}
+      </MuiDrawer>
+    );
+  }
+
+  return (
+    <StyledDrawer variant="permanent" open={open}>
+      <Toolbar sx={{ justifyContent: open ? 'flex-end' : 'center' }}>
+        {open && (
+          <IconButton onClick={onClose} sx={{ color: 'var(--color-bg-primary)' }}>
+            <MdClose />
+          </IconButton>
+        )}
+      </Toolbar>
+      {renderNavItems()}
+    </StyledDrawer>
+  );
+};
 
 export default NavigationDrawer;


### PR DESCRIPTION
## Summary
- replace the navigation drawer with a responsive mini-variant implementation that keeps icons visible when collapsed and highlights the active route
- adjust the main layout so desktop content shifts with the drawer width while preserving the existing mobile temporary drawer behaviour

## Testing
- npm run build *(fails: pre-existing TypeScript errors in BlurModal, charts components, AuthPage, and IntegratedStorage)*

------
https://chatgpt.com/codex/tasks/task_b_68db84299d60832facd570ce875d5d1b