### PR TITLE
Add directory permission setup before creating Samba shares

### DIFF
--- a/src/@types/samba.ts
+++ b/src/@types/samba.ts
@@ -21,6 +21,18 @@ export interface CreateSambaSharePayload {
   valid_users: string;
 }
 
+export interface CreateDirectoryPermissionsPayload {
+  path: string;
+  owner: string;
+  group: string;
+  mode?: string;
+}
+
+export interface CreateShareWithPermissionsPayload
+  extends CreateSambaSharePayload {
+  mode?: string;
+}
+
 export type RawSambaUserDetails = Record<string, unknown>;
 
 export type SambaUsersResponseData =

--- a/src/hooks/useCreateShare.ts
+++ b/src/hooks/useCreateShare.ts
@@ -2,8 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import type { FormEvent } from 'react';
 import { useCallback, useState } from 'react';
-import type { CreateSambaSharePayload } from '../@types/samba';
-import axiosInstance from '../lib/axiosInstance';
+import type { CreateShareWithPermissionsPayload } from '../@types/samba';
+import { createShareWithDirectoryPermissions } from '../lib/shareService';
 import { sambaSharesQueryKey } from './useSambaShares';
 
 interface ApiErrorResponse {
@@ -43,10 +43,6 @@ const extractApiMessage = (error: AxiosError<ApiErrorResponse>) => {
   }
 
   return error.message;
-};
-
-const createShareRequest = async (payload: CreateSambaSharePayload) => {
-  await axiosInstance.post('/api/samba/create/', payload);
 };
 
 const deriveShareDisplayName = (fullPath: string) => {
@@ -92,9 +88,9 @@ export const useCreateShare = ({
   const createShareMutation = useMutation<
     unknown,
     AxiosError<ApiErrorResponse>,
-    CreateSambaSharePayload
+    CreateShareWithPermissionsPayload
   >({
-    mutationFn: createShareRequest,
+    mutationFn: createShareWithDirectoryPermissions,
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: sambaSharesQueryKey });
       handleClose();

--- a/src/lib/shareService.ts
+++ b/src/lib/shareService.ts
@@ -1,0 +1,46 @@
+import type {
+  CreateDirectoryPermissionsPayload,
+  CreateShareWithPermissionsPayload,
+  CreateSambaSharePayload,
+} from '../@types/samba';
+import axiosInstance from './axiosInstance';
+
+export const DEFAULT_SHARE_DIRECTORY_MODE = '0700';
+
+const createDirectoryWithPermissions = async ({
+  path,
+  mode = DEFAULT_SHARE_DIRECTORY_MODE,
+  owner,
+  group,
+}: CreateDirectoryPermissionsPayload) => {
+  await axiosInstance.post('/api/dir/create/permissions/', {
+    path,
+    mode,
+    owner,
+    group,
+  });
+};
+
+const createSambaShare = async (payload: CreateSambaSharePayload) => {
+  await axiosInstance.post('/api/samba/create/', payload);
+};
+
+export const createShareWithDirectoryPermissions = async ({
+  full_path,
+  valid_users,
+  mode = DEFAULT_SHARE_DIRECTORY_MODE,
+}: CreateShareWithPermissionsPayload) => {
+  const sanitizedUser = valid_users.trim();
+
+  await createDirectoryWithPermissions({
+    path: full_path,
+    mode,
+    owner: sanitizedUser,
+    group: sanitizedUser,
+  });
+
+  await createSambaShare({
+    full_path,
+    valid_users,
+  });
+};


### PR DESCRIPTION
## Summary
- add type definitions for directory permission payloads used during share creation
- create a dedicated share service that issues directory permission and Samba share API requests
- update the share creation hook to orchestrate both API calls before refreshing the share list

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68dbac4c1054832f88186abbae666945