### PR TITLE
Add alphanumeric validation to storage creation forms

### DIFF
--- a/src/hooks/useCreateFileSystem.ts
+++ b/src/hooks/useCreateFileSystem.ts
@@ -130,6 +130,11 @@ export const useCreateFileSystem = ({
       if (!trimmedName) {
         setNameError('نام فضای فایلی را وارد کنید.');
         hasError = true;
+      } else if (!/^[A-Za-z0-9]+$/.test(trimmedName)) {
+        setNameError(
+          'نام فضای فایلی باید فقط شامل حروف انگلیسی و اعداد باشد.'
+        );
+        hasError = true;
       }
 
       if (!trimmedQuota) {

--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -126,6 +126,11 @@ export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
       if (!trimmedName) {
         setPoolNameError('لطفاً نام فضای یکپارچه را وارد کنید.');
         hasError = true;
+      } else if (!/^[A-Za-z0-9]+$/.test(trimmedName)) {
+        setPoolNameError(
+          'نام فضای یکپارچه باید فقط شامل حروف انگلیسی و اعداد باشد.'
+        );
+        hasError = true;
       }
 
       const deviceCount = selectedDevices.length;


### PR DESCRIPTION
## Summary
- enforce an alphanumeric-only rule for new pool names in the create pool flow
- ensure filesystem names entered in the filesystem creation modal are limited to English letters and numbers

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e4ea1dbad8832f938bd88c2d1b0b16