### PR TITLE
Optimize integrated storage detail polling

### DIFF
--- a/src/hooks/usePoolDetailQueries.ts
+++ b/src/hooks/usePoolDetailQueries.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useQueries, type UseQueryOptions } from '@tanstack/react-query';
+import type { ZpoolDetailEntry } from '../@types/zpool';
+import { fetchZpoolDetails, zpoolDetailQueryKey } from './useZpoolDetails';
+
+export const usePoolDetailQueries = (poolNames: string[]) => {
+  const hasPoolsToLoad = poolNames.length > 0;
+
+  const queries = useMemo<UseQueryOptions<ZpoolDetailEntry, Error>[]>(
+    () =>
+      poolNames.map((poolName) => ({
+        queryKey: zpoolDetailQueryKey(poolName),
+        queryFn: () => fetchZpoolDetails(poolName),
+        enabled: hasPoolsToLoad,
+        refetchInterval: hasPoolsToLoad ? 10000 : false,
+      })),
+    [hasPoolsToLoad, poolNames]
+  );
+
+  return useQueries({ queries });
+};

--- a/src/pages/IntegratedStorage.tsx
+++ b/src/pages/IntegratedStorage.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Typography } from '@mui/material';
-import { useQueries } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import type { ZpoolCapacityEntry, ZpoolDetailEntry } from '../@types/zpool';
@@ -24,7 +23,7 @@ import { type ReplaceDevicePayload, useReplacePoolDisk } from '../hooks/useRepla
 import { useZpool } from '../hooks/useZpool';
 import { useExportPool } from '../hooks/useExportPool';
 import { useImportPool } from '../hooks/useImportPool';
-import { fetchZpoolDetails, zpoolDetailQueryKey } from '../hooks/useZpoolDetails';
+import { usePoolDetailQueries } from '../hooks/usePoolDetailQueries';
 import {
   localizeDetailEntries,
   translateDetailKey,
@@ -351,14 +350,7 @@ const IntegratedStorage = () => {
     return Array.from(ids).slice(0, MAX_COMPARISON_ITEMS);
   }, [activeItemId, pinnedItemIds]);
 
-  const poolDetailQueries = useQueries({
-    queries: poolDetailIds.map((poolName) => ({
-      queryKey: zpoolDetailQueryKey(poolName),
-      queryFn: () => fetchZpoolDetails(poolName),
-      enabled: poolDetailIds.length > 0,
-      refetchInterval: 10000,
-    })),
-  });
+  const poolDetailQueries = usePoolDetailQueries(poolDetailIds);
 
   const selectedPoolDetailItems = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- extract pool detail polling into a dedicated hook with memoized query definitions
- reuse the new hook inside IntegratedStorage to avoid recreating queries and keep polling disabled when no pools are selected

## Testing
- npm run lint *(fails: pre-existing lint warnings/errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69538f227c64832697fedf1b01808662)