### PR TITLE
Add Web Share route and navigation item

### DIFF
--- a/src/constants/navigationDrawer.ts
+++ b/src/constants/navigationDrawer.ts
@@ -44,6 +44,7 @@ export const navItems: NavigationItem[] = [
     children:[
       {text:"SMB" , icon:createElement(BsFillShareFill), path:"/share"},
       {text:"NFS" , icon:createElement(MdFolderShared), path:"/share-nfs"},
+      {text:"Web Share" , icon:createElement(MdFolderShared), path:"/web-share"},
     ] 
   },
   {

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -14,6 +14,7 @@ import Services from '../pages/Services.tsx';
 import Settings from '../pages/Settings.tsx';
 import Share from '../pages/Share.tsx';
 import ShareNfs from '../pages/ShareNfs.tsx';
+import WebShare from '../pages/WebShare.tsx';
 import SnmpService from '../pages/SnmpService.tsx';
 import Users from '../pages/Users.tsx';
 
@@ -40,9 +41,10 @@ const router = createBrowserRouter([
       { path: 'users', element: <Users /> },
       { path: 'settings', element: <Settings /> },
       { path: 'share', element: <Share /> },
+      { path: 'share-nfs', element: <ShareNfs /> },
+      { path: 'web-share', element: <WebShare /> },
       { path: 'history', element: <History /> },
       { path: 'snmp-service', element: <SnmpService /> },
-      { path: 'share-nfs', element: <ShareNfs /> },
       { path: '*', element: <NotFoundPage /> },
     ],
   },


### PR DESCRIPTION
### Motivation
- Expose the new Web Share page in the app navigation so it is accessible alongside the existing SMB and NFS share pages under the `اشتراک گذاری` submenu.

### Description
- Imported `WebShare` in `src/routes/Routes.tsx` and added the protected child route `{ path: 'web-share', element: <WebShare /> }` near the existing `share` and `share-nfs` routes.
- Added a new navigation item under the `اشتراک گذاری` submenu in `src/constants/navigationDrawer.ts` with `text: "Web Share"`, `path: "/web-share"`, and re-used the existing `MdFolderShared` icon.
- Preserved existing SMB (`/share`) and NFS (`/share-nfs`) entries and did not modify other routes, layout, auth, theme, or page files.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` which exited non-zero because lint reported `3` errors and `8` warnings originating from unrelated files (`src/contexts/AuthContext.tsx`, `src/contexts/ThemeContext.tsx`, `src/hooks/useSambaUserAccountFlags.ts`), so lint failures are pre-existing and outside the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a329fb21c4c8327b5ce1bf7de72e508)