### PR TITLE
Display WWN identifiers in pool creation modal

### DIFF
--- a/src/components/integrated-storage/CreatePoolModal.tsx
+++ b/src/components/integrated-storage/CreatePoolModal.tsx
@@ -23,6 +23,7 @@ export interface DeviceOption {
   label: string;
   value: string;
   tooltip: string;
+  wwn: string;
 }
 
 interface CreatePoolModalProps {
@@ -205,12 +206,24 @@ const CreatePoolModal = ({
                       }
                       label={
                         <Tooltip title={device.tooltip} placement="top" arrow>
-                          <Typography
-                            component="span"
-                            sx={{ color: 'var(--color-text)' }}
-                          >
-                            {device.label}
-                          </Typography>
+                          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                            <Typography
+                              component="span"
+                              sx={{ color: 'var(--color-text)', fontWeight: 600 }}
+                            >
+                              {device.label}
+                            </Typography>
+                            <Typography
+                              component="span"
+                              sx={{
+                                color: 'var(--color-secondary)',
+                                fontSize: '0.78rem',
+                                direction: 'ltr',
+                              }}
+                            >
+                              {device.wwn}
+                            </Typography>
+                          </Box>
                         </Tooltip>
                       }
                       sx={{

--- a/src/pages/IntegratedStorage.tsx
+++ b/src/pages/IntegratedStorage.tsx
@@ -77,7 +77,8 @@ const IntegratedStorage = () => {
         return {
           label: deviceLabel,
           value: wwnValue,
-          tooltip: wwnValue,
+          tooltip: normalizedWwnPath,
+          wwn: normalizedWwnPath,
         } satisfies DeviceOption;
       })
       .filter((option): option is DeviceOption => option !== null)


### PR DESCRIPTION
## Summary
- extend pool creation device options to include the disk WWN identifier from the WWN map API
- render each selectable device with its WWN value so users can see the exact identifier when choosing disks

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e0f4004058832f8708abd9fb35489c