### PR TITLE
Add file system management UI

### DIFF
--- a/src/@types/filesystem.ts
+++ b/src/@types/filesystem.ts
@@ -1,0 +1,29 @@
+export interface FileSystemRawEntry {
+  [key: string]: unknown;
+}
+
+export interface FileSystemAttributeEntry {
+  key: string;
+  value: string;
+}
+
+export interface FileSystemEntry {
+  id: string;
+  fullName: string;
+  poolName: string;
+  filesystemName: string;
+  attributes: FileSystemAttributeEntry[];
+  attributeMap: Record<string, string>;
+  raw: FileSystemRawEntry;
+}
+
+export interface FileSystemApiResponse {
+  data?: unknown;
+  detail?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface FileSystemQueryResult {
+  filesystems: FileSystemEntry[];
+}

--- a/src/components/file-system/ConfirmDeleteFileSystemModal.tsx
+++ b/src/components/file-system/ConfirmDeleteFileSystemModal.tsx
@@ -1,0 +1,59 @@
+import { Box, Typography } from '@mui/material';
+import type { UseDeleteFileSystemReturn } from '../../hooks/useDeleteFileSystem';
+import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
+
+interface ConfirmDeleteFileSystemModalProps {
+  controller: UseDeleteFileSystemReturn;
+}
+
+const ConfirmDeleteFileSystemModal = ({
+  controller,
+}: ConfirmDeleteFileSystemModalProps) => {
+  const {
+    isOpen,
+    targetFileSystem,
+    closeModal,
+    confirmDelete,
+    isDeleting,
+    errorMessage,
+  } = controller;
+
+  return (
+    <BlurModal
+      open={isOpen}
+      onClose={closeModal}
+      title="حذف فایل سیستم"
+      actions={
+        <ModalActionButtons
+          onCancel={closeModal}
+          onConfirm={confirmDelete}
+          confirmLabel="حذف"
+          loadingLabel="در حال حذف…"
+          isLoading={isDeleting}
+          disabled={isDeleting}
+          disableConfirmGradient
+          confirmProps={{ color: 'error' }}
+        />
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography sx={{ color: 'var(--color-text)' }}>
+          آیا از حذف فایل سیستم{' '}
+          <Typography component="span" sx={{ fontWeight: 700 }}>
+            {targetFileSystem?.fullName}
+          </Typography>{' '}
+          مطمئن هستید؟ این عملیات قابل بازگشت نیست.
+        </Typography>
+
+        {errorMessage && (
+          <Typography sx={{ color: 'var(--color-error)', fontWeight: 600 }}>
+            {errorMessage}
+          </Typography>
+        )}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default ConfirmDeleteFileSystemModal;

--- a/src/components/file-system/CreateFileSystemModal.tsx
+++ b/src/components/file-system/CreateFileSystemModal.tsx
@@ -1,0 +1,143 @@
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import type { ChangeEvent } from 'react';
+import type { UseCreateFileSystemReturn } from '../../hooks/useCreateFileSystem';
+import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
+
+interface CreateFileSystemModalProps {
+  controller: UseCreateFileSystemReturn;
+  poolOptions: string[];
+}
+
+const inputBaseStyles = {
+  backgroundColor: 'var(--color-input-bg)',
+  borderRadius: '5px',
+  color: 'var(--color-text)',
+  '& fieldset': {
+    borderColor: 'var(--color-input-border)',
+  },
+  '&:hover fieldset': {
+    borderColor: 'var(--color-input-focus-border)',
+  },
+  '&.Mui-focused fieldset': {
+    borderColor: 'var(--color-input-focus-border)',
+  },
+};
+
+const CreateFileSystemModal = ({
+  controller,
+  poolOptions,
+}: CreateFileSystemModalProps) => {
+  const {
+    isOpen,
+    closeCreateModal,
+    handleSubmit,
+    selectedPool,
+    setSelectedPool,
+    poolError,
+    filesystemName,
+    setFileSystemName,
+    nameError,
+    apiError,
+    isCreating,
+  } = controller;
+
+  const handlePoolChange = (event: SelectChangeEvent<string>) => {
+    setSelectedPool(event.target.value);
+  };
+
+  const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setFileSystemName(event.target.value);
+  };
+
+  return (
+    <BlurModal
+      open={isOpen}
+      onClose={closeCreateModal}
+      title="ایجاد فایل سیستم جدید"
+      actions={
+        <ModalActionButtons
+          onCancel={closeCreateModal}
+          confirmLabel="ایجاد"
+          loadingLabel="در حال ایجاد…"
+          isLoading={isCreating}
+          disabled={isCreating}
+          confirmProps={{
+            type: 'submit',
+            form: 'create-filesystem-form',
+          }}
+        />
+      }
+    >
+      <Box component="form" id="create-filesystem-form" onSubmit={handleSubmit}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <FormControl fullWidth error={Boolean(poolError)}>
+            <InputLabel
+              id="filesystem-pool-select"
+              sx={{ color: 'var(--color-text)' }}
+            >
+              انتخاب Pool
+            </InputLabel>
+            <Select
+              labelId="filesystem-pool-select"
+              label="انتخاب Pool"
+              value={selectedPool}
+              onChange={handlePoolChange}
+              sx={inputBaseStyles}
+              MenuProps={{
+                PaperProps: {
+                  sx: {
+                    backgroundColor: 'var(--color-card-bg)',
+                    color: 'var(--color-text)',
+                  },
+                },
+              }}
+            >
+              {poolOptions.length === 0 && (
+                <MenuItem value="" disabled>
+                  Poolی برای ایجاد فایل سیستم موجود نیست.
+                </MenuItem>
+              )}
+              {poolOptions.map((pool) => (
+                <MenuItem key={pool} value={pool}>
+                  {pool}
+                </MenuItem>
+              ))}
+            </Select>
+            {poolError && <FormHelperText>{poolError}</FormHelperText>}
+          </FormControl>
+
+          <TextField
+            label="نام فایل سیستم"
+            value={filesystemName}
+            onChange={handleNameChange}
+            fullWidth
+            autoComplete="off"
+            error={Boolean(nameError)}
+            helperText={nameError ?? 'نامی یکتا برای فایل سیستم وارد کنید.'}
+            InputLabelProps={{ shrink: true }}
+            InputProps={{ sx: inputBaseStyles }}
+          />
+
+          {apiError && (
+            <Typography sx={{ color: 'var(--color-error)', fontWeight: 600 }}>
+              {apiError}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default CreateFileSystemModal;

--- a/src/components/file-system/FileSystemsTable.tsx
+++ b/src/components/file-system/FileSystemsTable.tsx
@@ -1,0 +1,155 @@
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useMemo } from 'react';
+import { MdDeleteOutline } from 'react-icons/md';
+import type { DataTableColumn } from '../../@types/dataTable';
+import type { FileSystemEntry } from '../../@types/filesystem';
+import DataTable from '../DataTable';
+
+interface FileSystemsTableProps {
+  filesystems: FileSystemEntry[];
+  attributeKeys: string[];
+  isLoading: boolean;
+  error: Error | null;
+  onDeleteFilesystem: (filesystem: FileSystemEntry) => void;
+  isDeleteDisabled: boolean;
+}
+
+const valueTypographySx = {
+  fontWeight: 600,
+  color: 'var(--color-text)',
+} as const;
+
+const numericValueTypographySx = {
+  ...valueTypographySx,
+  display: 'block',
+  textAlign: 'right' as const,
+  direction: 'ltr' as const,
+  fontVariantNumeric: 'tabular-nums',
+};
+
+const FileSystemsTable = ({
+  filesystems,
+  attributeKeys,
+  isLoading,
+  error,
+  onDeleteFilesystem,
+  isDeleteDisabled,
+}: FileSystemsTableProps) => {
+  const columns = useMemo<DataTableColumn<FileSystemEntry>[]>(() => {
+    const baseColumns: DataTableColumn<FileSystemEntry>[] = [
+      {
+        id: 'pool',
+        header: 'نام Pool',
+        align: 'left',
+        renderCell: (filesystem) => (
+          <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+            {filesystem.poolName}
+          </Typography>
+        ),
+      },
+      {
+        id: 'filesystem',
+        header: 'نام فایل سیستم',
+        align: 'left',
+        renderCell: (filesystem) => (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+            <Typography sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+              {filesystem.filesystemName}
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'var(--color-secondary)' }}>
+              {filesystem.fullName}
+            </Typography>
+          </Box>
+        ),
+      },
+    ];
+
+    const dynamicColumns = attributeKeys.map<DataTableColumn<FileSystemEntry>>(
+      (key) => ({
+        id: `attribute-${key}`,
+        header: key,
+        align: 'left',
+        renderCell: (filesystem) => {
+          const rawValue = filesystem.attributeMap[key];
+          const isNumericValue =
+            typeof rawValue === 'number' && Number.isFinite(rawValue);
+
+          return (
+            <Typography
+              sx={isNumericValue ? numericValueTypographySx : valueTypographySx}
+            >
+              {isNumericValue
+                ? new Intl.NumberFormat('en-US').format(rawValue)
+                : rawValue ?? '—'}
+            </Typography>
+          );
+        },
+      })
+    );
+
+    const actionColumn: DataTableColumn<FileSystemEntry> = {
+      id: 'actions',
+      header: 'عملیات',
+      align: 'center',
+      renderCell: (filesystem) => (
+        <Tooltip title="حذف فایل سیستم">
+          <span>
+            <IconButton
+              size="small"
+              color="error"
+              onClick={() => onDeleteFilesystem(filesystem)}
+              disabled={isDeleteDisabled}
+            >
+              <MdDeleteOutline size={18} />
+            </IconButton>
+          </span>
+        </Tooltip>
+      ),
+    };
+
+    return [...baseColumns, ...dynamicColumns, actionColumn];
+  }, [attributeKeys, isDeleteDisabled, onDeleteFilesystem]);
+
+  return (
+    <DataTable<FileSystemEntry>
+      columns={columns}
+      data={filesystems}
+      getRowId={(filesystem) => filesystem.id}
+      isLoading={isLoading}
+      error={error}
+      renderLoadingState={() => (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            alignItems: 'center',
+          }}
+        >
+          <CircularProgress color="primary" size={32} />
+          <Typography sx={{ color: 'var(--color-secondary)' }}>
+            در حال دریافت اطلاعات فایل سیستم‌ها...
+          </Typography>
+        </Box>
+      )}
+      renderErrorState={(tableError) => (
+        <Typography sx={{ color: 'var(--color-error)' }}>
+          خطا در دریافت اطلاعات فایل سیستم‌ها: {tableError.message}
+        </Typography>
+      )}
+      renderEmptyState={() => (
+        <Typography sx={{ color: 'var(--color-secondary)' }}>
+          هیچ فایل سیستمی برای نمایش وجود ندارد.
+        </Typography>
+      )}
+    />
+  );
+};
+
+export default FileSystemsTable;

--- a/src/hooks/useCreateFileSystem.ts
+++ b/src/hooks/useCreateFileSystem.ts
@@ -1,0 +1,159 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+import type { FormEvent } from 'react';
+import { useCallback, useState } from 'react';
+import axiosInstance from '../lib/axiosInstance';
+
+interface ApiErrorResponse {
+  detail?: string;
+  message?: string;
+  errors?: string | string[];
+  [key: string]: unknown;
+}
+
+interface CreateFileSystemPayload {
+  filesystem_name: string;
+}
+
+interface UseCreateFileSystemOptions {
+  onSuccess?: (filesystemName: string) => void;
+  onError?: (errorMessage: string) => void;
+}
+
+const extractApiMessage = (error: AxiosError<ApiErrorResponse>) => {
+  const payload = error.response?.data;
+
+  if (!payload) {
+    return error.message;
+  }
+
+  if (typeof payload === 'string') {
+    return payload;
+  }
+
+  if (payload.detail && typeof payload.detail === 'string') {
+    return payload.detail;
+  }
+
+  if (payload.message && typeof payload.message === 'string') {
+    return payload.message;
+  }
+
+  if (payload.errors) {
+    if (Array.isArray(payload.errors)) {
+      return payload.errors.join('، ');
+    }
+
+    if (typeof payload.errors === 'string') {
+      return payload.errors;
+    }
+  }
+
+  return error.message;
+};
+
+export const useCreateFileSystem = ({
+  onSuccess,
+  onError,
+}: UseCreateFileSystemOptions = {}) => {
+  const queryClient = useQueryClient();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedPool, setSelectedPool] = useState('');
+  const [filesystemName, setFileSystemName] = useState('');
+  const [poolError, setPoolError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setSelectedPool('');
+    setFileSystemName('');
+    setPoolError(null);
+    setNameError(null);
+    setApiError(null);
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    resetForm();
+    setIsOpen(true);
+  }, [resetForm]);
+
+  const handleClose = useCallback(() => {
+    resetForm();
+    setIsOpen(false);
+  }, [resetForm]);
+
+  const createFileSystemMutation = useMutation<
+    unknown,
+    AxiosError<ApiErrorResponse>,
+    CreateFileSystemPayload
+  >({
+    mutationFn: async (payload) => {
+      await axiosInstance.post('/api/filesystem/create/', payload);
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['filesystems'] });
+      handleClose();
+      onSuccess?.(variables.filesystem_name);
+    },
+    onError: (error) => {
+      const message = extractApiMessage(error);
+      setApiError(message);
+      onError?.(message);
+    },
+  });
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setPoolError(null);
+      setNameError(null);
+      setApiError(null);
+
+      const trimmedPool = selectedPool.trim();
+      const trimmedName = filesystemName.trim();
+
+      let hasError = false;
+
+      if (!trimmedPool) {
+        setPoolError('لطفاً Pool مقصد را انتخاب کنید.');
+        hasError = true;
+      }
+
+      if (!trimmedName) {
+        setNameError('نام فایل سیستم را وارد کنید.');
+        hasError = true;
+      }
+
+      if (hasError) {
+        return;
+      }
+
+      const payload: CreateFileSystemPayload = {
+        filesystem_name: `${trimmedPool}/${trimmedName}`.replace(/\s+/g, ''),
+      };
+
+      createFileSystemMutation.mutate(payload);
+    },
+    [createFileSystemMutation, filesystemName, selectedPool]
+  );
+
+  return {
+    isOpen,
+    selectedPool,
+    setSelectedPool,
+    filesystemName,
+    setFileSystemName,
+    poolError,
+    nameError,
+    apiError,
+    isCreating: createFileSystemMutation.isPending,
+    openCreateModal: handleOpen,
+    closeCreateModal: () => {
+      createFileSystemMutation.reset();
+      handleClose();
+    },
+    handleSubmit,
+  };
+};
+
+export type UseCreateFileSystemReturn = ReturnType<typeof useCreateFileSystem>;

--- a/src/hooks/useDeleteFileSystem.ts
+++ b/src/hooks/useDeleteFileSystem.ts
@@ -1,0 +1,114 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import type { FileSystemEntry, FileSystemQueryResult } from '../@types/filesystem';
+import axiosInstance from '../lib/axiosInstance';
+
+interface DeleteFileSystemPayload {
+  filesystem_name: string;
+}
+
+interface DeleteFileSystemResponse {
+  detail?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+const deleteFileSystemRequest = async ({
+  filesystem_name,
+}: DeleteFileSystemPayload): Promise<DeleteFileSystemResponse> => {
+  const response = await axiosInstance.delete<DeleteFileSystemResponse>(
+    '/api/filesystem/delete/',
+    {
+      data: { filesystem_name },
+    }
+  );
+
+  return response.data;
+};
+
+interface UseDeleteFileSystemOptions {
+  onSuccess?: (filesystemName: string) => void;
+  onError?: (error: Error, filesystemName: string) => void;
+}
+
+export const useDeleteFileSystem = ({
+  onSuccess,
+  onError,
+}: UseDeleteFileSystemOptions = {}) => {
+  const queryClient = useQueryClient();
+  const [targetFileSystem, setTargetFileSystem] = useState<FileSystemEntry | null>(
+    null
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const deleteMutation = useMutation<
+    DeleteFileSystemResponse,
+    Error,
+    DeleteFileSystemPayload
+  >({
+    mutationFn: deleteFileSystemRequest,
+    onSuccess: (_data, variables) => {
+      queryClient.setQueryData<FileSystemQueryResult | undefined>(
+        ['filesystems'],
+        (current) => {
+          if (!current) {
+            return current;
+          }
+
+          return {
+            ...current,
+            filesystems: current.filesystems.filter(
+              (filesystem) => filesystem.fullName !== variables.filesystem_name
+            ),
+          };
+        }
+      );
+
+      queryClient.invalidateQueries({ queryKey: ['filesystems'] });
+    },
+  });
+
+  const requestDelete = useCallback((filesystem: FileSystemEntry) => {
+    setErrorMessage(null);
+    setTargetFileSystem(filesystem);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setTargetFileSystem(null);
+    setErrorMessage(null);
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (!targetFileSystem || deleteMutation.isPending) {
+      return;
+    }
+
+    setErrorMessage(null);
+
+    deleteMutation.mutate(
+      { filesystem_name: targetFileSystem.fullName },
+      {
+        onSuccess: () => {
+          onSuccess?.(targetFileSystem.fullName);
+          closeModal();
+        },
+        onError: (error) => {
+          setErrorMessage(error.message);
+          onError?.(error, targetFileSystem.fullName);
+        },
+      }
+    );
+  }, [closeModal, deleteMutation, onError, onSuccess, targetFileSystem]);
+
+  return {
+    isOpen: Boolean(targetFileSystem),
+    targetFileSystem,
+    requestDelete,
+    closeModal,
+    confirmDelete,
+    isDeleting: deleteMutation.isPending,
+    errorMessage,
+  };
+};
+
+export type UseDeleteFileSystemReturn = ReturnType<typeof useDeleteFileSystem>;

--- a/src/hooks/useFileSystems.ts
+++ b/src/hooks/useFileSystems.ts
@@ -1,0 +1,166 @@
+import { useQuery } from '@tanstack/react-query';
+import type {
+  FileSystemApiResponse,
+  FileSystemEntry,
+  FileSystemQueryResult,
+  FileSystemRawEntry,
+} from '../@types/filesystem';
+import axiosInstance from '../lib/axiosInstance';
+
+const FILESYSTEM_LIST_ENDPOINT = '/api/filesystem/';
+
+const formatAttributeValue = (value: unknown): string => {
+  if (value == null) {
+    return '—';
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '—';
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => formatAttributeValue(item)).join('، ');
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '[object]';
+    }
+  }
+
+  return String(value);
+};
+
+const ensureObject = (raw: unknown): FileSystemRawEntry => {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as FileSystemRawEntry;
+  }
+
+  return {};
+};
+
+const deriveNameParts = (
+  fullNameHint: string | undefined,
+  raw: FileSystemRawEntry,
+  index: number
+) => {
+  const rawName = raw.name;
+  const fallbackName = `filesystem-${index + 1}`;
+  const fullNameSource = (() => {
+    if (typeof fullNameHint === 'string' && fullNameHint.trim().length > 0) {
+      return fullNameHint.trim();
+    }
+
+    if (typeof rawName === 'string' && rawName.trim().length > 0) {
+      return rawName.trim();
+    }
+
+    return fallbackName;
+  })();
+
+  const [poolPart, ...rest] = fullNameSource.split('/');
+  const poolName = poolPart?.trim() ? poolPart.trim() : 'نامشخص';
+  const filesystemNameSource = rest.length > 0 ? rest.join('/') : fullNameSource;
+  const filesystemName =
+    filesystemNameSource.trim().length > 0
+      ? filesystemNameSource.trim()
+      : fullNameSource;
+
+  return {
+    fullName: fullNameSource,
+    poolName,
+    filesystemName,
+  };
+};
+
+const enrichAttributes = (raw: FileSystemRawEntry, fullName: string) => {
+  const normalized = { ...raw };
+
+  if (typeof normalized.name !== 'string' || normalized.name.trim().length === 0) {
+    normalized.name = fullName;
+  }
+
+  const entries = Object.entries(normalized).map(([key, value]) => ({
+    key,
+    value: formatAttributeValue(value),
+  }));
+
+  const attributeMap = entries.reduce<Record<string, string>>((acc, attribute) => {
+    acc[attribute.key] = attribute.value;
+    return acc;
+  }, {});
+
+  return { entries, attributeMap };
+};
+
+const normalizeFileSystemEntry = (
+  fullNameHint: string | undefined,
+  raw: unknown,
+  index: number
+): FileSystemEntry => {
+  const normalizedRaw = ensureObject(raw);
+  const { fullName, poolName, filesystemName } = deriveNameParts(
+    fullNameHint,
+    normalizedRaw,
+    index
+  );
+  const { entries, attributeMap } = enrichAttributes(normalizedRaw, fullName);
+
+  return {
+    id: fullName,
+    fullName,
+    poolName,
+    filesystemName,
+    attributes: entries,
+    attributeMap,
+    raw: normalizedRaw,
+  };
+};
+
+const fetchFileSystems = async (): Promise<FileSystemQueryResult> => {
+  const response = await axiosInstance.get<FileSystemApiResponse>(
+    FILESYSTEM_LIST_ENDPOINT
+  );
+
+  const payload = response.data;
+  const data = payload?.data;
+
+  const filesystems = (() => {
+    if (Array.isArray(data)) {
+      return data.map((raw, index) => normalizeFileSystemEntry(undefined, raw, index));
+    }
+
+    if (data && typeof data === 'object') {
+      return Object.entries(data).map(([fullName, raw], index) =>
+        normalizeFileSystemEntry(fullName, raw, index)
+      );
+    }
+
+    return [] as FileSystemEntry[];
+  })().sort((a, b) => {
+    const poolCompare = a.poolName.localeCompare(b.poolName, 'fa');
+    if (poolCompare !== 0) {
+      return poolCompare;
+    }
+
+    return a.filesystemName.localeCompare(b.filesystemName, 'fa');
+  });
+
+  return { filesystems };
+};
+
+export const useFileSystems = () =>
+  useQuery<FileSystemQueryResult, Error>({
+    queryKey: ['filesystems'],
+    queryFn: fetchFileSystems,
+    staleTime: 15000,
+  });
+
+export type UseFileSystemsReturn = ReturnType<typeof useFileSystems>;

--- a/src/pages/FileSystem.tsx
+++ b/src/pages/FileSystem.tsx
@@ -1,11 +1,138 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import { useCallback, useMemo } from 'react';
+import { toast } from 'react-hot-toast';
+import type { FileSystemEntry } from '../@types/filesystem';
+import ConfirmDeleteFileSystemModal from '../components/file-system/ConfirmDeleteFileSystemModal';
+import CreateFileSystemModal from '../components/file-system/CreateFileSystemModal';
+import FileSystemsTable from '../components/file-system/FileSystemsTable';
+import { useCreateFileSystem } from '../hooks/useCreateFileSystem';
+import { useDeleteFileSystem } from '../hooks/useDeleteFileSystem';
+import { useFileSystems } from '../hooks/useFileSystems';
+import { useZpool } from '../hooks/useZpool';
 
-const FileSystem = () => (
-  <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
-    <Typography variant="h5" sx={{ color: 'var(--color-primary)' }}>
-      فایل سیستم
-    </Typography>
-  </Box>
-);
+const FileSystem = () => {
+  const createFileSystem = useCreateFileSystem({
+    onSuccess: (filesystemName) => {
+      toast.success(`فایل سیستم ${filesystemName} با موفقیت ایجاد شد.`);
+    },
+    onError: (errorMessage) => {
+      toast.error(`ایجاد فایل سیستم با خطا مواجه شد: ${errorMessage}`);
+    },
+  });
+
+  const deleteFileSystem = useDeleteFileSystem({
+    onSuccess: (filesystemName) => {
+      toast.success(`فایل سیستم ${filesystemName} با موفقیت حذف شد.`);
+    },
+    onError: (error, filesystemName) => {
+      toast.error(
+        `حذف فایل سیستم ${filesystemName} با خطا مواجه شد: ${error.message}`
+      );
+    },
+  });
+
+  const { data, isLoading, error } = useFileSystems();
+  const { data: poolData } = useZpool();
+
+  const poolOptions = useMemo(
+    () =>
+      (poolData?.pools ?? [])
+        .map((pool) => pool.name)
+        .sort((a, b) => a.localeCompare(b, 'fa')),
+    [poolData?.pools]
+  );
+
+  const filesystems = useMemo(
+    () => data?.filesystems ?? [],
+    [data?.filesystems]
+  );
+
+  const attributeKeys = useMemo(() => {
+    const keys = new Set<string>();
+
+    filesystems.forEach((filesystem) => {
+      filesystem.attributes.forEach((attribute) => {
+        if (attribute.key !== 'name') {
+          keys.add(attribute.key);
+        }
+      });
+    });
+
+    return Array.from(keys).sort((a, b) => a.localeCompare(b, 'fa'));
+  }, [filesystems]);
+
+  const handleOpenCreate = useCallback(() => {
+    createFileSystem.openCreateModal();
+  }, [createFileSystem]);
+
+  const handleDelete = useCallback(
+    (filesystem: FileSystemEntry) => {
+      deleteFileSystem.requestDelete(filesystem);
+    },
+    [deleteFileSystem]
+  );
+
+  return (
+    <Box sx={{ p: 3, fontFamily: 'var(--font-vazir)' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Typography
+            variant="h5"
+            sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+          >
+            فایل سیستم
+          </Typography>
+
+          <Button
+            onClick={handleOpenCreate}
+            variant="contained"
+            sx={{
+              px: 3,
+              py: 1.25,
+              borderRadius: '5px',
+              fontWeight: 700,
+              fontSize: '0.95rem',
+              background:
+                'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
+              color: 'var(--color-bg)',
+              boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
+              '&:hover': {
+                background:
+                  'linear-gradient(135deg, rgba(0, 198, 169, 0.95) 0%, rgba(18, 140, 200, 0.95) 100%)',
+                boxShadow: '0 18px 36px -18px rgba(0, 198, 169, 0.75)',
+              },
+            }}
+          >
+            ایجاد فایل سیستم
+          </Button>
+        </Box>
+      </Box>
+
+      <CreateFileSystemModal
+        controller={createFileSystem}
+        poolOptions={poolOptions}
+      />
+
+      <FileSystemsTable
+        filesystems={filesystems}
+        attributeKeys={attributeKeys}
+        isLoading={isLoading}
+        error={error ?? null}
+        onDeleteFilesystem={handleDelete}
+        isDeleteDisabled={deleteFileSystem.isDeleting}
+      />
+
+      <ConfirmDeleteFileSystemModal controller={deleteFileSystem} />
+    </Box>
+  );
+};
 
 export default FileSystem;


### PR DESCRIPTION
## Summary
- add reusable types and React Query hook for fetching filesystem entries
- introduce filesystem table plus create and delete modals wired to backend APIs
- update the filesystem page to surface the new management workflow and pool-aware creation

## Testing
- `npm run build` *(fails: existing TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68e0ea33b198832f983f9f6979d41354