### PR TITLE
Add mountpoint selection to share creation modal

### DIFF
--- a/src/hooks/useCreateShare.ts
+++ b/src/hooks/useCreateShare.ts
@@ -6,6 +6,8 @@ import type { CreateShareWithPermissionsPayload } from '../@types/samba';
 import { createShareWithDirectoryPermissions } from '../lib/shareService';
 import { sambaSharesQueryKey } from './useSambaShares';
 
+type PathValidationStatus = 'idle' | 'valid' | 'invalid';
+
 interface ApiErrorResponse {
   detail?: string;
   message?: string;
@@ -149,6 +151,10 @@ export const useCreateShare = ({
     validUsersError,
     apiError,
     isCreating: createShareMutation.isPending,
+    pathValidationStatus: 'idle' as PathValidationStatus,
+    pathValidationMessage: null as string | null,
+    isPathChecking: false,
+    isPathValid: false,
     openCreateModal: handleOpen,
     closeCreateModal,
     setFullPath,

--- a/src/hooks/useFilesystemMountpoints.ts
+++ b/src/hooks/useFilesystemMountpoints.ts
@@ -1,0 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import axiosInstance from '../lib/axiosInstance';
+import type { FileSystemApiResponse } from '../@types/filesystem';
+
+const FILESYSTEM_LIST_ENDPOINT = '/api/filesystem/';
+
+const normalizeMountpoints = (raw: unknown): string[] => {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const mountpoints = raw.reduce<string[]>((acc, entry) => {
+    if (entry && typeof entry === 'object') {
+      const mountpoint = (entry as { mountpoint?: unknown }).mountpoint;
+
+      if (typeof mountpoint === 'string') {
+        const trimmed = mountpoint.trim();
+
+        if (trimmed.length > 0 && !acc.includes(trimmed)) {
+          acc.push(trimmed);
+        }
+      }
+    }
+
+    return acc;
+  }, []);
+
+  return mountpoints.sort((a, b) => a.localeCompare(b, 'fa'));
+};
+
+const fetchFilesystemMountpoints = async (): Promise<string[]> => {
+  const response = await axiosInstance.get<FileSystemApiResponse>(
+    FILESYSTEM_LIST_ENDPOINT
+  );
+
+  const payload = response.data;
+  return normalizeMountpoints(payload?.data);
+};
+
+interface UseFilesystemMountpointsOptions {
+  enabled?: boolean;
+}
+
+export const useFilesystemMountpoints = ({
+  enabled = true,
+}: UseFilesystemMountpointsOptions = {}) =>
+  useQuery<string[], Error>({
+    queryKey: ['filesystem-mountpoints'],
+    queryFn: fetchFilesystemMountpoints,
+    staleTime: 15000,
+    enabled,
+  });
+
+export type UseFilesystemMountpointsReturn = ReturnType<
+  typeof useFilesystemMountpoints
+>;
+


### PR DESCRIPTION
## Summary
- load filesystem mountpoints from the API for share creation
- present mountpoint suggestions in the create share modal input
- expose placeholder path validation state fields from the create share hook

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_b_68e0f2e092b4832f994d0945ed0e368b