### PR TITLE
Revamp memory chart and move Samba management to shares

### DIFF
--- a/src/components/Memory.tsx
+++ b/src/components/Memory.tsx
@@ -253,6 +253,10 @@ const Memory = () => {
     // { key: 'cached', label: 'کش', value: formatBytesForDisplay(cachedValue) },
   ];
 
+  const chartOuterRadius = Math.min(110, chartSize / 2 - 8);
+  const chartInnerRadius = Math.max(chartOuterRadius - 24, chartOuterRadius * 0.22);
+  const chartFadedInnerRadius = Math.max(chartInnerRadius - 6, chartInnerRadius * 0.9);
+
   return (
     <Box sx={{ ...cardSx, width: '100%' }}>
       <Typography
@@ -297,7 +301,14 @@ const Memory = () => {
       {/*  </Typography>*/}
       {/*</Box>*/}
 
-      <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+      <Box
+        sx={{
+          width: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          position: 'relative',
+        }}
+      >
         <AppPieChart
           series={[
             {
@@ -316,14 +327,15 @@ const Memory = () => {
                   color: remainingArcColor,
                 },
               ],
-              outerRadius: 120,
+              outerRadius: chartOuterRadius,
+              innerRadius: chartInnerRadius,
               paddingAngle: 2,
               cornerRadius: 6,
               startAngle: 0,
               endAngle: 360,
               highlightScope: { fade: 'global', highlight: 'item' },
               faded: {
-                innerRadius: 70,
+                innerRadius: chartFadedInnerRadius,
                 additionalRadius: -18,
                 color: fadedArcColor,
               },
@@ -361,6 +373,35 @@ const Memory = () => {
             },
           }}
         />
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            pointerEvents: 'none',
+            gap: 0.5,
+          }}
+        >
+          <Typography
+            variant="h5"
+            sx={{
+              fontFamily: 'var(--font-didot)',
+              fontWeight: 700,
+              color: 'var(--color-primary)',
+            }}
+          >
+            {percentDisplay}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: theme.palette.text.secondary }}
+          >
+            درصد استفاده
+          </Typography>
+        </Box>
       </Box>
 
       <Box

--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -2,7 +2,6 @@ export const DEFAULT_LOGIN_SHELL = '/usr/sbin/nologin';
 
 export const USERS_TABS = {
   os: 'os-users',
-  samba: 'samba-users',
   other: 'other-users',
 } as const;
 

--- a/src/pages/Share.tsx
+++ b/src/pages/Share.tsx
@@ -1,16 +1,57 @@
-import { Box, Button, Typography } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Box, Button, Tab, Tabs, Typography } from '@mui/material';
+import { type SyntheticEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import type { SambaShareEntry } from '../@types/samba';
+import TabPanel from '../components/TabPanel';
 import CreateShareModal from '../components/share/CreateShareModal';
 import SelectedSharesDetailsPanel from '../components/share/SelectedSharesDetailsPanel';
 import SharesTable from '../components/share/SharesTable';
+import SambaUserCreateModal from '../components/users/SambaUserCreateModal';
+import SambaUserPasswordModal from '../components/users/SambaUserPasswordModal';
+import SambaUsersTable from '../components/users/SambaUsersTable';
+import SelectedSambaUsersDetailsPanel from '../components/users/SelectedSambaUsersDetailsPanel';
+import { DEFAULT_LOGIN_SHELL } from '../constants/users';
 import { useCreateShare } from '../hooks/useCreateShare';
 import { useDeleteShare } from '../hooks/useDeleteShare';
+import { useCreateOsUser } from '../hooks/useCreateOsUser';
 import { useSambaShares } from '../hooks/useSambaShares';
 import { useServiceAction } from '../hooks/useServiceAction';
+import { useCreateSambaUser } from '../hooks/useCreateSambaUser';
+import { useEnableSambaUser } from '../hooks/useEnableSambaUser';
+import { useSambaUsers } from '../hooks/useSambaUsers';
+import { useUpdateSambaUserPassword } from '../hooks/useUpdateSambaUserPassword';
+import { normalizeSambaUsers } from '../utils/sambaUsers';
+
+const SHARE_TABS = {
+  shares: 'shares',
+  sambaUsers: 'samba-users',
+} as const;
+
+type ShareTabValue = (typeof SHARE_TABS)[keyof typeof SHARE_TABS];
 
 const Share = () => {
+  const [activeTab, setActiveTab] = useState<ShareTabValue>(SHARE_TABS.shares);
+  const [selectedShares, setSelectedShares] = useState<string[]>([]);
+  const [isSambaCreateModalOpen, setIsSambaCreateModalOpen] = useState(false);
+  const [sambaCreateError, setSambaCreateError] = useState<string | null>(null);
+  const [sambaCreateInitialUsername, setSambaCreateInitialUsername] = useState<
+    string | undefined
+  >(undefined);
+  const [selectedSambaUsers, setSelectedSambaUsers] = useState<string[]>([]);
+  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+  const [passwordModalUsername, setPasswordModalUsername] = useState<
+    string | null
+  >(null);
+  const [passwordModalError, setPasswordModalError] = useState<string | null>(
+    null
+  );
+  const [pendingEnableUsername, setPendingEnableUsername] = useState<
+    string | null
+  >(null);
+  const [pendingPasswordUsername, setPendingPasswordUsername] = useState<
+    string | null
+  >(null);
+
   const { data: shares = [], isLoading, error } = useSambaShares();
 
   const createShare = useCreateShare({
@@ -34,7 +75,12 @@ const Share = () => {
     },
   });
 
-  const [selectedShares, setSelectedShares] = useState<string[]>([]);
+  const handleTabChange = useCallback(
+    (_: SyntheticEvent, value: ShareTabValue) => {
+      setActiveTab(value);
+    },
+    []
+  );
 
   const serviceAction = useServiceAction({
     onSuccess: ({ service }) => {
@@ -129,71 +175,361 @@ const Share = () => {
     [selectedShares, shares]
   );
 
-  return (
-    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 2,
-            flexWrap: 'wrap',
-          }}
-        >
-          <Typography
-            variant="h5"
-            sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
-          >
-            اشتراک‌گذاری فایل
-          </Typography>
+  const sambaUsersQuery = useSambaUsers({
+    enabled: activeTab === SHARE_TABS.sambaUsers,
+  });
 
-          <Button
-            onClick={createShare.openCreateModal}
-            variant="contained"
+  const sambaUsers = useMemo(
+    () => normalizeSambaUsers(sambaUsersQuery.data?.data),
+    [sambaUsersQuery.data?.data]
+  );
+
+  const createOsUser = useCreateOsUser({
+    onSuccess: (username) => {
+      toast.success(`کاربر ${username} با موفقیت ایجاد شد.`);
+    },
+    onError: (message) => {
+      toast.error(`ایجاد کاربر با خطا مواجه شد: ${message}`);
+    },
+  });
+
+  const createSambaUser = useCreateSambaUser({
+    onSuccess: (username) => {
+      toast.success(`کاربر Samba ${username} با موفقیت ایجاد شد.`);
+      setIsSambaCreateModalOpen(false);
+      setSambaCreateError(null);
+    },
+    onError: (message) => {
+      setSambaCreateError(message);
+      toast.error(`ایجاد کاربر Samba با خطا مواجه شد: ${message}`);
+    },
+  });
+
+  const enableSambaUser = useEnableSambaUser({
+    onSuccess: (username) => {
+      toast.success(`کاربر ${username} فعال شد.`);
+    },
+    onError: (message) => {
+      toast.error(`فعال‌سازی کاربر با خطا مواجه شد: ${message}`);
+    },
+  });
+
+  const updateSambaPassword = useUpdateSambaUserPassword({
+    onSuccess: (username) => {
+      toast.success(`گذرواژه کاربر ${username} بروزرسانی شد.`);
+      setIsPasswordModalOpen(false);
+      setPasswordModalUsername(null);
+      setPasswordModalError(null);
+    },
+    onError: (message) => {
+      setPasswordModalError(message);
+      toast.error(`تغییر گذرواژه با خطا مواجه شد: ${message}`);
+    },
+  });
+
+  const handleOpenSambaCreateModal = useCallback(
+    (username?: string) => {
+      setSambaCreateError(null);
+      createSambaUser.reset();
+      setSambaCreateInitialUsername(username);
+      setIsSambaCreateModalOpen(true);
+    },
+    [createSambaUser]
+  );
+
+  const handleCloseSambaCreateModal = useCallback(() => {
+    setIsSambaCreateModalOpen(false);
+    setSambaCreateError(null);
+    createSambaUser.reset();
+    setSambaCreateInitialUsername(undefined);
+  }, [createSambaUser]);
+
+  const handleSubmitCreateSambaUser = useCallback(
+    ({
+      username,
+      password,
+      createOsUserFirst,
+    }: {
+      username: string;
+      password: string;
+      createOsUserFirst: boolean;
+    }) => {
+      const run = async () => {
+        if (createOsUserFirst) {
+          try {
+            await createOsUser.mutateAsync({
+              username,
+              login_shell: DEFAULT_LOGIN_SHELL,
+              shell: DEFAULT_LOGIN_SHELL,
+            });
+          } catch {
+            return;
+          }
+        }
+
+        createSambaUser.mutate({ username, password });
+      };
+
+      void run();
+    },
+    [createOsUser, createSambaUser]
+  );
+
+  const handleToggleSelectSambaUser = useCallback(
+    (user: { username: string }, checked: boolean) => {
+      setSelectedSambaUsers((prev) => {
+        if (checked) {
+          if (prev.includes(user.username)) {
+            return prev;
+          }
+
+          return [...prev, user.username];
+        }
+
+        return prev.filter((username) => username !== user.username);
+      });
+    },
+    []
+  );
+
+  const handleRemoveSelectedSambaUser = useCallback((username: string) => {
+    setSelectedSambaUsers((prev) => prev.filter((item) => item !== username));
+  }, []);
+
+  const handleEnableSambaUser = useCallback(
+    (user: { username: string }) => {
+      setPendingEnableUsername(user.username);
+      enableSambaUser.mutate(
+        { username: user.username },
+        {
+          onSettled: () => {
+            setPendingEnableUsername(null);
+          },
+        }
+      );
+    },
+    [enableSambaUser]
+  );
+
+  const handleOpenPasswordModal = useCallback(
+    (user: { username: string }) => {
+      setPasswordModalUsername(user.username);
+      setPasswordModalError(null);
+      updateSambaPassword.reset();
+      setIsPasswordModalOpen(true);
+    },
+    [updateSambaPassword]
+  );
+
+  const handleClosePasswordModal = useCallback(() => {
+    setIsPasswordModalOpen(false);
+    setPasswordModalUsername(null);
+    setPasswordModalError(null);
+    updateSambaPassword.reset();
+  }, [updateSambaPassword]);
+
+  const handleSubmitPasswordChange = useCallback(
+    (payload: { username: string; new_password: string }) => {
+      setPendingPasswordUsername(payload.username);
+      updateSambaPassword.mutate(payload, {
+        onSettled: () => {
+          setPendingPasswordUsername(null);
+        },
+      });
+    },
+    [updateSambaPassword]
+  );
+
+  useEffect(() => {
+    setSelectedSambaUsers((prev) =>
+      prev.filter((username) =>
+        sambaUsers.some((user) => user.username === username)
+      )
+    );
+  }, [sambaUsers]);
+
+  const selectedSambaUserItems = useMemo(
+    () =>
+      selectedSambaUsers
+        .map((username) =>
+          sambaUsers.find((user) => user.username === username)
+        )
+        .filter((user): user is (typeof sambaUsers)[number] => Boolean(user)),
+    [sambaUsers, selectedSambaUsers]
+  );
+
+  return (
+    <Box
+      sx={{
+        p: 3,
+        fontFamily: 'var(--font-vazir)',
+        backgroundColor: 'var(--color-background)',
+        minHeight: '100%',
+      }}
+    >
+      <Tabs
+        value={activeTab}
+        onChange={handleTabChange}
+        sx={{
+          mb: 3,
+          '& .MuiTab-root': {
+            color: 'var(--color-secondary)',
+            fontWeight: 600,
+            '&.Mui-selected': {
+              color: 'var(--color-primary)',
+            },
+          },
+          '& .MuiTabs-indicator': {
+            backgroundColor: 'var(--color-primary)',
+          },
+        }}
+      >
+        <Tab label="اشتراک‌ها" value={SHARE_TABS.shares} />
+        <Tab label="کاربران Samba" value={SHARE_TABS.sambaUsers} />
+      </Tabs>
+
+      <TabPanel value={SHARE_TABS.shares} currentValue={activeTab}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          <Box
             sx={{
-              px: 3,
-              py: 1.25,
-              borderRadius: '3px',
-              fontWeight: 700,
-              fontSize: '0.95rem',
-              background:
-                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
-              color: 'var(--color-bg)',
-              boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
-              '&:hover': {
-                background:
-                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
-              },
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              flexWrap: 'wrap',
             }}
           >
-            ایجاد اشتراک جدید
-          </Button>
+            <Typography
+              variant="h5"
+              sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+            >
+              اشتراک‌گذاری فایل
+            </Typography>
+
+            <Button
+              onClick={createShare.openCreateModal}
+              variant="contained"
+              sx={{
+                px: 3,
+                py: 1.25,
+                borderRadius: '3px',
+                fontWeight: 700,
+                fontSize: '0.95rem',
+                background:
+                  'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+                color: 'var(--color-bg)',
+                boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
+                '&:hover': {
+                  background:
+                    'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+                },
+              }}
+            >
+              ایجاد اشتراک جدید
+            </Button>
+          </Box>
+
+          <SharesTable
+            shares={shares}
+            isLoading={isLoading}
+            error={error}
+            selectedShares={selectedShares}
+            onToggleSelect={handleToggleSelect}
+            onDelete={handleDeleteShare}
+            pendingShareName={deleteShare.pendingShareName}
+            isDeleting={deleteShare.isDeleting}
+          />
+
+          <SelectedSharesDetailsPanel
+            items={comparisonItems}
+            onRemove={handleRemoveSelected}
+          />
         </Box>
+      </TabPanel>
 
-        {/*<Typography variant="body2" sx={{ color: 'var(--color-secondary)' }}>*/}
-        {/*  از جدول زیر می‌توانید اشتراک‌های موجود را مشاهده، حذف و برای مقایسه*/}
-        {/*  انتخاب کنید.*/}
-        {/*</Typography>*/}
+      <TabPanel value={SHARE_TABS.sambaUsers} currentValue={activeTab}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Typography
+              variant="h6"
+              sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+            >
+              مدیریت کاربران Samba
+            </Typography>
 
-        <SharesTable
-          shares={shares}
-          isLoading={isLoading}
-          error={error}
-          selectedShares={selectedShares}
-          onToggleSelect={handleToggleSelect}
-          onDelete={handleDeleteShare}
-          pendingShareName={deleteShare.pendingShareName}
-          isDeleting={deleteShare.isDeleting}
-        />
+            <Button
+              onClick={() => handleOpenSambaCreateModal()}
+              variant="contained"
+              sx={{
+                px: 3,
+                py: 1.25,
+                borderRadius: '3px',
+                fontWeight: 700,
+                fontSize: '0.95rem',
+                background:
+                  'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
+                color: 'var(--color-bg)',
+                boxShadow:
+                  '0 16px 32px -18px color-mix(in srgb, var(--color-primary) 55%, transparent)',
+                '&:hover': {
+                  background:
+                    'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
+                },
+              }}
+            >
+              افزودن کاربر Samba
+            </Button>
+          </Box>
 
-        <SelectedSharesDetailsPanel
-          items={comparisonItems}
-          onRemove={handleRemoveSelected}
-        />
-      </Box>
+          <SambaUsersTable
+            users={sambaUsers}
+            isLoading={sambaUsersQuery.isLoading || sambaUsersQuery.isFetching}
+            error={sambaUsersQuery.error ?? null}
+            selectedUsers={selectedSambaUsers}
+            onToggleSelect={handleToggleSelectSambaUser}
+            onEnable={handleEnableSambaUser}
+            onEditPassword={handleOpenPasswordModal}
+            pendingEnableUsername={pendingEnableUsername}
+            isEnabling={enableSambaUser.isPending}
+            pendingPasswordUsername={pendingPasswordUsername}
+            isUpdatingPassword={updateSambaPassword.isPending}
+          />
+
+          <SelectedSambaUsersDetailsPanel
+            items={selectedSambaUserItems}
+            onRemove={handleRemoveSelectedSambaUser}
+          />
+        </Box>
+      </TabPanel>
 
       <CreateShareModal controller={createShare} />
+
+      <SambaUserCreateModal
+        open={isSambaCreateModalOpen}
+        onClose={handleCloseSambaCreateModal}
+        onSubmit={handleSubmitCreateSambaUser}
+        isSubmitting={createSambaUser.isPending}
+        errorMessage={sambaCreateError}
+        initialUsername={sambaCreateInitialUsername}
+      />
+
+      <SambaUserPasswordModal
+        open={isPasswordModalOpen}
+        username={passwordModalUsername}
+        onClose={handleClosePasswordModal}
+        onSubmit={handleSubmitPasswordChange}
+        errorMessage={passwordModalError}
+        isSubmitting={updateSambaPassword.isPending}
+        pendingUsername={pendingPasswordUsername}
+      />
     </Box>
   );
 };

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -11,7 +11,6 @@ import {
   type ChangeEvent,
   type SyntheticEvent,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -21,9 +20,6 @@ import TabPanel from '../components/TabPanel';
 import OsUserCreateModal from '../components/users/OsUserCreateModal';
 import OsUsersTable from '../components/users/OsUsersTable';
 import SambaUserCreateModal from '../components/users/SambaUserCreateModal';
-import SambaUserPasswordModal from '../components/users/SambaUserPasswordModal';
-import SambaUsersTable from '../components/users/SambaUsersTable';
-import SelectedSambaUsersDetailsPanel from '../components/users/SelectedSambaUsersDetailsPanel';
 import {
   DEFAULT_LOGIN_SHELL,
   USERS_TABS,
@@ -31,10 +27,8 @@ import {
 } from '../constants/users';
 import { useCreateOsUser } from '../hooks/useCreateOsUser';
 import { useCreateSambaUser } from '../hooks/useCreateSambaUser';
-import { useEnableSambaUser } from '../hooks/useEnableSambaUser';
 import { useOsUsers } from '../hooks/useOsUsers';
 import { useSambaUsers } from '../hooks/useSambaUsers';
-import { useUpdateSambaUserPassword } from '../hooks/useUpdateSambaUserPassword';
 import { normalizeOsUsers } from '../utils/osUsers';
 import { normalizeSambaUsers } from '../utils/sambaUsers';
 
@@ -48,20 +42,6 @@ const Users = () => {
   const [sambaCreateInitialUsername, setSambaCreateInitialUsername] = useState<
     string | undefined
   >(undefined);
-  const [selectedSambaUsers, setSelectedSambaUsers] = useState<string[]>([]);
-  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
-  const [passwordModalUsername, setPasswordModalUsername] = useState<
-    string | null
-  >(null);
-  const [passwordModalError, setPasswordModalError] = useState<string | null>(
-    null
-  );
-  const [pendingEnableUsername, setPendingEnableUsername] = useState<
-    string | null
-  >(null);
-  const [pendingPasswordUsername, setPendingPasswordUsername] = useState<
-    string | null
-  >(null);
 
   const osUsersQuery = useOsUsers({
     includeSystem,
@@ -120,28 +100,6 @@ const Users = () => {
     onError: (message) => {
       setSambaCreateError(message);
       toast.error(`ایجاد کاربر Samba با خطا مواجه شد: ${message}`);
-    },
-  });
-
-  const enableSambaUser = useEnableSambaUser({
-    onSuccess: (username) => {
-      toast.success(`کاربر ${username} فعال شد.`);
-    },
-    onError: (message) => {
-      toast.error(`فعال‌سازی کاربر با خطا مواجه شد: ${message}`);
-    },
-  });
-
-  const updateSambaPassword = useUpdateSambaUserPassword({
-    onSuccess: (username) => {
-      toast.success(`گذرواژه کاربر ${username} بروزرسانی شد.`);
-      setIsPasswordModalOpen(false);
-      setPasswordModalUsername(null);
-      setPasswordModalError(null);
-    },
-    onError: (message) => {
-      setPasswordModalError(message);
-      toast.error(`تغییر گذرواژه با خطا مواجه شد: ${message}`);
     },
   });
 
@@ -233,89 +191,6 @@ const Users = () => {
     [createOsUser, createSambaUser]
   );
 
-  const handleToggleSelectSambaUser = useCallback(
-    (user: { username: string }, checked: boolean) => {
-      setSelectedSambaUsers((prev) => {
-        if (checked) {
-          if (prev.includes(user.username)) {
-            return prev;
-          }
-
-          return [...prev, user.username];
-        }
-
-        return prev.filter((username) => username !== user.username);
-      });
-    },
-    []
-  );
-
-  const handleRemoveSelectedSambaUser = useCallback((username: string) => {
-    setSelectedSambaUsers((prev) => prev.filter((item) => item !== username));
-  }, []);
-
-  const handleEnableSambaUser = useCallback(
-    (user: { username: string }) => {
-      setPendingEnableUsername(user.username);
-      enableSambaUser.mutate(
-        { username: user.username },
-        {
-          onSettled: () => {
-            setPendingEnableUsername(null);
-          },
-        }
-      );
-    },
-    [enableSambaUser]
-  );
-
-  const handleOpenPasswordModal = useCallback(
-    (user: { username: string }) => {
-      setPasswordModalUsername(user.username);
-      setPasswordModalError(null);
-      updateSambaPassword.reset();
-      setIsPasswordModalOpen(true);
-    },
-    [updateSambaPassword]
-  );
-
-  const handleClosePasswordModal = useCallback(() => {
-    setIsPasswordModalOpen(false);
-    setPasswordModalUsername(null);
-    setPasswordModalError(null);
-    updateSambaPassword.reset();
-  }, [updateSambaPassword]);
-
-  const handleSubmitPasswordChange = useCallback(
-    (payload: { username: string; new_password: string }) => {
-      setPendingPasswordUsername(payload.username);
-      updateSambaPassword.mutate(payload, {
-        onSettled: () => {
-          setPendingPasswordUsername(null);
-        },
-      });
-    },
-    [updateSambaPassword]
-  );
-
-  useEffect(() => {
-    setSelectedSambaUsers((prev) =>
-      prev.filter((username) =>
-        sambaUsers.some((user) => user.username === username)
-      )
-    );
-  }, [sambaUsers]);
-
-  const selectedSambaUserItems = useMemo(
-    () =>
-      selectedSambaUsers
-        .map((username) =>
-          sambaUsers.find((user) => user.username === username)
-        )
-        .filter((user): user is (typeof sambaUsers)[number] => Boolean(user)),
-    [sambaUsers, selectedSambaUsers]
-  );
-
   return (
     <Box
       sx={{
@@ -350,7 +225,6 @@ const Users = () => {
         }}
       >
         <Tab label="کاربران سامانه" value={USERS_TABS.os} />
-        <Tab label="کاربران samba" value={USERS_TABS.samba} />
         <Tab label="سایر کاربران" value={USERS_TABS.other} />
       </Tabs>
 
@@ -423,74 +297,6 @@ const Users = () => {
         </Box>
       </TabPanel>
 
-      <TabPanel value={USERS_TABS.samba} currentValue={activeTab}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 2,
-              flexWrap: 'wrap',
-            }}
-          >
-            <Typography
-              variant="h6"
-              sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
-            >
-              مدیریت کاربران Samba
-            </Typography>
-
-            <Button
-              onClick={() => handleOpenSambaCreateModal()}
-              variant="contained"
-              sx={{
-                px: 3,
-                py: 1.25,
-                borderRadius: '3px',
-                fontWeight: 700,
-                fontSize: '0.95rem',
-                background:
-                  'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-light) 100%)',
-                color: 'var(--color-bg)',
-                boxShadow:
-                  '0 16px 32px -18px color-mix(in srgb, var(--color-primary) 55%, transparent)',
-                '&:hover': {
-                  background:
-                    'linear-gradient(135deg, var(--color-primary-light) 0%, var(--color-primary) 100%)',
-                },
-              }}
-            >
-              افزودن کاربر Samba
-            </Button>
-          </Box>
-
-          {/*<Typography variant="body2" sx={{ color: 'var(--color-secondary)' }}>*/}
-          {/*  از جدول زیر می‌توانید کاربران Samba را مشاهده، برای مقایسه انتخاب و*/}
-          {/*  عملیات فعال‌سازی یا تغییر گذرواژه را انجام دهید.*/}
-          {/*</Typography>*/}
-
-          <SambaUsersTable
-            users={sambaUsers}
-            isLoading={sambaUsersQuery.isLoading || sambaUsersQuery.isFetching}
-            error={sambaUsersQuery.error ?? null}
-            selectedUsers={selectedSambaUsers}
-            onToggleSelect={handleToggleSelectSambaUser}
-            onEnable={handleEnableSambaUser}
-            onEditPassword={handleOpenPasswordModal}
-            pendingEnableUsername={pendingEnableUsername}
-            isEnabling={enableSambaUser.isPending}
-            pendingPasswordUsername={pendingPasswordUsername}
-            isUpdatingPassword={updateSambaPassword.isPending}
-          />
-
-          <SelectedSambaUsersDetailsPanel
-            items={selectedSambaUserItems}
-            onRemove={handleRemoveSelectedSambaUser}
-          />
-        </Box>
-      </TabPanel>
-
       <TabPanel value={USERS_TABS.other} currentValue={activeTab}>
         <Typography sx={{ color: 'var(--color-secondary)' }}>
           بخش سایر کاربران در دست توسعه است.
@@ -512,15 +318,6 @@ const Users = () => {
         isSubmitting={createSambaUser.isPending}
         errorMessage={sambaCreateError}
         initialUsername={sambaCreateInitialUsername}
-      />
-
-      <SambaUserPasswordModal
-        open={isPasswordModalOpen}
-        username={passwordModalUsername}
-        onClose={handleClosePasswordModal}
-        onSubmit={handleSubmitPasswordChange}
-        isSubmitting={updateSambaPassword.isPending}
-        errorMessage={passwordModalError}
       />
     </Box>
   );


### PR DESCRIPTION
## Summary
- restyle the memory usage pie chart as a donut with an overlaid percent display matching the zpool visuals
- move Samba user management into a new tab on the Share page while keeping creation, enable, and password flows intact
- simplify the Users page tabs and constants after relocating Samba-specific UI

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components errors in AuthContext.tsx and ThemeContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68e0c33893e8832fa5546d348bc5b6bb