### PR TITLE
Add Web Share (NGINX) API integration

### DIFF
--- a/src/@types/webshare.ts
+++ b/src/@types/webshare.ts
@@ -32,13 +32,13 @@ export interface WebShareEntry {
 export interface WebShareCreatePayload {
   pool_name: string;
   fs_name: string;
-  save_to_db: boolean;
+  save_to_db?: false;
 }
 
 export interface WebShareDeleteParams {
   pool_name: string;
   fs_name: string;
-  save_to_db: boolean;
+  save_to_db?: false;
 }
 
 export interface WebSharePermissionPayload {

--- a/src/hooks/useWebShares.ts
+++ b/src/hooks/useWebShares.ts
@@ -269,7 +269,10 @@ export const useCreateWebShare = () => {
 
   return useMutation<unknown, AxiosError<ApiErrorResponse>, WebShareCreatePayload>({
     mutationFn: async (payload) => {
-      await axiosInstance.post(WEB_SHARE_ENDPOINT, payload);
+      await axiosInstance.post(WEB_SHARE_ENDPOINT, {
+        ...payload,
+        save_to_db: false,
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: webSharesQueryKey });
@@ -282,7 +285,12 @@ export const useDeleteWebShare = () => {
 
   return useMutation<unknown, AxiosError<ApiErrorResponse>, WebShareDeleteParams>({
     mutationFn: async (params) => {
-      await axiosInstance.delete(WEB_SHARE_DELETE_ENDPOINT, { params });
+      await axiosInstance.delete(WEB_SHARE_DELETE_ENDPOINT, {
+        params: {
+          ...params,
+          save_to_db: false,
+        },
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: webSharesQueryKey });


### PR DESCRIPTION
### Motivation
- Expose a typed client and hooks for the new "Web Share"/"NGINX Web Share" API so the UI can list, create, delete and set permissions for web shares.
- Ensure requests respect the API requirement of not persisting changes by sending `save_to_db: false` for create/delete operations.

### Description
- Make the `save_to_db` flag optional-but-fixed to `false` in `WebShareCreatePayload` and `WebShareDeleteParams` by updating `src/@types/webshare.ts` to `save_to_db?: false`.
- Ensure `useCreateWebShare` always sends `save_to_db: false` when calling `POST /api/webshare/` by merging the flag into the request body in `src/hooks/useWebShares.ts`.
- Ensure `useDeleteWebShare` always sends `save_to_db: false` when calling `DELETE /api/webshare/delete/` by adding the flag to the request `params` in `src/hooks/useWebShares.ts`.
- Preserve existing normalization, defensive parsing, error extraction and permission mutation behavior, and continue to invalidate `webSharesQueryKey` after successful mutations in `useWebShares`.

### Testing
- Ran `npm run build`, which completed successfully with the project building and bundling the client assets.
- Ran `npm run lint`, which failed due to pre-existing unrelated lint errors in `src/contexts/AuthContext.tsx`, `src/contexts/ThemeContext.tsx`, and `src/hooks/useSambaUserAccountFlags.ts` while other warnings remained in unrelated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329cb46fc483279b618b5b91419144)