### PR TITLE
Add network interface IP edit modal

### DIFF
--- a/src/@types/network.ts
+++ b/src/@types/network.ts
@@ -10,3 +10,9 @@ export type IPv4Info = {
   address: string;
   netmask: string | null;
 };
+
+export type UpdateInterfaceIpPayload = {
+  interfaceName: string;
+  ip: string;
+  netmask: string;
+};

--- a/src/components/settings/NetworkInterfaceIpEditModal.tsx
+++ b/src/components/settings/NetworkInterfaceIpEditModal.tsx
@@ -1,0 +1,146 @@
+import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import { type FormEvent, useEffect, useState } from 'react';
+import BlurModal from '../BlurModal';
+
+interface NetworkInterfaceIpEditModalProps {
+  open: boolean;
+  interfaceName: string | null;
+  initialIp: string;
+  initialNetmask: string;
+  onClose: () => void;
+  onSubmit: (payload: { ip: string; netmask: string }) => void;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+}
+
+const NetworkInterfaceIpEditModal = ({
+  open,
+  interfaceName,
+  initialIp,
+  initialNetmask,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+}: NetworkInterfaceIpEditModalProps) => {
+  const [ip, setIp] = useState(initialIp);
+  const [netmask, setNetmask] = useState(initialNetmask);
+
+  useEffect(() => {
+    if (open) {
+      setIp(initialIp);
+      setNetmask(initialNetmask);
+    }
+  }, [initialIp, initialNetmask, open]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!interfaceName) {
+      return;
+    }
+
+    onSubmit({ ip, netmask });
+  };
+
+  return (
+    <BlurModal
+      open={open}
+      onClose={onClose}
+      title="ویرایش آدرس IP"
+      actions={
+        <Button
+          type="submit"
+          form="network-interface-ip-edit-form"
+          variant="contained"
+          disabled={isSubmitting || !interfaceName || !ip || !netmask}
+          sx={{
+            px: 3,
+            py: 1,
+            fontWeight: 600,
+            background:
+              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+            color: 'var(--color-bg)',
+            '&:hover': {
+              background:
+                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+            },
+            '&.Mui-disabled': {
+              backgroundColor:
+                'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+              color: 'var(--color-secondary)',
+            },
+          }}
+        >
+          {isSubmitting ? 'در حال ارسال...' : 'ثبت تغییرات'}
+        </Button>
+      }
+    >
+      <Box
+        component="form"
+        id="network-interface-ip-edit-form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+      >
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          آدرس IP و نت‌ماسک جدید برای رابط انتخاب‌شده را وارد کنید.
+        </Typography>
+
+        <TextField
+          label="رابط شبکه"
+          value={interfaceName ?? ''}
+          disabled
+          fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-secondary)' },
+            },
+          }}
+        />
+
+        <TextField
+          label="آدرس IP"
+          value={ip}
+          onChange={(event) => setIp(event.target.value)}
+          required
+          fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
+        />
+
+        <TextField
+          label="نت‌ماسک"
+          value={netmask}
+          onChange={(event) => setNetmask(event.target.value)}
+          required
+          fullWidth
+          InputLabelProps={{ sx: { color: 'var(--color-secondary)' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'var(--color-input-bg)',
+              borderRadius: 1,
+              '& .MuiInputBase-input': { color: 'var(--color-text)' },
+            },
+          }}
+        />
+
+        {errorMessage ? (
+          <Alert severity="error" sx={{ mt: 1 }}>
+            {errorMessage}
+          </Alert>
+        ) : null}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default NetworkInterfaceIpEditModal;

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -34,6 +34,8 @@ export interface NetworkData {
   interfaces: Record<string, NetworkInterface>;
 }
 
+export const networkQueryKey = ['network'] as const;
+
 const fetchNetwork = async () => {
   const { data } = await axiosInstance.get<NetworkData>('/api/net');
   return data;
@@ -41,7 +43,7 @@ const fetchNetwork = async () => {
 
 export const useNetwork = (enabled = true) => {
   return useQuery<NetworkData, Error>({
-    queryKey: ['network'],
+    queryKey: networkQueryKey,
     queryFn: fetchNetwork,
     refetchInterval: enabled ? 1000 : false,
     enabled,

--- a/src/hooks/useUpdateInterfaceIp.ts
+++ b/src/hooks/useUpdateInterfaceIp.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { UpdateInterfaceIpPayload } from '../@types/network';
+import axiosInstance from '../lib/axiosInstance';
+import type { ApiErrorResponse } from '../utils/apiError';
+import { extractApiErrorMessage } from '../utils/apiError';
+import { networkQueryKey } from './useNetwork';
+
+const updateInterfaceIpRequest = async ({
+  interfaceName,
+  ip,
+  netmask,
+}: UpdateInterfaceIpPayload) => {
+  const endpoint = `/api/net/nicfile/${encodeURIComponent(
+    interfaceName
+  )}/ip/edit/`;
+
+  await axiosInstance.post(endpoint, { ip, netmask });
+};
+
+interface UseUpdateInterfaceIpOptions {
+  onSuccess?: (interfaceName: string) => void;
+  onError?: (message: string) => void;
+}
+
+export const useUpdateInterfaceIp = ({
+  onSuccess,
+  onError,
+}: UseUpdateInterfaceIpOptions = {}) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    unknown,
+    AxiosError<ApiErrorResponse>,
+    UpdateInterfaceIpPayload
+  >({
+    mutationFn: updateInterfaceIpRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: networkQueryKey });
+      onSuccess?.(variables.interfaceName);
+    },
+    onError: (error) => {
+      const message = extractApiErrorMessage(error);
+      onError?.(message);
+    },
+  });
+};
+
+export type UseUpdateInterfaceIpReturn = ReturnType<typeof useUpdateInterfaceIp>;


### PR DESCRIPTION
## Summary
- add a reusable modal for editing interface IPv4 details in the network settings tab
- add a React Query mutation hook to post IP updates and refresh network data
- wire the edit action to open the modal and show success or error toasts

## Testing
- npm run lint *(fails: react-refresh/only-export-components in src/contexts/AuthContext.tsx and src/contexts/ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68db8a2557ac832fa014b7430f25b204