### PR TITLE
Add interactive 3D server slots widget to dashboard

### DIFF
--- a/src/components/dashboard/server-3d/ServerBay.tsx
+++ b/src/components/dashboard/server-3d/ServerBay.tsx
@@ -1,5 +1,5 @@
 import { Html, RoundedBox } from '@react-three/drei';
-import { memo, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import type { ServerSlotHealth, ServerSlotViewModel } from './serverSlotModel';
 
 export interface ServerSceneColors {
@@ -62,6 +62,10 @@ const ServerBay = ({
 }: ServerBayProps) => {
   const [hovered, setHovered] = useState(false);
 
+  useEffect(() => () => {
+    document.body.style.cursor = 'default';
+  }, []);
+
   const ledColor = useMemo(
     () => resolveLedColor(bay.health, selected, colors),
     [bay.health, colors, selected]
@@ -104,6 +108,12 @@ const ServerBay = ({
           event.stopPropagation();
           setHovered(false);
           document.body.style.cursor = 'default';
+        }}
+        onPointerDown={(event) => {
+          event.stopPropagation();
+        }}
+        onPointerUp={(event) => {
+          event.stopPropagation();
         }}
       >
         <meshStandardMaterial


### PR DESCRIPTION
### Motivation
- Provide an interactive 3D visualization of the server front panel with four physical disk bays and per-slot disk details inside the dashboard card. 
- Reuse the existing storage data layer (`useZpool`, `usePoolDeviceSlots`, `PoolDiskSlot`, `PoolSlotMap`) and disk detail utilities to avoid new APIs or backend changes. 
- Keep the implementation light-weight (no external GLTF/textures) and consistent with the existing design system and RTL Persian UI.

### Description
- Added a server-3d widget composed of a slot model, 3D chassis scene, bay component, and a disk detail side panel, reusing `createCardSx`, `buildDiskDetailValues`, and `formatDetailValue`. 
- Implemented `serverSlotModel.ts` utilities to normalize, deduplicate and place pool disks into exactly `DEFAULT_SERVER_SLOT_COUNT = 4` `ServerSlotViewModel` items, and exported `resolveServerSlotHealth` and `sortServerSlots`. 
- Implemented `ServerChassisScene.tsx` which renders a `Canvas` with lightweight geometries, `OrbitControls` (zoom disabled, rotation limited) and four `ServerBay` instances placed across the chassis. 
- Implemented `ServerBay.tsx` rendering disk trays, grills, LEDs and a Persian HTML label, with pointer event propagation guards and a `useEffect` safety to reset `document.body.style.cursor`, and implemented `DiskSlotDetailsPanel.tsx` showing empty/select states and up to 8 useful disk detail tiles with a link to `/disks?selected=<diskName>`. 
- Added `ServerSlots3DWidget.tsx` which wires `useZpool` (`refetchInterval: 60000`) and `usePoolDeviceSlots` (`refetchInterval: 10000`) to build slots, render loading/error/empty states, the 3D scene and the responsive side detail panel, and registered the widget in the dashboard widgets list in `src/pages/Dashboard.tsx` with the requested id, Persian title/description and layout options. 

### Testing
- Ran `npm run build` which failed due to pre-existing TypeScript errors outside the widget scope (errors included implicit `any` in `NavigationDrawer.tsx`, missing/incorrect types in `shareService.ts` and other unrelated files, and missing mock imports); build therefore did not complete. 
- Ran `npm run lint` which reported pre-existing ESLint/React refresh errors in other files (for example `AuthContext.tsx`, `ThemeContext.tsx`) so lint did not pass. 
- Confirmed the widget registration and pointer interaction refinements compile locally in the modified widget file, and pointer propagation/cursor reset behavior was implemented to protect UI during interactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f5cbccbfd8832689cd1aba153f56a8)