### PR TITLE
Enforce English-only naming in storage creation modals

### DIFF
--- a/src/hooks/useCreateFileSystem.ts
+++ b/src/hooks/useCreateFileSystem.ts
@@ -130,6 +130,9 @@ export const useCreateFileSystem = ({
       if (!trimmedName) {
         setNameError('نام فضای فایلی را وارد کنید.');
         hasError = true;
+      } else if (!/^[A-Za-z]+$/.test(trimmedName)) {
+        setNameError('نام فضای فایلی باید فقط شامل حروف انگلیسی باشد.');
+        hasError = true;
       }
 
       if (!trimmedQuota) {

--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -126,6 +126,9 @@ export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
       if (!trimmedName) {
         setPoolNameError('لطفاً نام فضای یکپارچه را وارد کنید.');
         hasError = true;
+      } else if (!/^[A-Za-z]+$/.test(trimmedName)) {
+        setPoolNameError('نام فضای یکپارچه باید فقط شامل حروف انگلیسی باشد.');
+        hasError = true;
       }
 
       const deviceCount = selectedDevices.length;


### PR DESCRIPTION
## Summary
- validate integrated storage pool names to allow only English letters
- restrict new file system names to English letters and surface validation feedback

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e4e867f318832f8419410a67bae5d1