### PR TITLE
Add confirmation modal for deleting shares

### DIFF
--- a/src/components/share/ConfirmDeleteShareModal.tsx
+++ b/src/components/share/ConfirmDeleteShareModal.tsx
@@ -1,0 +1,59 @@
+import { Box, Typography } from '@mui/material';
+import type { UseDeleteShareReturn } from '../../hooks/useDeleteShare';
+import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
+
+interface ConfirmDeleteShareModalProps {
+  controller: UseDeleteShareReturn;
+}
+
+const ConfirmDeleteShareModal = ({
+  controller,
+}: ConfirmDeleteShareModalProps) => {
+  const {
+    isOpen,
+    targetShare,
+    closeModal,
+    confirmDelete,
+    isDeleting,
+    errorMessage,
+  } = controller;
+
+  return (
+    <BlurModal
+      open={isOpen}
+      onClose={closeModal}
+      title="حذف اشتراک"
+      actions={
+        <ModalActionButtons
+          onCancel={closeModal}
+          onConfirm={confirmDelete}
+          confirmLabel="حذف"
+          loadingLabel="در حال حذف…"
+          isLoading={isDeleting}
+          disabled={isDeleting}
+          disableConfirmGradient
+          confirmProps={{ color: 'error' }}
+        />
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography sx={{ color: 'var(--color-text)' }}>
+          آیا از حذف اشتراک{' '}
+          <Typography component="span" sx={{ fontWeight: 700 }}>
+            {targetShare?.name}
+          </Typography>{' '}
+          مطمئن هستید؟ این عملیات قابل بازگشت نیست.
+        </Typography>
+
+        {errorMessage ? (
+          <Typography sx={{ color: 'var(--color-error)', fontWeight: 600 }}>
+            {errorMessage}
+          </Typography>
+        ) : null}
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default ConfirmDeleteShareModal;

--- a/src/pages/Share.tsx
+++ b/src/pages/Share.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from 'react-hot-toast';
 import type { SambaShareEntry } from '../@types/samba';
 import TabPanel from '../components/TabPanel';
+import ConfirmDeleteShareModal from '../components/share/ConfirmDeleteShareModal';
 import CreateShareModal from '../components/share/CreateShareModal';
 import SelectedSharesDetailsPanel from '../components/share/SelectedSharesDetailsPanel';
 import SharesTable from '../components/share/SharesTable';
@@ -70,7 +71,7 @@ const Share = () => {
     },
   });
 
-  const deleteShare = useDeleteShare({
+  const shareDeletion = useDeleteShare({
     onSuccess: (shareName) => {
       toast.success(`اشتراک ${shareName} با موفقیت حذف شد.`);
     },
@@ -150,9 +151,9 @@ const Share = () => {
 
   const handleDeleteShare = useCallback(
     (share: SambaShareEntry) => {
-      deleteShare.deleteShare(share.name);
+      shareDeletion.requestDelete(share);
     },
-    [deleteShare]
+    [shareDeletion]
   );
 
   const comparisonItems = useMemo(
@@ -442,8 +443,8 @@ const Share = () => {
             selectedShares={selectedShares}
             onToggleSelect={handleToggleSelect}
             onDelete={handleDeleteShare}
-            pendingShareName={deleteShare.pendingShareName}
-            isDeleting={deleteShare.isDeleting}
+            pendingShareName={shareDeletion.pendingShareName}
+            isDeleting={shareDeletion.isDeleting}
           />
 
           <SelectedSharesDetailsPanel
@@ -517,6 +518,8 @@ const Share = () => {
       </TabPanel>
 
       <CreateShareModal controller={createShare} />
+
+      <ConfirmDeleteShareModal controller={shareDeletion} />
 
       <SambaUserCreateModal
         open={isSambaCreateModalOpen}


### PR DESCRIPTION
## Summary
- add a confirmation modal for deleting Samba shares to the share management page
- extend the delete share hook with modal state, pending tracking, and error handling
- integrate the new modal and controller into the share table actions

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e0fac188b0832f9b6c8eac3f3f99bc