### PR TITLE
Polish share member panels and add confirm disk‑wipe flow

### DIFF
--- a/src/components/disks/ConfirmWipeDiskModal.tsx
+++ b/src/components/disks/ConfirmWipeDiskModal.tsx
@@ -1,0 +1,56 @@
+import { Box, Typography } from '@mui/material';
+import type { DiskInventoryItem } from '../../@types/disk';
+import BlurModal from '../BlurModal';
+import ModalActionButtons from '../common/ModalActionButtons';
+
+interface ConfirmWipeDiskModalProps {
+  open: boolean;
+  disk: DiskInventoryItem | null;
+  onClose: () => void;
+  onConfirm: () => void;
+  isWiping: boolean;
+}
+
+const ConfirmWipeDiskModal = ({
+  open,
+  disk,
+  onClose,
+  onConfirm,
+  isWiping,
+}: ConfirmWipeDiskModalProps) => {
+  return (
+    <BlurModal
+      open={open}
+      onClose={onClose}
+      title="پاکسازی دیسک"
+      actions={
+        <ModalActionButtons
+          onCancel={onClose}
+          onConfirm={onConfirm}
+          confirmLabel="پاکسازی"
+          loadingLabel="در حال پاکسازی…"
+          isLoading={isWiping}
+          disabled={isWiping}
+          disableConfirmGradient
+          confirmProps={{ color: 'error' }}
+        />
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography sx={{ color: 'var(--color-text)', lineHeight: 1.9 }}>
+          آیا از پاکسازی دیسک{' '}
+          <Typography component="span" sx={{ fontWeight: 700 }}>
+            {disk?.disk}
+          </Typography>{' '}
+          مطمئن هستید؟
+        </Typography>
+        <Typography sx={{ color: 'var(--color-error)', lineHeight: 1.9 }}>
+          با انجام این عملیات، پارتیشن‌ها، امضاها و اطلاعات قابل شناسایی روی این
+          دیسک حذف می‌شوند. این عملیات قابل بازگشت نیست.
+        </Typography>
+      </Box>
+    </BlurModal>
+  );
+};
+
+export default ConfirmWipeDiskModal;

--- a/src/components/disks/DisksTable.tsx
+++ b/src/components/disks/DisksTable.tsx
@@ -203,6 +203,12 @@ const DisksTable = ({
             typeof partitionCount === 'number'
               ? partitionCount === 0
               : disk.has_partition === false;
+          const isActionDisabled =
+            isDisabled ||
+            !onWipe ||
+            isPartitionLoading ||
+            hasNoPartitions ||
+            !hasPartitions;
 
           if (disabledDisks.has(disk.disk) && hasPartitions) {
             return renderStateChip('در حال استفاده', 'error');
@@ -233,15 +239,11 @@ const DisksTable = ({
                 > */}
                 <Chip
                   label={<PiBroomFill size={18} />}
-                  clickable={
-                    isDisabled ||
-                    !onWipe ||
-                    isPartitionLoading ||
-                    hasNoPartitions ||
-                    !hasPartitions
-                  }
+                  clickable={!isActionDisabled}
+                  disabled={isActionDisabled}
                   onClick={(event) => {
                     event.stopPropagation();
+                    if (isActionDisabled) return;
                     onWipe?.(disk);
                   }}
                   color= "error"

--- a/src/components/groups/ManageSambaGroupMembersModal.tsx
+++ b/src/components/groups/ManageSambaGroupMembersModal.tsx
@@ -51,6 +51,29 @@ const chipStyles = {
   },
 } as const;
 
+const memberPanelBaseSx = {
+  flex: 1,
+  width: '100%',
+  minWidth: 0,
+  p: 1.75,
+  borderRadius: '13px',
+  boxShadow: '0 18px 40px -34px rgba(15, 23, 42, 0.35)',
+} as const;
+
+const currentPanelSx = {
+  ...memberPanelBaseSx,
+  border: '1px solid rgba(0, 198, 169, 0.24)',
+  background:
+    'linear-gradient(145deg, var(--color-card-bg) 0%, rgba(0, 198, 169, 0.045) 100%)',
+} as const;
+
+const availablePanelSx = {
+  ...memberPanelBaseSx,
+  border: '1px solid rgba(148, 163, 184, 0.22)',
+  background:
+    'linear-gradient(145deg, var(--color-card-bg) 0%, rgba(148, 163, 184, 0.045) 100%)',
+} as const;
+
 const ManageSambaGroupMembersModal = ({
   open,
   groupname,
@@ -266,27 +289,20 @@ const ManageSambaGroupMembersModal = ({
               onDragOver={(event) => event.preventDefault()}
               onDrop={handleDropToMembers}
               sx={{
-                flex: 1,
-                width: '100%',
-                minWidth: 0,
+                ...currentPanelSx,
                 order: { xs: 1, md: 1 },
-                p: 1.75,
-                borderRadius: '13px',
-                border: '1px solid rgba(31, 182, 255, 0.24)',
-                background:
-                  'linear-gradient(180deg, rgba(31, 182, 255, 0.08), rgba(31, 182, 255, 0.03))',
               }}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, flexWrap: 'wrap' }}>
                 <Typography sx={{ color: 'var(--color-primary)', fontWeight: 900 }}>
                   اعضای فعلی گروه
                 </Typography>
-                <Chip label={`${stagedMembers.length} عضو`} size="small" sx={{ fontWeight: 800, color: 'var(--color-primary)', backgroundColor: 'rgba(31, 182, 255, 0.12)', border: '1px solid rgba(31, 182, 255, 0.24)' }} />
+                <Chip label={`${stagedMembers.length} عضو`} size="small" sx={{ fontWeight: 800, color: 'var(--color-primary)', backgroundColor: 'rgba(0, 198, 169, 0.09)', border: '1px solid rgba(0, 198, 169, 0.22)' }} />
               </Box>
-              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.8rem' }}>
+              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.82rem' }}>
                 اعضای فعال و تاییدشده گروه در این بخش قرار دارند.
               </Typography>
-              <Divider sx={{ borderColor: 'rgba(31, 182, 255, 0.2)' }} />
+              <Divider sx={{ borderColor: 'rgba(0, 198, 169, 0.2)' }} />
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, maxHeight: 260, overflowY: 'auto', alignContent: 'flex-start' }}>
                 {stagedMembers.length ? (
                   stagedMembers.map((member) => (
@@ -295,7 +311,7 @@ const ManageSambaGroupMembersModal = ({
                       label={member}
                       onDelete={() => handleRemoveMember(member)}
                       disabled={isSubmitting}
-                      sx={{ ...chipStyles.remove, color: 'var(--color-text)', backgroundColor: 'rgba(255, 255, 255, 0.72)', border: '1px solid rgba(31, 182, 255, 0.2)', '& .MuiChip-deleteIcon': { color: 'var(--color-error)' } }}
+                      sx={{ ...chipStyles.remove, color: 'var(--color-text)', backgroundColor: 'var(--color-card-bg)', border: '1px solid rgba(0, 198, 169, 0.22)', '& .MuiChip-deleteIcon': { color: 'var(--color-error)' } }}
                       draggable
                       onDragStart={(event) => handleDragStart(event, { member, source: 'members' })}
                     />
@@ -315,27 +331,20 @@ const ManageSambaGroupMembersModal = ({
               onDragOver={(event) => event.preventDefault()}
               onDrop={handleDropToAvailable}
               sx={{
-                flex: 1,
-                width: '100%',
-                minWidth: 0,
+                ...availablePanelSx,
                 order: { xs: 2, md: 2 },
-                p: 1.75,
-                borderRadius: '13px',
-                border: '1px solid rgba(255, 255, 255, 0.5)',
-                background:
-                  'linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.06))',
               }}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, flexWrap: 'wrap' }}>
                 <Typography sx={{ color: 'var(--color-text)', fontWeight: 800 }}>
                   کاربران خارج از گروه
                 </Typography>
-                <Chip label={`${availableCandidates.length} کاربر`} size="small" sx={{ fontWeight: 700 }} />
+                <Chip label={`${availableCandidates.length} کاربر`} size="small" sx={{ fontWeight: 700, border: '1px solid rgba(148, 163, 184, 0.25)' }} />
               </Box>
-              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.8rem' }}>
+              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.82rem' }}>
                 کاربران قابل‌افزودن به گروه در این لیست نمایش داده می‌شوند.
               </Typography>
-              <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.35)' }} />
+              <Divider sx={{ borderColor: 'rgba(148, 163, 184, 0.24)' }} />
               <Box sx={{ display: 'flex', flexWrap: 'nowrap', flexDirection: 'column', gap: 1, alignItems: 'stretch', maxHeight: 260, overflowY: 'auto' }}>
                 {availableCandidates.length ? (
                   availableCandidates.map((candidate) => (

--- a/src/components/share/ManageShareMembersModal.tsx
+++ b/src/components/share/ManageShareMembersModal.tsx
@@ -93,6 +93,29 @@ const membersProperty: Record<ManageShareMembersType, string> = {
   groups: 'valid groups',
 };
 
+const memberPanelBaseSx = {
+  flex: 1,
+  width: '100%',
+  minWidth: 0,
+  p: 1.75,
+  borderRadius: '13px',
+  boxShadow: '0 18px 40px -34px rgba(15, 23, 42, 0.35)',
+} as const;
+
+const currentPanelSx = {
+  ...memberPanelBaseSx,
+  border: '1px solid rgba(0, 198, 169, 0.24)',
+  background:
+    'linear-gradient(145deg, var(--color-card-bg) 0%, rgba(0, 198, 169, 0.045) 100%)',
+} as const;
+
+const availablePanelSx = {
+  ...memberPanelBaseSx,
+  border: '1px solid rgba(148, 163, 184, 0.22)',
+  background:
+    'linear-gradient(145deg, var(--color-card-bg) 0%, rgba(148, 163, 184, 0.045) 100%)',
+} as const;
+
 const ManageShareMembersModal = ({
   open,
   shareName,
@@ -349,15 +372,8 @@ const ManageShareMembersModal = ({
               onDragOver={(event) => event.preventDefault()}
               onDrop={handleDropToMembers}
               sx={{
-                flex: 1,
-                width: '100%',
-                minWidth: 0,
+                ...currentPanelSx,
                 order: { xs: 1, md: 1 },
-                p: 1.75,
-                borderRadius: '13px',
-                border: '1px solid rgba(31, 182, 255, 0.24)',
-                background:
-                  'linear-gradient(180deg, rgba(31, 182, 255, 0.08), rgba(31, 182, 255, 0.03))',
               }}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, flexWrap: 'wrap' }}>
@@ -370,15 +386,15 @@ const ManageShareMembersModal = ({
                   sx={{
                     fontWeight: 800,
                     color: 'var(--color-primary)',
-                    backgroundColor: 'rgba(31, 182, 255, 0.12)',
-                    border: '1px solid rgba(31, 182, 255, 0.24)',
+                    backgroundColor: 'rgba(0, 198, 169, 0.09)',
+                    border: '1px solid rgba(0, 198, 169, 0.22)',
                   }}
                 />
               </Box>
-              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.8rem' }}>
+              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.82rem' }}>
                 {copy.currentHelper}
               </Typography>
-              <Divider sx={{ borderColor: 'rgba(31, 182, 255, 0.2)' }} />
+              <Divider sx={{ borderColor: 'rgba(0, 198, 169, 0.2)' }} />
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, maxHeight: 260, overflowY: 'auto', alignContent: 'flex-start' }}>
                 {hasMembers ? (
                   stagedMembers.map((member) => (
@@ -390,8 +406,8 @@ const ManageShareMembersModal = ({
                       sx={{
                         ...chipStyles.remove,
                         color: 'var(--color-text)',
-                        backgroundColor: 'rgba(255, 255, 255, 0.72)',
-                        border: '1px solid rgba(31, 182, 255, 0.2)',
+                        backgroundColor: 'var(--color-card-bg)',
+                        border: '1px solid rgba(0, 198, 169, 0.22)',
                         '& .MuiChip-deleteIcon': { color: 'var(--color-error)' },
                       }}
                       draggable
@@ -415,27 +431,20 @@ const ManageShareMembersModal = ({
               onDragOver={(event) => event.preventDefault()}
               onDrop={handleDropToAvailable}
               sx={{
-                flex: 1,
-                width: '100%',
-                minWidth: 0,
+                ...availablePanelSx,
                 order: { xs: 2, md: 2 },
-                p: 1.75,
-                borderRadius: '13px',
-                border: '1px solid rgba(255, 255, 255, 0.5)',
-                background:
-                  'linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.06))',
               }}
             >
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, flexWrap: 'wrap' }}>
                 <Typography sx={{ color: 'var(--color-text)', fontWeight: 800 }}>
                   {copy.addLabel}
                 </Typography>
-                <Chip label={`${availableCandidates.length} ${copy.currentUnit}`} size="small" sx={{ fontWeight: 700 }} />
+                <Chip label={`${availableCandidates.length} ${copy.currentUnit}`} size="small" sx={{ fontWeight: 700, border: '1px solid rgba(148, 163, 184, 0.25)' }} />
               </Box>
-              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.8rem' }}>
+              <Typography sx={{ color: 'var(--color-secondary)', fontWeight: 500, fontSize: '0.82rem' }}>
                 {copy.availableHelper}
               </Typography>
-              <Divider sx={{ borderColor: 'rgba(255, 255, 255, 0.35)' }} />
+              <Divider sx={{ borderColor: 'rgba(148, 163, 184, 0.24)' }} />
               <Box sx={{ display: 'flex', flexWrap: 'nowrap', flexDirection: 'column', gap: 1, alignItems: 'stretch', maxHeight: 260, overflowY: 'auto' }}>
                 {availableCandidates.length ? (
                   availableCandidates.map((candidate) => (

--- a/src/lib/diskMaintenance.ts
+++ b/src/lib/diskMaintenance.ts
@@ -6,6 +6,11 @@ export const DEFAULT_CLEAR_DISK_ERROR_MESSAGE =
 export const DEFAULT_WIPE_DISK_ERROR_MESSAGE =
   'امکان پاکسازی دیسک متصل به فضای یکپارچه وجود ندارد.';
 
+export interface CleanupDiskResult {
+  clearZfsSucceeded: boolean;
+  clearZfsError?: string;
+}
+
 export const clearDiskZfs = async (diskName: string) => {
   const encodedDiskName = encodeURIComponent(diskName);
 
@@ -30,7 +35,21 @@ export const wipeDisk = async (diskName: string) => {
   }
 };
 
-export const cleanupDisk = async (diskName: string) => {
-  await clearDiskZfs(diskName);
+export const cleanupDisk = async (
+  diskName: string
+): Promise<CleanupDiskResult> => {
+  let clearZfsError: string | undefined;
+
+  try {
+    await clearDiskZfs(diskName);
+  } catch (error) {
+    clearZfsError = error instanceof Error ? error.message : String(error);
+  }
+
   await wipeDisk(diskName);
+
+  return {
+    clearZfsSucceeded: !clearZfsError,
+    clearZfsError,
+  };
 };

--- a/src/pages/Disks.tsx
+++ b/src/pages/Disks.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { DiskInventoryItem } from '../@types/disk';
 import PageContainer from '../components/PageContainer';
 import DisksTable from '../components/disks/DisksTable';
+import ConfirmWipeDiskModal from '../components/disks/ConfirmWipeDiskModal';
 import SelectedDisksDetailsPanel from '../components/disks/SelectedDisksDetailsPanel';
 import { useDiskDetails, useDiskInventory } from '../hooks/useDiskInventory';
 import usePoolDeviceNames from '../hooks/usePoolDeviceNames';
@@ -17,6 +18,7 @@ const DISK_DETAIL_VIEW_ID = 'disks';
 
 const Disks = () => {
   const [wipingDisks, setWipingDisks] = useState<Record<string, boolean>>({});
+  const [wipeTargetDisk, setWipeTargetDisk] = useState<DiskInventoryItem | null>(null);
   const queryClient = useQueryClient();
   const { data: disks = [], isLoading, error } = useDiskInventory();
   const { activeItemId, pinnedItemIds } = useDetailSplitViewStore(
@@ -78,9 +80,13 @@ const Disks = () => {
     }
   }, [activeItemId, disks, pinnedItemIds, setActiveItemId, unpinItem]);
 
-  const handleWipeDisk = useCallback(
-    async (disk: DiskInventoryItem) => {
-      const diskName = disk.disk;
+  const handleCloseWipeModal = useCallback(() => {
+    setWipeTargetDisk(null);
+  }, []);
+
+  const handleConfirmWipeDisk = useCallback(async () => {
+      if (!wipeTargetDisk) return;
+      const diskName = wipeTargetDisk.disk;
       const toastId = toast.loading(`در حال پاکسازی دیسک ${diskName}...`);
 
       setWipingDisks((prev) => ({ ...prev, [diskName]: true }));
@@ -90,6 +96,7 @@ const Disks = () => {
         toast.success(`دیسک ${diskName} پاکسازی شد.`, { id: toastId });
         queryClient.invalidateQueries({ queryKey: ['disk', 'inventory'] });
         queryClient.invalidateQueries({ queryKey: ['disk', 'partition-count', diskName] });
+        setWipeTargetDisk(null);
       } catch (error) {
         toast.error(
           extractApiErrorMessage(error, 'پاکسازی دیسک با خطا مواجه شد.'),
@@ -103,7 +110,7 @@ const Disks = () => {
         });
       }
     },
-    [queryClient]
+    [queryClient, wipeTargetDisk]
   );
 
   const activeWipingDisks = useMemo(
@@ -132,7 +139,7 @@ const Disks = () => {
             disks={disks}
             isLoading={isLoading}
             error={error ?? null}
-            onWipe={handleWipeDisk}
+            onWipe={setWipeTargetDisk}
             disabledDiskNames={poolDeviceNames}
             wipingDiskNames={activeWipingDisks}
             areActionsLoading={isPoolDevicesLoading}
@@ -150,6 +157,13 @@ const Disks = () => {
           />
         </Box>
       </Stack>
+      <ConfirmWipeDiskModal
+        open={Boolean(wipeTargetDisk)}
+        disk={wipeTargetDisk}
+        onClose={handleCloseWipeModal}
+        onConfirm={handleConfirmWipeDisk}
+        isWiping={Boolean(wipeTargetDisk && wipingDisks[wipeTargetDisk.disk])}
+      />
     </PageContainer>
   );
 };


### PR DESCRIPTION
### Motivation
- Improve visual polish and contrast of the member management panels so light mode looks like calm enterprise cards and headings/chips no longer read as destructive. 
- Make disk cleanup robust: always attempt disk `wipe` even if `clear-zfs` fails, and require an explicit destructive confirmation before running cleanup.

### Description
- Share modals: added local reusable `sx` style helpers (`memberPanelBaseSx`, `currentPanelSx`, `availablePanelSx`) and updated panel/chip/divider/header styles to use `var(--color-card-bg)` surfaces, subtle rgba borders/accents, and stronger typography while preserving all existing add/remove/drag/drop/confirm behavior; changes applied in `src/components/share/ManageShareMembersModal.tsx` and `src/components/groups/ManageSambaGroupMembersModal.tsx`.
- Disk cleanup flow: changed `cleanupDisk` in `src/lib/diskMaintenance.ts` to try `clearDiskZfs` as best-effort, capture any clear error, always call `wipeDisk`, return a `CleanupDiskResult` and only throw when `wipeDisk` fails (so successful wipe resolves even if clear-zfs failed).
- Confirmation modal: added `src/components/disks/ConfirmWipeDiskModal.tsx` implementing a Persian destructive confirmation using `BlurModal` + `ModalActionButtons` with required labels, loading state and destructive styling.
- Page wiring: updated `src/pages/Disks.tsx` to open the confirmation modal when wipe is requested, run `cleanupDisk` only after explicit confirm, close the modal on success and invalidate queries; errors keep current toast behavior.
- Action semantics: fixed the cleanup action chip in `src/components/disks/DisksTable.tsx` by computing `isActionDisabled`, setting `clickable={!isActionDisabled}` and `disabled={isActionDisabled}`, guarding `onClick`, and preserving tooltips/icon/availability rules.
- Files changed: `src/components/share/ManageShareMembersModal.tsx`, `src/components/groups/ManageSambaGroupMembersModal.tsx`, `src/lib/diskMaintenance.ts`, `src/pages/Disks.tsx`, `src/components/disks/DisksTable.tsx`, `src/components/disks/ConfirmWipeDiskModal.tsx`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and reported pre-existing unrelated lint issues in other files; no new lint suppressions or changes were introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c1dddecac832694c773710971584d)