### PR TITLE
Align numeric display with English digits and right alignment

### DIFF
--- a/src/components/Cpu.tsx
+++ b/src/components/Cpu.tsx
@@ -38,15 +38,15 @@ const Cpu = () => {
   const cardSx = createCardSx(theme);
 
   const percentFormatter = useMemo(
-    () => new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 0 }),
+    () => new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }),
     []
   );
   // const frequencyFormatter = useMemo(
-  //   () => new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 2 }),
+  //   () => new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }),
   //   []
   // );
   const integerFormatter = useMemo(
-    () => new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 0 }),
+    () => new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }),
     []
   );
 

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -228,7 +228,7 @@ const DataTable = <T,>({
                   <Typography sx={{ color: 'var(--color-secondary)' }}>
                     {pagination.rowCountFormatter
                       ? pagination.rowCountFormatter(pagination.count)
-                      : `تعداد سطرها: ${pagination.count.toLocaleString('fa-IR')}`}
+                  : `تعداد سطرها: ${pagination.count.toLocaleString('en-US')}`}
                   </Typography>
                   <TablePagination
                     component="div"

--- a/src/components/Network.tsx
+++ b/src/components/Network.tsx
@@ -48,7 +48,7 @@ const Network = () => {
   }, [data]);
 
   const speedFormatter = useMemo(
-    () => new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 0 }),
+    () => new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }),
     []
   );
 

--- a/src/components/block-storage/VolumesTable.tsx
+++ b/src/components/block-storage/VolumesTable.tsx
@@ -23,6 +23,14 @@ interface VolumesTableProps {
 const valueTypographySx = {
   fontWeight: 600,
   color: 'var(--color-text)',
+} as const;
+
+const numericValueTypographySx = {
+  ...valueTypographySx,
+  display: 'block',
+  textAlign: 'right' as const,
+  direction: 'ltr' as const,
+  fontVariantNumeric: 'tabular-nums',
 };
 
 const VolumesTable = ({
@@ -70,11 +78,19 @@ const VolumesTable = ({
         id: `attribute-${key}`,
         header: key,
         align: 'left',
-        renderCell: (volume) => (
-          <Typography sx={valueTypographySx}>
-            {volume.attributeMap[key] ?? '—'}
-          </Typography>
-        ),
+        renderCell: (volume) => {
+          const rawValue = volume.attributeMap[key];
+          const isNumericValue =
+            typeof rawValue === 'number' && Number.isFinite(rawValue);
+
+          return (
+            <Typography sx={isNumericValue ? numericValueTypographySx : valueTypographySx}>
+              {isNumericValue
+                ? new Intl.NumberFormat('en-US').format(rawValue)
+                : rawValue ?? '—'}
+            </Typography>
+          );
+        },
       })
     );
 

--- a/src/components/integrated-storage/PoolsTable.tsx
+++ b/src/components/integrated-storage/PoolsTable.tsx
@@ -31,6 +31,15 @@ interface PoolsTableProps {
   onToggleSelect: (pool: ZpoolCapacityEntry, checked: boolean) => void;
 }
 
+const numberValueSx = {
+  fontWeight: 600,
+  color: 'var(--color-text)',
+  direction: 'ltr' as const,
+  textAlign: 'right' as const,
+  display: 'block',
+  fontVariantNumeric: 'tabular-nums',
+};
+
 const PoolsTable = ({
   pools,
   isLoading,
@@ -82,9 +91,9 @@ const PoolsTable = ({
       {
         id: 'total',
         header: 'ظرفیت کل',
-        align: 'left',
+        align: 'right',
         renderCell: (pool) => (
-          <Typography sx={{ fontWeight: 600, color: 'var(--color-text)' }}>
+          <Typography sx={numberValueSx}>
             {formatCapacity(pool.totalBytes)}
           </Typography>
         ),
@@ -92,13 +101,15 @@ const PoolsTable = ({
       {
         id: 'used',
         header: 'حجم مصرف‌شده',
-        align: 'center',
+        align: 'right',
         cellSx: { minWidth: 180 },
         renderCell: (pool) => {
           const utilization = clampPercent(pool.capacityPercent);
 
           return (
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box
+              sx={{ display: 'flex', flexDirection: 'column', gap: 1, alignItems: 'flex-end' }}
+            >
               <Box
                 sx={{
                   position: 'relative',
@@ -122,7 +133,10 @@ const PoolsTable = ({
                 variant="body2"
                 sx={{
                   color: 'var(--color-text)',
-                  // fontFamily: 'var(--font-didot)',
+                  textAlign: 'right',
+                  direction: 'ltr',
+                  display: 'block',
+                  fontVariantNumeric: 'tabular-nums',
                 }}
               >
                 {formatBytes(pool.usedBytes)}
@@ -143,7 +157,7 @@ const PoolsTable = ({
         header: 'حجم آزاد',
         align: 'right',
         renderCell: (pool) => (
-          <Typography sx={{ color: 'var(--color-text)' }}>
+          <Typography sx={{ ...numberValueSx, fontWeight: 500 }}>
             {formatCapacity(pool.freeBytes)}
           </Typography>
         ),

--- a/src/components/integrated-storage/status.ts
+++ b/src/components/integrated-storage/status.ts
@@ -79,7 +79,7 @@ export const resolveStatus = (health?: string) => {
 
 export const formatCapacity = (value: number | null | undefined) =>
   formatBytes(value, {
-    locale: 'fa-IR',
+    locale: 'en-US',
     maximumFractionDigits: 1,
     fallback: '-',
   });

--- a/src/components/services/ServicesTable.tsx
+++ b/src/components/services/ServicesTable.tsx
@@ -53,6 +53,13 @@ const actionConfigs: Array<{
   },
 ];
 
+const numberTypographySx = {
+  display: 'block',
+  textAlign: 'right' as const,
+  direction: 'ltr' as const,
+  fontVariantNumeric: 'tabular-nums',
+};
+
 const formatServiceValue = (value: ServiceValue) => {
   if (value === null || value === undefined) {
     return '—';
@@ -64,6 +71,10 @@ const formatServiceValue = (value: ServiceValue) => {
 
   if (Array.isArray(value)) {
     return value.map((item) => (item ?? '—').toString()).join(', ');
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Intl.NumberFormat('en-US').format(value);
   }
 
   return String(value);
@@ -128,7 +139,7 @@ const ServicesTable = ({
       width: 64,
       renderCell: (_, index) => (
         <Typography component="span" sx={{ fontWeight: 500 }}>
-          {(page * rowsPerPage + index + 1).toLocaleString('fa-IR')}
+          {(page * rowsPerPage + index + 1).toLocaleString('en-US')}
         </Typography>
       ),
     };
@@ -147,7 +158,17 @@ const ServicesTable = ({
       (key) => ({
         id: key,
         header: key,
-        renderCell: (row) => formatServiceValue(row.details[key]),
+        renderCell: (row) => {
+          const rawValue = row.details[key];
+          const formatted = formatServiceValue(rawValue);
+          const isNumeric = typeof rawValue === 'number' && Number.isFinite(rawValue);
+
+          return (
+            <Typography component="span" sx={isNumeric ? numberTypographySx : undefined}>
+              {formatted}
+            </Typography>
+          );
+        },
       })
     );
 
@@ -228,17 +249,17 @@ const ServicesTable = ({
         rowsPerPageOptions: [5, 10, 25],
         labelRowsPerPage: 'ردیف در هر صفحه',
         labelDisplayedRows: ({ from, to, count }) => {
-          const localizedFrom = from.toLocaleString('fa-IR');
-          const localizedTo = to.toLocaleString('fa-IR');
+          const localizedFrom = from.toLocaleString('en-US');
+          const localizedTo = to.toLocaleString('en-US');
           const localizedCount =
             count !== -1
-              ? count.toLocaleString('fa-IR')
+              ? count.toLocaleString('en-US')
               : `بیش از ${localizedTo}`;
 
           return `${localizedFrom}–${localizedTo} از ${localizedCount}`;
         },
         rowCountFormatter: (count) =>
-          `تعداد کل سرویس‌ها: ${count.toLocaleString('fa-IR')}`,
+          `تعداد کل سرویس‌ها: ${count.toLocaleString('en-US')}`,
       }}
     />
   );

--- a/src/components/settings/NetworkSettingsTable.tsx
+++ b/src/components/settings/NetworkSettingsTable.tsx
@@ -27,7 +27,7 @@ type NetworkSettingsTableRow = {
 };
 
 const createSpeedFormatter = () =>
-  new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 0 });
+  new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 
 const createRows = (
   interfaces: NetworkData['interfaces'] | undefined,
@@ -156,7 +156,7 @@ const NetworkSettingsTable = () => {
       width: 64,
       renderCell: (_, index) => (
         <Typography component="span" sx={{ fontWeight: 500 }}>
-          {(page * rowsPerPage + index + 1).toLocaleString('fa-IR')}
+          {(page * rowsPerPage + index + 1).toLocaleString('en-US')}
         </Typography>
       ),
     };
@@ -225,7 +225,21 @@ const NetworkSettingsTable = () => {
     const speedColumn: DataTableColumn<NetworkSettingsTableRow> = {
       id: 'link-speed',
       header: 'link-speed',
-      renderCell: (row) => row.speed,
+      align: 'right',
+      renderCell: (row) => (
+        <Typography
+          component="span"
+          sx={{
+            display: 'block',
+            textAlign: 'right',
+            direction: 'ltr',
+            fontVariantNumeric: 'tabular-nums',
+            color: 'var(--color-text)',
+          }}
+        >
+          {row.speed}
+        </Typography>
+      ),
     };
 
     const actionColumn: DataTableColumn<NetworkSettingsTableRow> = {
@@ -282,17 +296,17 @@ const NetworkSettingsTable = () => {
           rowsPerPageOptions: [5, 10, 25],
           labelRowsPerPage: 'ردیف در هر صفحه',
           labelDisplayedRows: ({ from, to, count }) => {
-            const localizedFrom = from.toLocaleString('fa-IR');
-            const localizedTo = to.toLocaleString('fa-IR');
+            const localizedFrom = from.toLocaleString('en-US');
+            const localizedTo = to.toLocaleString('en-US');
             const localizedCount =
               count !== -1
-                ? count.toLocaleString('fa-IR')
+                ? count.toLocaleString('en-US')
                 : `بیش از ${localizedTo}`;
 
             return `${localizedFrom}–${localizedTo} از ${localizedCount}`;
           },
           rowCountFormatter: (count) =>
-            `تعداد کل موارد: ${count.toLocaleString('fa-IR')}`,
+            `تعداد کل موارد: ${count.toLocaleString('en-US')}`,
         }}
       />
 

--- a/src/components/users/OsUsersTable.tsx
+++ b/src/components/users/OsUsersTable.tsx
@@ -56,7 +56,7 @@ const OsUsersTable = ({
         width: 64,
         renderCell: (_row, index) => (
           <Typography component="span" sx={{ fontWeight: 600 }}>
-            {(page * rowsPerPage + index + 1).toLocaleString('fa-IR')}
+            {(page * rowsPerPage + index + 1).toLocaleString('en-US')}
           </Typography>
         ),
       },
@@ -199,17 +199,17 @@ const OsUsersTable = ({
         rowsPerPageOptions: [5, 10, 25],
         labelRowsPerPage: 'ردیف در هر صفحه',
         labelDisplayedRows: ({ from, to, count }) => {
-          const localizedFrom = from.toLocaleString('fa-IR');
-          const localizedTo = to.toLocaleString('fa-IR');
+          const localizedFrom = from.toLocaleString('en-US');
+          const localizedTo = to.toLocaleString('en-US');
           const localizedCount =
             count !== -1
-              ? count.toLocaleString('fa-IR')
+              ? count.toLocaleString('en-US')
               : `بیش از ${localizedTo}`;
 
           return `${localizedFrom}–${localizedTo} از ${localizedCount}`;
         },
         rowCountFormatter: (count) =>
-          `تعداد کل کاربران: ${count.toLocaleString('fa-IR')}`,
+          `تعداد کل کاربران: ${count.toLocaleString('en-US')}`,
       }}
     />
   );

--- a/src/constants/disk.ts
+++ b/src/constants/disk.ts
@@ -68,7 +68,7 @@ export const safeNumber = (value: unknown) => {
   return Number.isFinite(numeric) ? numeric : 0;
 };
 
-export const diskPercentFormatter = new Intl.NumberFormat('fa-IR', {
+export const diskPercentFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 1,
   maximumFractionDigits: 1,
 });

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -1,6 +1,6 @@
 const IRAN_TIME_ZONE = 'Asia/Tehran';
 
-const IRAN_DATE_TIME_FORMATTER = new Intl.DateTimeFormat('fa-IR', {
+const IRAN_DATE_TIME_FORMATTER = new Intl.DateTimeFormat('fa-IR-u-nu-latn', {
   dateStyle: 'medium',
   timeStyle: 'short',
   hourCycle: 'h23',

--- a/src/utils/formatDetailValue.ts
+++ b/src/utils/formatDetailValue.ts
@@ -4,7 +4,7 @@ const formatDetailValue = (value: unknown): string => {
   }
 
   if (typeof value === 'number' && Number.isFinite(value)) {
-    return new Intl.NumberFormat('fa-IR').format(value);
+    return new Intl.NumberFormat('en-US').format(value);
   }
 
   if (Array.isArray(value)) {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -52,10 +52,9 @@ export const formatBytes = (
     resolvedUnits[unitIndex] ?? resolvedUnits[resolvedUnits.length - 1] ?? '';
 
   const formattedValue = formatter.format(currentValue);
+  const signedValue = `${sign}${formattedValue}`;
 
-  return unitLabel
-    ? `${sign} ${unitLabel}${formattedValue}`
-    : `${sign}${formattedValue}`;
+  return unitLabel ? `${signedValue} ${unitLabel}`.trim() : signedValue;
 };
 
 export type FormatDurationOptions = {


### PR DESCRIPTION
## Summary
- switch numeric formatters and table pagination helpers to use en-US digits for server-provided values
- right-align numeric columns in storage and network tables with LTR typography for consistent presentation
- update shared formatting utilities to emit Latin digits while keeping existing fallbacks and labels

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components errors in contexts and hook dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68e0cb508368832fb11d64d600b6aa89