### PR TITLE
feat: add shared modal action buttons

### DIFF
--- a/src/components/block-storage/ConfirmDeleteVolumeModal.tsx
+++ b/src/components/block-storage/ConfirmDeleteVolumeModal.tsx
@@ -1,15 +1,11 @@
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import type { UseDeleteVolumeReturn } from '../../hooks/useDeleteVolume';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface ConfirmDeleteVolumeModalProps {
   controller: UseDeleteVolumeReturn;
 }
-
-const buttonStyles = {
-  borderRadius: '10px',
-  fontWeight: 600,
-};
 
 const ConfirmDeleteVolumeModal = ({
   controller,
@@ -29,26 +25,16 @@ const ConfirmDeleteVolumeModal = ({
       onClose={closeModal}
       title="حذف Volume"
       actions={
-        <>
-          <Button
-            onClick={closeModal}
-            color="inherit"
-            variant="outlined"
-            disabled={isDeleting}
-            sx={buttonStyles}
-          >
-            انصراف
-          </Button>
-          <Button
-            onClick={confirmDelete}
-            variant="contained"
-            color="error"
-            disabled={isDeleting}
-            sx={buttonStyles}
-          >
-            {isDeleting ? 'در حال حذف…' : 'حذف'}
-          </Button>
-        </>
+        <ModalActionButtons
+          onCancel={closeModal}
+          onConfirm={confirmDelete}
+          confirmLabel="حذف"
+          loadingLabel="در حال حذف…"
+          isLoading={isDeleting}
+          disabled={isDeleting}
+          disableConfirmGradient
+          confirmProps={{ color: 'error' }}
+        />
       }
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/src/components/block-storage/CreateVolumeModal.tsx
+++ b/src/components/block-storage/CreateVolumeModal.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   FormControl,
   FormHelperText,
   InputLabel,
@@ -13,16 +12,12 @@ import type { SelectChangeEvent } from '@mui/material/Select';
 import type { ChangeEvent } from 'react';
 import type { UseCreateVolumeReturn } from '../../hooks/useCreateVolume';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface CreateVolumeModalProps {
   controller: UseCreateVolumeReturn;
   poolOptions: string[];
 }
-
-const buttonBaseStyles = {
-  borderRadius: '10px',
-  fontWeight: 600,
-};
 
 const inputBaseStyles = {
   backgroundColor: 'var(--color-input-bg)',
@@ -84,36 +79,17 @@ const CreateVolumeModal = ({
       onClose={closeCreateModal}
       title="ایجاد Volume جدید"
       actions={
-        <>
-          <Button
-            onClick={closeCreateModal}
-            variant="outlined"
-            color="inherit"
-            disabled={isCreating}
-            sx={{ ...buttonBaseStyles, px: 3 }}
-          >
-            انصراف
-          </Button>
-          <Button
-            type="submit"
-            form="create-volume-form"
-            variant="contained"
-            disabled={isCreating}
-            sx={{
-              ...buttonBaseStyles,
-              px: 4,
-              background:
-                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
-              boxShadow: '0 14px 28px -18px rgba(0, 198, 169, 0.8)',
-              '&:hover': {
-                background:
-                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
-              },
-            }}
-          >
-            {isCreating ? 'در حال ایجاد…' : 'ایجاد'}
-          </Button>
-        </>
+        <ModalActionButtons
+          onCancel={closeCreateModal}
+          confirmLabel="ایجاد"
+          loadingLabel="در حال ایجاد…"
+          isLoading={isCreating}
+          disabled={isCreating}
+          confirmProps={{
+            type: 'submit',
+            form: 'create-volume-form',
+          }}
+        />
       }
     >
       <Box component="form" id="create-volume-form" onSubmit={handleSubmit}>

--- a/src/components/common/ModalActionButtons.tsx
+++ b/src/components/common/ModalActionButtons.tsx
@@ -1,0 +1,136 @@
+import { Button } from '@mui/material';
+import type { ButtonProps, SxProps, Theme } from '@mui/material';
+
+interface ModalActionButtonsProps {
+  onConfirm?: ButtonProps['onClick'];
+  onCancel?: ButtonProps['onClick'];
+  confirmLabel: string;
+  cancelLabel?: string;
+  disabled?: boolean;
+  isLoading?: boolean;
+  loadingLabel?: string;
+  confirmProps?: ButtonProps;
+  cancelProps?: ButtonProps;
+  disableConfirmGradient?: boolean;
+}
+
+const baseButtonSx: SxProps<Theme> = {
+  borderRadius: '10px',
+  fontWeight: 600,
+};
+
+const gradientButtonSx: SxProps<Theme> = {
+  px: 4,
+  background:
+    'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+  boxShadow: '0 14px 28px -18px rgba(0, 198, 169, 0.8)',
+  '&:hover': {
+    background:
+      'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+  },
+};
+
+const cancelButtonSx: SxProps<Theme> = {
+  px: 3,
+};
+
+const mergeSx = (
+  ...styles: Array<SxProps<Theme> | undefined>
+): SxProps<Theme> =>
+  styles
+    .filter(Boolean)
+    .flatMap((style) =>
+      Array.isArray(style) ? style : [style]
+    ) as SxProps<Theme>;
+
+const ModalActionButtons = ({
+  onConfirm,
+  onCancel,
+  confirmLabel,
+  cancelLabel = 'انصراف',
+  disabled = false,
+  isLoading = false,
+  loadingLabel,
+  confirmProps,
+  cancelProps,
+  disableConfirmGradient = false,
+}: ModalActionButtonsProps) => {
+  const {
+    sx: confirmSxProp,
+    disabled: confirmDisabledProp,
+    onClick: confirmOnClickProp,
+    variant: confirmVariant,
+    color: confirmColor,
+    ...confirmRest
+  } = confirmProps ?? {};
+
+  const {
+    sx: cancelSxProp,
+    disabled: cancelDisabledProp,
+    onClick: cancelOnClickProp,
+    variant: cancelVariant,
+    color: cancelColor,
+    ...cancelRest
+  } = cancelProps ?? {};
+
+  const handleConfirmClick: ButtonProps['onClick'] = (event) => {
+    if (confirmOnClickProp) {
+      confirmOnClickProp(event);
+    }
+
+    if (onConfirm) {
+      onConfirm(event);
+    }
+  };
+
+  const handleCancelClick: ButtonProps['onClick'] = (event) => {
+    if (cancelOnClickProp) {
+      cancelOnClickProp(event);
+    }
+
+    if (onCancel) {
+      onCancel(event);
+    }
+  };
+
+  const confirmDisabled = Boolean(disabled || isLoading || confirmDisabledProp);
+  const cancelDisabled = Boolean(disabled || cancelDisabledProp);
+
+  const confirmSx = mergeSx(
+    baseButtonSx,
+    disableConfirmGradient ? undefined : gradientButtonSx,
+    confirmSxProp
+  );
+
+  const cancelSx = mergeSx(baseButtonSx, cancelButtonSx, cancelSxProp);
+
+  return (
+    <>
+      {onCancel ? (
+        <Button
+          onClick={handleCancelClick}
+          variant={cancelVariant ?? 'outlined'}
+          color={cancelColor ?? 'inherit'}
+          disabled={cancelDisabled}
+          sx={cancelSx}
+          {...cancelRest}
+        >
+          {cancelLabel}
+        </Button>
+      ) : null}
+
+      <Button
+        onClick={handleConfirmClick}
+        variant={confirmVariant ?? 'contained'}
+        color={confirmColor}
+        disabled={confirmDisabled}
+        sx={confirmSx}
+        {...confirmRest}
+      >
+        {isLoading && loadingLabel ? loadingLabel : confirmLabel}
+      </Button>
+    </>
+  );
+};
+
+export default ModalActionButtons;

--- a/src/components/integrated-storage/ConfirmDeletePoolModal.tsx
+++ b/src/components/integrated-storage/ConfirmDeletePoolModal.tsx
@@ -1,15 +1,11 @@
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import type { UseDeleteZpoolReturn } from '../../hooks/useDeleteZpool';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface ConfirmDeletePoolModalProps {
   controller: UseDeleteZpoolReturn;
 }
-
-const buttonStyles = {
-  borderRadius: '10px',
-  fontWeight: 600,
-};
 
 const ConfirmDeletePoolModal = ({
   controller,
@@ -29,26 +25,16 @@ const ConfirmDeletePoolModal = ({
       onClose={closeModal}
       title="حذف Pool"
       actions={
-        <>
-          <Button
-            onClick={closeModal}
-            color="inherit"
-            variant="outlined"
-            disabled={isDeleting}
-            sx={buttonStyles}
-          >
-            انصراف
-          </Button>
-          <Button
-            onClick={confirmDelete}
-            variant="contained"
-            color="error"
-            disabled={isDeleting}
-            sx={buttonStyles}
-          >
-            {isDeleting ? 'در حال حذف…' : 'حذف'}
-          </Button>
-        </>
+        <ModalActionButtons
+          onCancel={closeModal}
+          onConfirm={confirmDelete}
+          confirmLabel="حذف"
+          loadingLabel="در حال حذف…"
+          isLoading={isDeleting}
+          disabled={isDeleting}
+          disableConfirmGradient
+          confirmProps={{ color: 'error' }}
+        />
       }
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/src/components/integrated-storage/CreatePoolModal.tsx
+++ b/src/components/integrated-storage/CreatePoolModal.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Checkbox,
   FormControl,
   FormControlLabel,
@@ -18,6 +17,7 @@ import type { SelectChangeEvent } from '@mui/material/Select';
 import type { ChangeEvent } from 'react';
 import type { UseCreatePoolReturn } from '../../hooks/useCreatePool';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 export interface DeviceOption {
   label: string;
@@ -31,11 +31,6 @@ interface CreatePoolModalProps {
   isDiskLoading: boolean;
   diskError: Error | null;
 }
-
-const buttonBaseStyles = {
-  borderRadius: '3px',
-  fontWeight: 600,
-};
 
 const inputBaseStyles = {
   backgroundColor: 'var(--color-input-bg)',
@@ -89,36 +84,21 @@ const CreatePoolModal = ({
       onClose={closeCreateModal}
       title="ایجاد Pool جدید"
       actions={
-        <>
-          <Button
-            onClick={closeCreateModal}
-            variant="outlined"
-            color="inherit"
-            disabled={isCreating}
-            sx={{ ...buttonBaseStyles, px: 3 }}
-          >
-            انصراف
-          </Button>
-          <Button
-            type="submit"
-            form="create-pool-form"
-            variant="contained"
-            disabled={isCreating}
-            sx={{
-              ...buttonBaseStyles,
-              px: 4,
-              background:
-                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
-              boxShadow: '0 14px 28px -18px rgba(0, 198, 169, 0.8)',
-              '&:hover': {
-                background:
-                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
-              },
-            }}
-          >
-            {isCreating ? 'در حال ایجاد…' : 'ایجاد'}
-          </Button>
-        </>
+        <ModalActionButtons
+          onCancel={closeCreateModal}
+          confirmLabel="ایجاد"
+          loadingLabel="در حال ایجاد…"
+          isLoading={isCreating}
+          disabled={isCreating}
+          cancelProps={{
+            sx: { borderRadius: '3px', px: 3 },
+          }}
+          confirmProps={{
+            type: 'submit',
+            form: 'create-pool-form',
+            sx: { borderRadius: '3px' },
+          }}
+        />
       }
     >
       <Box component="form" id="create-pool-form" onSubmit={handleSubmit}>

--- a/src/components/settings/NetworkInterfaceIpEditModal.tsx
+++ b/src/components/settings/NetworkInterfaceIpEditModal.tsx
@@ -1,6 +1,7 @@
-import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import { Alert, Box, TextField, Typography } from '@mui/material';
 import { type FormEvent, useEffect, useState } from 'react';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface NetworkInterfaceIpEditModalProps {
   open: boolean;
@@ -43,37 +44,43 @@ const NetworkInterfaceIpEditModal = ({
     onSubmit({ ip, netmask });
   };
 
+  const isConfirmDisabled =
+    isSubmitting || !interfaceName || !ip || !netmask;
+
   return (
     <BlurModal
       open={open}
       onClose={onClose}
       title="ویرایش آدرس IP"
       actions={
-        <Button
-          type="submit"
-          form="network-interface-ip-edit-form"
-          variant="contained"
-          disabled={isSubmitting || !interfaceName || !ip || !netmask}
-          sx={{
-            px: 3,
-            py: 1,
-            fontWeight: 600,
-            background:
-              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
-            color: 'var(--color-bg)',
-            '&:hover': {
+        <ModalActionButtons
+          confirmLabel="ثبت تغییرات"
+          loadingLabel="در حال ارسال..."
+          isLoading={isSubmitting}
+          disabled={isConfirmDisabled}
+          disableConfirmGradient
+          confirmProps={{
+            type: 'submit',
+            form: 'network-interface-ip-edit-form',
+            sx: {
+              px: 3,
+              py: 1,
+              fontWeight: 600,
               background:
-                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
-            },
-            '&.Mui-disabled': {
-              backgroundColor:
-                'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
-              color: 'var(--color-secondary)',
+                'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+              color: 'var(--color-bg)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+              },
+              '&.Mui-disabled': {
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+                color: 'var(--color-secondary)',
+              },
             },
           }}
-        >
-          {isSubmitting ? 'در حال ارسال...' : 'ثبت تغییرات'}
-        </Button>
+        />
       }
     >
       <Box

--- a/src/components/share/CreateShareModal.tsx
+++ b/src/components/share/CreateShareModal.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Autocomplete,
   Box,
-  Button,
   CircularProgress,
   InputAdornment,
   TextField,
@@ -16,15 +15,11 @@ import type { UseCreateShareReturn } from '../../hooks/useCreateShare';
 import { useSambaUsers } from '../../hooks/useSambaUsers';
 import normalizeSambaUsers from '../../utils/sambaUsers';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface CreateShareModalProps {
   controller: UseCreateShareReturn;
 }
-
-const buttonBaseStyles = {
-  borderRadius: '3px',
-  fontWeight: 600,
-};
 
 const inputBaseStyles = {
   backgroundColor: 'var(--color-input-bg)',
@@ -124,36 +119,21 @@ const CreateShareModal = ({ controller }: CreateShareModalProps) => {
       onClose={closeCreateModal}
       title="ایجاد اشتراک جدید"
       actions={
-        <>
-          <Button
-            onClick={closeCreateModal}
-            variant="outlined"
-            color="inherit"
-            disabled={isCreating}
-            sx={{ ...buttonBaseStyles, px: 3 }}
-          >
-            انصراف
-          </Button>
-          <Button
-            type="submit"
-            form="create-share-form"
-            variant="contained"
-            disabled={isCreating}
-            sx={{
-              ...buttonBaseStyles,
-              px: 4,
-              background:
-                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
-              boxShadow: '0 14px 28px -18px rgba(0, 198, 169, 0.8)',
-              '&:hover': {
-                background:
-                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
-              },
-            }}
-          >
-            {isCreating ? 'در حال ایجاد…' : 'ایجاد'}
-          </Button>
-        </>
+        <ModalActionButtons
+          onCancel={closeCreateModal}
+          confirmLabel="ایجاد"
+          loadingLabel="در حال ایجاد…"
+          isLoading={isCreating}
+          disabled={isCreating}
+          cancelProps={{
+            sx: { borderRadius: '3px', px: 3 },
+          }}
+          confirmProps={{
+            type: 'submit',
+            form: 'create-share-form',
+            sx: { borderRadius: '3px' },
+          }}
+        />
       }
     >
       <Box component="form" id="create-share-form" onSubmit={handleSubmit}>

--- a/src/components/users/SambaUserCreateModal.tsx
+++ b/src/components/users/SambaUserCreateModal.tsx
@@ -1,7 +1,6 @@
 import {
   Alert,
   Box,
-  Button,
   Checkbox,
   FormControlLabel,
   TextField,
@@ -10,6 +9,7 @@ import {
 import { type FormEvent, useEffect, useState } from 'react';
 import type { CreateSambaUserPayload } from '../../@types/samba';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface SambaUserCreateModalProps {
   open: boolean;
@@ -56,37 +56,43 @@ const SambaUserCreateModal = ({
     });
   };
 
+  const isConfirmDisabled =
+    isSubmitting || !username.trim() || !password;
+
   return (
     <BlurModal
       open={open}
       onClose={onClose}
       title="ایجاد کاربر Samba"
       actions={
-        <Button
-          type="submit"
-          form="samba-user-create-form"
-          variant="contained"
-          disabled={isSubmitting || !username.trim() || !password}
-          sx={{
-            px: 3,
-            py: 1,
-            fontWeight: 600,
-            background:
-              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
-            color: 'var(--color-bg)',
-            '&:hover': {
+        <ModalActionButtons
+          confirmLabel="ایجاد کاربر"
+          loadingLabel="در حال ایجاد..."
+          isLoading={isSubmitting}
+          disabled={isConfirmDisabled}
+          disableConfirmGradient
+          confirmProps={{
+            type: 'submit',
+            form: 'samba-user-create-form',
+            sx: {
+              px: 3,
+              py: 1,
+              fontWeight: 600,
               background:
-                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
-            },
-            '&.Mui-disabled': {
-              backgroundColor:
-                'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
-              color: 'var(--color-secondary)',
+                'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+              color: 'var(--color-bg)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+              },
+              '&.Mui-disabled': {
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+                color: 'var(--color-secondary)',
+              },
             },
           }}
-        >
-          {isSubmitting ? 'در حال ایجاد...' : 'ایجاد کاربر'}
-        </Button>
+        />
       }
     >
       <Box

--- a/src/components/users/SambaUserPasswordModal.tsx
+++ b/src/components/users/SambaUserPasswordModal.tsx
@@ -1,7 +1,8 @@
-import { Alert, Box, Button, TextField, Typography } from '@mui/material';
+import { Alert, Box, TextField, Typography } from '@mui/material';
 import { type FormEvent, useEffect, useState } from 'react';
 import type { UpdateSambaUserPasswordPayload } from '../../@types/samba';
 import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
 
 interface SambaUserPasswordModalProps {
   open: boolean;
@@ -41,37 +42,43 @@ const SambaUserPasswordModal = ({
     });
   };
 
+  const isConfirmDisabled =
+    isSubmitting || !username || !password;
+
   return (
     <BlurModal
       open={open}
       onClose={onClose}
       title="تغییر گذرواژه کاربر"
       actions={
-        <Button
-          type="submit"
-          form="samba-user-password-form"
-          variant="contained"
-          disabled={isSubmitting || !username || !password}
-          sx={{
-            px: 3,
-            py: 1,
-            fontWeight: 600,
-            background:
-              'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
-            color: 'var(--color-bg)',
-            '&:hover': {
+        <ModalActionButtons
+          confirmLabel="ثبت گذرواژه جدید"
+          loadingLabel="در حال بروزرسانی..."
+          isLoading={isSubmitting}
+          disabled={isConfirmDisabled}
+          disableConfirmGradient
+          confirmProps={{
+            type: 'submit',
+            form: 'samba-user-password-form',
+            sx: {
+              px: 3,
+              py: 1,
+              fontWeight: 600,
               background:
-                'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
-            },
-            '&.Mui-disabled': {
-              backgroundColor:
-                'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
-              color: 'var(--color-secondary)',
+                'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+              color: 'var(--color-bg)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+              },
+              '&.Mui-disabled': {
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-secondary) 25%, transparent)',
+                color: 'var(--color-secondary)',
+              },
             },
           }}
-        >
-          {isSubmitting ? 'در حال بروزرسانی...' : 'ثبت گذرواژه جدید'}
-        </Button>
+        />
       }
     >
       <Box


### PR DESCRIPTION
## Summary
- create a reusable ModalActionButtons component with default gradients, loading labels, and override hooks
- refactor volume, pool, share, network, and Samba modals to use the shared action buttons while preserving custom styles

## Testing
- npm run lint *(fails: react-refresh/only-export-components errors in existing context files)*

------
https://chatgpt.com/codex/tasks/task_b_68dcd9e234ec832f894ef686c42530c1