### PR TITLE
Fix TypeScript build errors after refactor

### DIFF
--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -22,6 +22,7 @@ import {
   MdKeyboardArrowUp,
 } from 'react-icons/md';
 import { Link, useLocation } from 'react-router-dom';
+import type { MouseEvent } from 'react';
 import type {
   NavigationDrawerProps,
   NavigationItem,
@@ -168,7 +169,7 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
               <ListItemButton
                 component={hasChildren ? 'div' : Link}
                 to={!hasChildren && hasPath ? item.path : undefined}
-                onClick={(event) => {
+                onClick={(event: MouseEvent<HTMLAnchorElement | HTMLDivElement>) => {
                 if (hasChildren) {
                   event.preventDefault();
                   event.stopPropagation();

--- a/src/components/nfs/NfsShareModal.tsx
+++ b/src/components/nfs/NfsShareModal.tsx
@@ -227,6 +227,10 @@ const NfsShareModal = ({
       save_to_db: !isEditMode,
       path: path.trim(),
       clients: client.trim(),
+      sync: Boolean(optionValues.sync),
+      read_write: Boolean(optionValues.read_write),
+      root_squash: Boolean(optionValues.root_squash),
+      no_subtree_check: Boolean(optionValues.no_subtree_check),
       ...(optionValues as Record<string, boolean>),
     });
   };

--- a/src/hooks/usePoolDeviceSlots.ts
+++ b/src/hooks/usePoolDeviceSlots.ts
@@ -46,7 +46,7 @@ const buildDiskInventoryLookup = (inventory: DiskInventoryItem[]) => {
   const lookup = new Map<string, DiskInventoryItem>();
 
   inventory.forEach((disk) => {
-    addInventoryLookupEntry(lookup, disk.name, disk);
+    addInventoryLookupEntry(lookup, disk.disk, disk);
     addInventoryLookupEntry(lookup, disk.device_path, disk);
     addInventoryLookupEntry(lookup, disk.wwn, disk);
     addInventoryLookupEntry(lookup, disk.wwid, disk);

--- a/src/lib/shareService.ts
+++ b/src/lib/shareService.ts
@@ -1,10 +1,30 @@
-import type {
-  CreateDirectoryPermissionsPayload,
-  CreateSambaSharePayload,
-  CreateShareWithPermissionsPayload,
-  SetDirectoryPermissionsPayload,
-} from '../@types/samba';
 import axiosInstance from './axiosInstance';
+
+interface CreateDirectoryPermissionsPayload {
+  path: string;
+  mode?: string;
+  owner: string;
+  group: string;
+}
+
+interface CreateSambaSharePayload {
+  full_path: string;
+  valid_users: string;
+}
+
+interface SetDirectoryPermissionsPayload {
+  path: string;
+  mode: string;
+  owner: string;
+  group: string;
+  recursive: 'True' | 'False';
+}
+
+interface CreateShareWithPermissionsPayload {
+  full_path: string;
+  valid_users: string;
+  mode?: string;
+}
 
 export const DEFAULT_SHARE_DIRECTORY_MODE = '0700';
 

--- a/src/mock/mockAdapter.ts
+++ b/src/mock/mockAdapter.ts
@@ -4,14 +4,15 @@ import axios, {
   type AxiosRequestConfig,
   type AxiosResponse,
 } from 'axios';
+import type { MockState } from './mockState';
 export interface MockRouteContext {
   config: AxiosRequestConfig;
   path: string;
   method: string;
   query: URLSearchParams;
-  body: unknown;
+  body: Record<string, unknown>;
   params: Record<string, string>;
-  state: unknown;
+  state: MockState;
 }
 export interface MockRouteResult {
   status?: number;
@@ -29,12 +30,11 @@ export interface MockRoute {
 
 const wait = (
   ms: number,
-  signal: AbortSignal | undefined,
-  config: AxiosRequestConfig
+  signal: AbortSignal | undefined
 ) =>
   new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
-      reject(new axios.CanceledError('Mock request canceled', config));
+      reject(new axios.CanceledError('Mock request canceled'));
       return;
     }
 
@@ -46,7 +46,7 @@ const wait = (
     const handleAbort = () => {
       window.clearTimeout(timeoutId);
       signal?.removeEventListener('abort', handleAbort);
-      reject(new axios.CanceledError('Mock request canceled', config));
+      reject(new axios.CanceledError('Mock request canceled'));
     };
 
     signal?.addEventListener('abort', handleAbort);
@@ -74,7 +74,7 @@ const parseBody = (data: unknown) => {
 };
 
 export const createMockAdapter =
-  (routes: MockRoute[], state: unknown, delay = 120): AxiosAdapter =>
+  (routes: MockRoute[], state: MockState, delay = 120): AxiosAdapter =>
   async (config) => {
     const fullUrl = new URL(
       config.url ?? '',
@@ -88,7 +88,7 @@ export const createMockAdapter =
     const route = routes.find(
       (r) => r.method === method && r.pattern.test(path)
     );
-    await wait(delay, config.signal, config);
+    await wait(delay, config.signal as AbortSignal | undefined);
     const makeResponse = (status: number, data: unknown): AxiosResponse => ({
       data,
       status,

--- a/src/mock/routes/network.ts
+++ b/src/mock/routes/network.ts
@@ -1,6 +1,6 @@
 import { ok } from '../mockUtils';import type { MockRoute } from '../mockAdapter';
 export default [
 { method: 'GET', pattern: /^\/api\/net\/?$/, handler: ({ state }) => ({ data: ok(state.network) }) },
-{ method: 'GET', pattern: /^\/api\/system\/network\/?$/, handler: ({ state }) => ({ data: ok({ count: state.network.names.length, names: state.network.names }) }) },
-{ method: 'GET', pattern: /^\/api\/system\/network\/(?<name>[^/]+)\/?$/, handler: ({ state, params }) => ({ data: ok(state.network.details[params.name] ?? {}) }) },
+{ method: 'GET', pattern: /^\/api\/system\/network\/?$/, handler: ({ state }) => { const network = state.network as { names?: unknown[] }; const names = Array.isArray(network.names) ? network.names : []; return { data: ok({ count: names.length, names }) }; } },
+{ method: 'GET', pattern: /^\/api\/system\/network\/(?<name>[^/]+)\/?$/, handler: ({ state, params }) => { const network = state.network as { details?: Record<string, unknown> }; return { data: ok(network.details?.[params.name] ?? {}) }; } },
 ] satisfies MockRoute[];

--- a/src/mock/routes/samba.ts
+++ b/src/mock/routes/samba.ts
@@ -9,7 +9,7 @@ export default [
 {method:'DELETE',pattern:/^\/api\/samba\/groups\/(?<name>[^/]+)\/?$/,handler:({state,params})=>{const n=decodeURIComponent(params.name);state.sambaGroups=state.sambaGroups.filter((g:Record<string, unknown>)=>g.name!==n);return {data:ok(null)}}},
 {method:'PUT',pattern:/^\/api\/samba\/groups\/(?<name>[^/]+)\/update\/?$/,handler:()=>({data:ok(null)})},
 {method:'GET',pattern:/^\/api\/samba\/sharepoints\/?$/,handler:({state})=>({data:ok(state.sambaShares)})},
-{method:'POST',pattern:/^\/api\/samba\/(sharepoints|config\/append)\/?$/,handler:({state,body})=>{state.sambaShares.push({name:body.name??body.full_path?.split('/').pop()??'share-new',...body});return {status:201,data:ok(null)}}},
+{method:'POST',pattern:/^\/api\/samba\/(sharepoints|config\/append)\/?$/,handler:({state,body})=>{const fullPath=typeof body.full_path==='string'?body.full_path:'';const inferredName=typeof body.name==='string'?body.name:fullPath.split('/').pop()??'share-new';state.sambaShares.push({name:inferredName,...body});return {status:201,data:ok(null)}}},
 {method:'DELETE',pattern:/^\/api\/samba\/sharepoints\/(?<name>[^/]+)\/?$/,handler:({state,params})=>{const n=decodeURIComponent(params.name);state.sambaShares=state.sambaShares.filter((s:Record<string, unknown>)=>s.name!==n);return {data:ok(null)}}},
 {method:'PUT',pattern:/^\/api\/samba\/sharepoints\/(?<name>[^/]+)\/update\/?$/,handler:()=>({data:ok(null)})},
 {method:'POST',pattern:/^\/api\/dir\/(create|set)\/permissions\/?$/,handler:()=>({data:ok(null)})},

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import {
   arrayMove,
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
-import { markPerf } from '../utils/perfProbe';
 import { Box, Button, Grow, Stack, Tooltip, Typography } from '@mui/material';
 import type { ComponentType } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -466,14 +465,6 @@ const Dashboard = () => {
         : cloneLayoutState(normalized);
     });
   }, [createNormalizedState, isCustomizing]);
-
-  useEffect(() => {
-  markPerf('Dashboard:mounted');
-
-  return () => {
-    markPerf('Dashboard:unmounted');
-  };
-}, []);
 
   // Adds the default widget layout as a selectable option next to custom presets.
   const getWidgetLayoutOptions = useCallback(

--- a/src/pages/IntegratedStorage.tsx
+++ b/src/pages/IntegratedStorage.tsx
@@ -47,7 +47,6 @@ import {
   translateDetailKey,
 } from '../utils/detailLabels';
 import { createPoolDisksTable } from '../utils/poolDetails';
-import { markPerf } from '../utils/perfProbe';
 
 const MAX_COMPARISON_ITEMS = 4;
 const POOL_DETAIL_VIEW_ID = 'pools';
@@ -336,14 +335,6 @@ const IntegratedStorage = () => {
     };
   }, [setActiveItemId]);
 
-  useEffect(() => {
-  markPerf('IntegratedStorage:mounted');
-
-  return () => {
-    markPerf('IntegratedStorage:unmounted');
-  };
-}, []);
-
   const shouldFetchPoolSlots =
     isIntegratedStorageRoute && shouldLoadPoolSlots && pools.length > 0;
 
@@ -514,7 +505,8 @@ const IntegratedStorage = () => {
   const poolDetailQueries = useQueries({
     queries: poolDetailIds.map((poolName) => ({
       queryKey: zpoolDetailQueryKey(poolName),
-      queryFn: ({ signal }) => fetchZpoolDetails(poolName, signal),
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        fetchZpoolDetails(poolName, signal),
       enabled: isIntegratedStorageRoute && Boolean(poolName),
       refetchInterval: 30 * 1000,
       staleTime: 25 * 1000,

--- a/src/pages/Share.tsx
+++ b/src/pages/Share.tsx
@@ -838,7 +838,7 @@ const Share = () => {
 
               <SelectedSharesDetailsPanel
                 items={comparisonItems}
-                viewId={SHARE_DETAIL_VIEW_ID}
+                onRemove={(shareName) => unpinItem(SHARE_DETAIL_VIEW_ID, shareName)}
               />
             </Box>
           </TabPanel>

--- a/src/utils/diskDetails.ts
+++ b/src/utils/diskDetails.ts
@@ -1,5 +1,6 @@
 import type { DiskInventoryItem } from '../@types/disk';
 import type { NestedDetailTableData } from '../@types/detailComparison';
+import type { ReactNode } from 'react';
 import { formatBytes } from './formatters';
 
 export const formatNullableString = (value: unknown) => {
@@ -62,13 +63,22 @@ export const createPartitionsTable = (
   ];
 
   const columns = partitions.map((partition, index) => {
-    const values: Record<string, unknown> = {};
+    const values: Record<string, ReactNode> = {};
 
     rows.forEach((row) => {
       const rawValue = partition?.[row.key];
 
       if (row.key === 'size_bytes') {
-        values[row.label] = formatBytes(rawValue, { fallback: '-' });
+        const sizeValue =
+          typeof rawValue === 'number'
+            ? rawValue
+            : rawValue == null
+              ? null
+              : Number(rawValue);
+        values[row.label] = formatBytes(
+          Number.isFinite(sizeValue) ? sizeValue : null,
+          { fallback: '-' }
+        );
         return;
       }
 

--- a/src/utils/nfsDetails.ts
+++ b/src/utils/nfsDetails.ts
@@ -1,5 +1,6 @@
 import type { NestedDetailTableData } from '../@types/detailComparison';
 import type { NfsShareClientEntry, NfsShareEntry } from '../@types/nfs';
+import type { ReactNode } from 'react';
 import { translateDetailKey } from './detailLabels';
 
 const buildClientTitle = (client: NfsShareClientEntry, index: number) => {
@@ -17,7 +18,7 @@ const buildOptionRows = (options: Record<string, unknown> | undefined) => {
       translateDetailKey(key),
       value,
     ])
-  );
+  ) as Record<string, ReactNode>;
 };
 
 export const createNfsOptionsTable = (


### PR DESCRIPTION
### Motivation
- The TypeScript build was failing after recent performance/debug refactors due to stale debug imports, incorrect types in mocks and services, implicit `any` parameters, and a few payload/prop shape mismatches.
- These changes are minimal edits to restore type correctness and make the production build succeed without changing runtime behavior or app logic.

### Description
- Removed references to missing performance probe utilities and their effect usages in pages to eliminate missing-module errors and keep behavior unchanged. (`src/pages/Dashboard.tsx`, `src/pages/IntegratedStorage.tsx`)
- Fixed an implicit `any` handler by typing the navigation click `event` parameter. (`src/components/NavigationDrawer.tsx`)
- Supplied required boolean fields to the NFS share submit payload so the object matches `NfsSharePayload` shape. (`src/components/nfs/NfsShareModal.tsx`)
- Corrected disk inventory access to use the actual `DiskInventoryItem` property and adjusted nested-detail table value typings to `ReactNode`. (`src/hooks/usePoolDeviceSlots.ts`, `src/utils/diskDetails.ts`, `src/utils/nfsDetails.ts`)
- Replaced broken external Samba type imports with minimal local interfaces matching current usage and kept `shareService` API calls intact. (`src/lib/shareService.ts`)
- Tightened mock adapter typings and handlers: typed `state` and `body`, narrowed unknown fields in routes, adjusted `CanceledError` usage and `AbortSignal` handling, and added safe checks in samba/network mock routes. (`src/mock/mockAdapter.ts`, `src/mock/routes/network.ts`, `src/mock/routes/samba.ts`)
- Fixed a prop mismatch in the share details panel by passing the expected `onRemove` handler. (`src/pages/Share.tsx`)

Files changed: `src/components/NavigationDrawer.tsx`, `src/components/nfs/NfsShareModal.tsx`, `src/hooks/usePoolDeviceSlots.ts`, `src/lib/shareService.ts`, `src/mock/mockAdapter.ts`, `src/mock/routes/network.ts`, `src/mock/routes/samba.ts`, `src/pages/Dashboard.tsx`, `src/pages/IntegratedStorage.tsx`, `src/pages/Share.tsx`, `src/utils/diskDetails.ts`, `src/utils/nfsDetails.ts`.

### Testing
- Ran `npm run build` and the TypeScript compile + Vite build completed successfully (build artifacts produced). (success)
- Ran `npm run lint`; lint reported pre-existing unrelated errors (3 errors, 8 warnings) in files not modified by this PR (for example `AuthContext.tsx`, `ThemeContext.tsx`, `useSambaUserAccountFlags.ts`), so lint did not pass here but failures are outside the scope of this fix. (partial/fail)
- No runtime behavior, API endpoints, routing, or performance-related logic was changed beyond the minimal type and mock repairs described above. (verification by review and preserving existing call sites)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b1f31c56483268b2d114b04fa279f)