### PR TITLE
Add permissions update request to share creation flow

### DIFF
--- a/src/@types/samba.ts
+++ b/src/@types/samba.ts
@@ -33,6 +33,14 @@ export interface CreateShareWithPermissionsPayload
   mode?: string;
 }
 
+export interface SetDirectoryPermissionsPayload {
+  path: string;
+  owner: string;
+  group: string;
+  mode: string;
+  recursive: string;
+}
+
 export type RawSambaUserDetails = Record<string, unknown>;
 
 export type SambaUsersResponseData =

--- a/src/lib/shareService.ts
+++ b/src/lib/shareService.ts
@@ -2,6 +2,7 @@ import type {
   CreateDirectoryPermissionsPayload,
   CreateSambaSharePayload,
   CreateShareWithPermissionsPayload,
+  SetDirectoryPermissionsPayload,
 } from '../@types/samba';
 import axiosInstance from './axiosInstance';
 
@@ -25,6 +26,22 @@ const createSambaShare = async (payload: CreateSambaSharePayload) => {
   await axiosInstance.post('/api/samba/config/append/', payload);
 };
 
+const setDirectoryPermissions = async ({
+  path,
+  mode,
+  owner,
+  group,
+  recursive,
+}: SetDirectoryPermissionsPayload) => {
+  await axiosInstance.post('/api/dir/set/permissions/', {
+    path,
+    mode,
+    owner,
+    group,
+    recursive,
+  });
+};
+
 export const createShareWithDirectoryPermissions = async ({
   full_path,
   valid_users,
@@ -42,5 +59,13 @@ export const createShareWithDirectoryPermissions = async ({
   await createSambaShare({
     full_path,
     valid_users,
+  });
+
+  await setDirectoryPermissions({
+    path: full_path,
+    mode: '0755',
+    owner: sanitizedUser,
+    group: sanitizedUser,
+    recursive: 'True',
   });
 };


### PR DESCRIPTION
## Summary
- add a payload type for directory permission updates
- call the directory permission update API after creating a share so it uses the selected user and 0755 mode

## Testing
- npm run lint *(fails: pre-existing lint errors about react-refresh and unused vars)*

------
https://chatgpt.com/codex/tasks/task_b_68e10038635c832fa81e23e96d7e58cb