### PR TITLE
Normalize device identifiers when creating pools

### DIFF
--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -156,9 +156,13 @@ export const useCreatePool = ({ onSuccess }: UseCreatePoolOptions = {}) => {
         return;
       }
 
+      const normalizedDevices = selectedDevices.map((device) =>
+        device.startsWith('/') ? device : `/dev/disk/by-id/${device}`
+      );
+
       createPoolMutation.mutate({
         pool_name: trimmedName,
-        devices: selectedDevices,
+        devices: normalizedDevices,
         vdev_type: vdevType,
       });
     },


### PR DESCRIPTION
## Summary
- normalize selected disk identifiers to full /dev/disk/by-id paths before submitting the create pool request
- leave existing validation and mutation flow unchanged

## Testing
- npm run build *(fails: existing TypeScript errors in IntegratedStorage.tsx and other files)*

------
https://chatgpt.com/codex/tasks/task_b_68e601e7abf0832fb14b8950ca455516