### PR TITLE
Fix pool disk refresh and improve deletion API compatibility

### DIFF
--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -96,6 +96,7 @@ export const useCreatePool = ({
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['zpool'] });
+      queryClient.invalidateQueries({ queryKey: ['disk', 'free'] });
       handleClose();
       onSuccess?.(variables.pool_name);
     },


### PR DESCRIPTION
## Summary
- invalidate the cached free disk list after pool creation so the modal reloads available disks
- update the pool deletion flow to record attached devices before removing the pool and support the API's delete endpoints
- ensure disk clean-up supports both POST and DELETE variants to avoid backend 500 errors

## Testing
- npm run lint *(fails: pre-existing warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68e60fc4e3cc832f811cde36edfb4faa