### PR TITLE
Add real-time path validation to share creation

### DIFF
--- a/src/hooks/useCreateShare.ts
+++ b/src/hooks/useCreateShare.ts
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react';
 import { useCallback, useState } from 'react';
 import type { CreateSambaSharePayload } from '../@types/samba';
 import axiosInstance from '../lib/axiosInstance';
+import { useDirPermissionsValidation } from './useDirPermissionsValidation';
 import { sambaSharesQueryKey } from './useSambaShares';
 
 interface ApiErrorResponse {
@@ -65,11 +66,28 @@ export const useCreateShare = ({
 }: UseCreateShareOptions = {}) => {
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
-  const [fullPath, setFullPath] = useState('');
-  const [validUsers, setValidUsers] = useState('');
+  const [fullPath, setFullPathState] = useState('');
+  const [validUsers, setValidUsersState] = useState('');
   const [fullPathError, setFullPathError] = useState<string | null>(null);
   const [validUsersError, setValidUsersError] = useState<string | null>(null);
   const [apiError, setApiError] = useState<string | null>(null);
+  const dirPermissionsValidation = useDirPermissionsValidation(fullPath);
+  const setFullPath = useCallback(
+    (value: string) => {
+      setFullPathState(value);
+      setFullPathError(null);
+      setApiError(null);
+    },
+    [setApiError, setFullPathError, setFullPathState]
+  );
+  const setValidUsers = useCallback(
+    (value: string) => {
+      setValidUsersState(value);
+      setValidUsersError(null);
+      setApiError(null);
+    },
+    [setApiError, setValidUsersError, setValidUsersState]
+  );
 
   const resetForm = useCallback(() => {
     setFullPath('');
@@ -77,7 +95,13 @@ export const useCreateShare = ({
     setFullPathError(null);
     setValidUsersError(null);
     setApiError(null);
-  }, []);
+  }, [
+    setApiError,
+    setFullPath,
+    setFullPathError,
+    setValidUsers,
+    setValidUsersError,
+  ]);
 
   const handleOpen = useCallback(() => {
     resetForm();
@@ -126,6 +150,15 @@ export const useCreateShare = ({
       if (!trimmedPath) {
         setFullPathError('لطفاً مسیر کامل اشتراک را وارد کنید.');
         hasError = true;
+      } else if (dirPermissionsValidation.isChecking) {
+        setFullPathError('در حال بررسی مسیر، لطفاً کمی صبر کنید.');
+        hasError = true;
+      } else if (!dirPermissionsValidation.isValid) {
+        setFullPathError(
+          dirPermissionsValidation.message ??
+            'لطفاً مسیری معتبر با دسترسی مناسب انتخاب کنید.'
+        );
+        hasError = true;
       }
 
       if (!trimmedUsers) {
@@ -142,7 +175,14 @@ export const useCreateShare = ({
         valid_users: trimmedUsers,
       });
     },
-    [createShareMutation, fullPath, validUsers]
+    [
+      createShareMutation,
+      dirPermissionsValidation.isChecking,
+      dirPermissionsValidation.isValid,
+      dirPermissionsValidation.message,
+      fullPath,
+      validUsers,
+    ]
   );
 
   return {
@@ -153,6 +193,10 @@ export const useCreateShare = ({
     validUsersError,
     apiError,
     isCreating: createShareMutation.isPending,
+    pathValidationStatus: dirPermissionsValidation.status,
+    pathValidationMessage: dirPermissionsValidation.message,
+    isPathChecking: dirPermissionsValidation.isChecking,
+    isPathValid: dirPermissionsValidation.isValid,
     openCreateModal: handleOpen,
     closeCreateModal,
     setFullPath,

--- a/src/hooks/useDirPermissionsValidation.ts
+++ b/src/hooks/useDirPermissionsValidation.ts
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { AxiosError } from 'axios';
+import axios from 'axios';
+import axiosInstance from '../lib/axiosInstance';
+
+interface DirPermissionsErrorPayload {
+  message?: string;
+  [key: string]: unknown;
+}
+
+interface DirPermissionsResponse {
+  ok?: boolean;
+  error?: DirPermissionsErrorPayload | null;
+  [key: string]: unknown;
+}
+
+export type DirPermissionsValidationStatus =
+  | 'idle'
+  | 'checking'
+  | 'valid'
+  | 'invalid';
+
+interface UseDirPermissionsValidationOptions {
+  debounceMs?: number;
+}
+
+interface DirPermissionsValidationState {
+  status: DirPermissionsValidationStatus;
+  message: string | null;
+  lastCheckedPath: string | null;
+}
+
+const DEFAULT_OPTIONS: Required<UseDirPermissionsValidationOptions> = {
+  debounceMs: 500,
+};
+
+const extractErrorMessage = (error: unknown): string => {
+  if (axios.isCancel(error)) {
+    return '';
+  }
+
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as
+      | DirPermissionsResponse
+      | DirPermissionsErrorPayload
+      | undefined;
+
+    if (data && typeof data === 'object') {
+      const message =
+        'message' in data && typeof data.message === 'string'
+          ? data.message
+          : 'ok' in data && data.ok === false && 'error' in data
+            ? resolveResponseMessage(data as DirPermissionsResponse)
+            : undefined;
+
+      if (message && message.trim()) {
+        return message.trim();
+      }
+    }
+
+    if (typeof error.message === 'string' && error.message.trim()) {
+      return error.message;
+    }
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'خطا در بررسی مسیر انتخاب‌شده رخ داد.';
+};
+
+const resolveResponseMessage = (
+  response: DirPermissionsResponse
+): string | null => {
+  if (response.ok) {
+    return null;
+  }
+
+  const errorPayload = response.error;
+
+  if (!errorPayload) {
+    return 'اجازه دسترسی به این مسیر وجود ندارد.';
+  }
+
+  if (typeof errorPayload.message === 'string' && errorPayload.message.trim()) {
+    return errorPayload.message.trim();
+  }
+
+  return 'اجازه دسترسی به این مسیر وجود ندارد.';
+};
+
+export const useDirPermissionsValidation = (
+  path: string,
+  options?: UseDirPermissionsValidationOptions
+) => {
+  const { debounceMs } = useMemo(
+    () => ({ ...DEFAULT_OPTIONS, ...options }),
+    [options]
+  );
+  const [state, setState] = useState<DirPermissionsValidationState>({
+    status: 'idle',
+    message: null,
+    lastCheckedPath: null,
+  });
+
+  useEffect(() => {
+    const trimmedPath = path.trim();
+
+    if (!trimmedPath) {
+      setState({ status: 'idle', message: null, lastCheckedPath: null });
+      return undefined;
+    }
+
+    setState((prev) => ({
+      status: 'checking',
+      message: prev.lastCheckedPath === trimmedPath ? prev.message : null,
+      lastCheckedPath: prev.lastCheckedPath,
+    }));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      const requestConfig = {
+        url: '/api/dir/info/permissions/',
+        method: 'GET' as const,
+        data: { path: trimmedPath },
+        signal: controller.signal,
+      };
+
+      axiosInstance
+        .request<DirPermissionsResponse>(requestConfig)
+        .then(({ data }) => {
+          const message = resolveResponseMessage(data);
+
+          setState({
+            status: message ? 'invalid' : 'valid',
+            message,
+            lastCheckedPath: trimmedPath,
+          });
+        })
+        .catch((error: AxiosError | Error) => {
+          if (axios.isCancel(error)) {
+            return;
+          }
+
+          const message = extractErrorMessage(error);
+
+          setState({
+            status: 'invalid',
+            message: message || 'خطا در بررسی مسیر انتخاب‌شده رخ داد.',
+            lastCheckedPath: trimmedPath,
+          });
+        });
+    }, debounceMs);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeoutId);
+    };
+  }, [debounceMs, path]);
+
+  return {
+    status: state.status,
+    message: state.message,
+    isChecking: state.status === 'checking',
+    isValid: state.status === 'valid',
+  };
+};
+
+export type UseDirPermissionsValidationReturn = ReturnType<
+  typeof useDirPermissionsValidation
+>;


### PR DESCRIPTION
## Summary
- add a reusable debounced hook to validate directory permissions before creating a share
- surface validation feedback and status icons in the share creation modal while enforcing Samba user selection
- reset form state cohesively when reopening or editing the share creation modal

## Testing
- npm run build *(fails: existing TypeScript issues in unrelated components such as BlurModal and charts)*

------
https://chatgpt.com/codex/tasks/task_b_68db8edba0f0832fbfd0c1e1838a789e