### PR TITLE
Add restart and shutdown controls to navbar

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -2,33 +2,96 @@ import {
   AppBar,
   Box,
   Button,
+  CircularProgress,
   IconButton,
   TextField,
   Toolbar,
+  Tooltip,
   Typography,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
 import React, { useState } from 'react';
 import { IoPersonCircleOutline } from 'react-icons/io5';
-import { MdClose, MdLogout, MdMenu, MdSearch } from 'react-icons/md';
+import {
+  MdClose,
+  MdLogout,
+  MdMenu,
+  MdPowerSettingsNew,
+  MdRestartAlt,
+  MdSearch,
+} from 'react-icons/md';
 import { Outlet } from 'react-router';
+import { toast } from 'react-hot-toast';
 import { useAuth } from '../contexts/AuthContext';
 import '../index.css';
 import NavigationDrawer from './NavigationDrawer';
 import ThemeToggle from './ThemeToggle';
 import { drawerWidth } from '../constants/navigationDrawer';
+import { usePowerAction, type PowerAction } from '../hooks/usePowerAction';
+
+const powerButtonBaseSx = {
+  color: '#fff',
+  borderRadius: '12px',
+  padding: '8px',
+  minWidth: 0,
+  boxShadow: '0 10px 24px rgba(0, 0, 0, 0.18)',
+  transition: 'transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease',
+  '&:hover': {
+    transform: 'translateY(-3px) scale(1.05)',
+    boxShadow: '0 14px 28px rgba(0, 0, 0, 0.25)',
+    filter: 'brightness(1.05)',
+  },
+  '&:active': {
+    transform: 'scale(0.95)',
+  },
+  '&:disabled': {
+    opacity: 0.65,
+    boxShadow: 'none',
+    transform: 'none',
+    filter: 'none',
+  },
+} as const;
+
+const createPowerButtonSx = (gradient: string) => ({
+  ...powerButtonBaseSx,
+  background: gradient,
+});
 
 const MainLayout: React.FC = () => {
   const { logout, username } = useAuth();
   const [searchQuery, setSearchQuery] = useState('');
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [activePowerAction, setActivePowerAction] = useState<PowerAction | null>(null);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
+  const { mutate: triggerPowerAction, isPending: isPowerActionPending } =
+    usePowerAction({
+      onSuccess: (_data, action) => {
+        const successMessage =
+          action === 'restart'
+            ? 'سیستم در حال راه‌اندازی مجدد است.'
+            : 'سیستم در حال خاموش شدن است.';
+        toast.success(successMessage);
+      },
+      onError: (message, action) => {
+        const actionLabel = action === 'restart' ? 'راه‌اندازی مجدد' : 'خاموش کردن';
+        toast.error(`${actionLabel} سیستم با خطا مواجه شد: ${message}`);
+      },
+      onSettled: () => {
+        setActivePowerAction(null);
+      },
+    });
+
   const handleLogout = async () => {
     await logout();
+  };
+
+  const handlePowerAction = (action: PowerAction) => {
+    setActivePowerAction(action);
+    triggerPowerAction(action);
   };
 
   return (
@@ -179,6 +242,42 @@ const MainLayout: React.FC = () => {
                 خروج
               </Button>
             )}
+            <Tooltip title="راه‌اندازی مجدد سیستم" placement="bottom">
+              <span>
+                <IconButton
+                  aria-label="راه‌اندازی مجدد سیستم"
+                  onClick={() => handlePowerAction('restart')}
+                  disabled={isPowerActionPending}
+                  sx={createPowerButtonSx(
+                    'linear-gradient(135deg, var(--color-primary), var(--color-primary-light))'
+                  )}
+                >
+                  {isPowerActionPending && activePowerAction === 'restart' ? (
+                    <CircularProgress size={18} sx={{ color: '#fff' }} />
+                  ) : (
+                    <MdRestartAlt size={22} />
+                  )}
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="خاموش کردن سیستم" placement="bottom">
+              <span>
+                <IconButton
+                  aria-label="خاموش کردن سیستم"
+                  onClick={() => handlePowerAction('shutdown')}
+                  disabled={isPowerActionPending}
+                  sx={createPowerButtonSx(
+                    'linear-gradient(135deg, #f97316, var(--color-secondary))'
+                  )}
+                >
+                  {isPowerActionPending && activePowerAction === 'shutdown' ? (
+                    <CircularProgress size={18} sx={{ color: '#fff' }} />
+                  ) : (
+                    <MdPowerSettingsNew size={22} />
+                  )}
+                </IconButton>
+              </span>
+            </Tooltip>
             <ThemeToggle fixed={false} />
           </Box>
         </Toolbar>

--- a/src/hooks/usePowerAction.ts
+++ b/src/hooks/usePowerAction.ts
@@ -1,0 +1,70 @@
+import { useMutation } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import axiosInstance from '../lib/axiosInstance';
+
+export type PowerAction = 'restart' | 'shutdown';
+
+interface PowerActionResponse {
+  detail?: string;
+  message?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+type ApiErrorResponse = string | { detail?: string; message?: string; error?: string };
+
+interface UsePowerActionOptions {
+  onSuccess?: (data: PowerActionResponse, action: PowerAction) => void;
+  onError?: (message: string, action: PowerAction) => void;
+  onSettled?: () => void;
+}
+
+const getEndpoint = (action: PowerAction) => `/api/os/power/${action}`;
+
+const extractErrorMessage = (error: AxiosError<ApiErrorResponse>) => {
+  const payload = error.response?.data;
+
+  if (!payload) {
+    return error.message;
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload.detail && typeof payload.detail === 'string') {
+    return payload.detail;
+  }
+
+  if (payload.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  if (payload.error && typeof payload.error === 'string') {
+    return payload.error;
+  }
+
+  return error.message;
+};
+
+export const usePowerAction = (options: UsePowerActionOptions = {}) =>
+  useMutation<PowerActionResponse, AxiosError<ApiErrorResponse>, PowerAction>({
+    mutationFn: async (action) => {
+      const { data } = await axiosInstance.get<PowerActionResponse>(
+        getEndpoint(action)
+      );
+      return data;
+    },
+    onSuccess: (data, variables) => {
+      options.onSuccess?.(data, variables);
+    },
+    onError: (error, variables) => {
+      const message = extractErrorMessage(error);
+      options.onError?.(message, variables);
+    },
+    onSettled: () => {
+      options.onSettled?.();
+    },
+  });
+
+export type UsePowerActionReturn = ReturnType<typeof usePowerAction>;


### PR DESCRIPTION
## Summary
- add a dedicated power action hook to trigger the OS power management endpoints
- enhance the main layout navbar with restart and shutdown controls, styling, and user feedback

## Testing
- npm run lint *(fails: Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components)*

------
https://chatgpt.com/codex/tasks/task_b_68db983ad780832faa233d0c33a67d0e