### PR TITLE
Fix disk refresh and deletion workflow for pools

### DIFF
--- a/src/components/integrated-storage/CreatePoolModal.tsx
+++ b/src/components/integrated-storage/CreatePoolModal.tsx
@@ -96,6 +96,7 @@ const CreatePoolModal = ({
     },
     enabled: shouldFetchDiskList && isOpen,
     refetchOnWindowFocus: false,
+    refetchOnMount: 'always',
   });
 
   const deviceOptions = useMemo<DeviceOption[]>(() => {

--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -96,6 +96,7 @@ export const useCreatePool = ({
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['zpool'] });
+      queryClient.invalidateQueries({ queryKey: ['disk', 'free'] });
       handleClose();
       onSuccess?.(variables.pool_name);
     },


### PR DESCRIPTION
## Summary
- refresh the free disk list whenever the create pool modal reopens after a pool is created
- send POST requests for pool and disk deletions while preserving disk names captured before removing a pool
- invalidate cached free disk data after pool creation and deletion to keep the selector accurate

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e60fc4e3cc832f811cde36edfb4faa