### PR TITLE
Polish Web Share page to use DataTable and BlurModal

### DIFF
--- a/src/components/webshare/WebSharesTable.tsx
+++ b/src/components/webshare/WebSharesTable.tsx
@@ -1,0 +1,199 @@
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useMemo } from 'react';
+import { MdDeleteOutline, MdLockReset } from 'react-icons/md';
+import type { DataTableColumn } from '../../@types/dataTable';
+import type { WebShareEntry } from '../../@types/webshare';
+import DataTable from '../DataTable';
+
+interface WebSharesTableProps {
+  detailViewId: string;
+  shares: WebShareEntry[];
+  isLoading: boolean;
+  error: Error | null;
+  onDelete: (share: WebShareEntry) => void;
+  onPermission: (share: WebShareEntry) => void;
+  pendingShareId?: string | null;
+  isMutating?: boolean;
+}
+
+const WebSharesTable = ({
+  detailViewId,
+  shares,
+  isLoading,
+  error,
+  onDelete,
+  onPermission,
+  pendingShareId = null,
+  isMutating = false,
+}: WebSharesTableProps) => {
+  const columns = useMemo<DataTableColumn<WebShareEntry>[]>(
+    () => [
+      {
+        id: 'index',
+        header: '#',
+        align: 'center',
+        width: 60,
+        renderCell: (_share, index) => (
+          <Typography sx={{ fontWeight: 600, color: 'var(--color-text)' }}>
+            {index + 1}
+          </Typography>
+        ),
+      },
+      {
+        id: 'targetName',
+        header: 'نام Web Share',
+        align: 'center',
+        renderCell: (share) => (
+          <Typography sx={{ color: 'var(--color-text)', fontWeight: 600 }}>
+            {share.targetName}
+          </Typography>
+        ),
+      },
+      {
+        id: 'poolName',
+        header: 'Pool',
+        align: 'center',
+        renderCell: (share) => (
+          <Typography sx={{ color: 'var(--color-text)' }}>{share.poolName}</Typography>
+        ),
+      },
+      {
+        id: 'fsName',
+        header: 'FileSystem',
+        align: 'center',
+        renderCell: (share) => (
+          <Typography sx={{ color: 'var(--color-text)' }}>{share.fsName}</Typography>
+        ),
+      },
+      {
+        id: 'path',
+        header: 'مسیر/Location',
+        align: 'center',
+        renderCell: (share) => (
+          <Typography
+            sx={{
+              color: 'var(--color-text)',
+              direction: 'ltr',
+              fontFamily: 'var(--font-vazir)',
+              wordBreak: 'break-all',
+            }}
+          >
+            {share.path}
+          </Typography>
+        ),
+      },
+      {
+        id: 'permission',
+        header: 'Permission',
+        align: 'center',
+        renderCell: (share) =>
+          share.permission ? (
+            <Chip
+              label={share.permission}
+              size="small"
+              sx={{
+                fontWeight: 700,
+                color: 'var(--color-primary)',
+                backgroundColor: 'rgba(0, 198, 169, 0.12)',
+              }}
+            />
+          ) : (
+            <Typography sx={{ color: 'var(--color-secondary)' }}>—</Typography>
+          ),
+      },
+      {
+        id: 'actions',
+        header: 'عملیات',
+        align: 'center',
+        width: 90,
+        renderCell: (share) => {
+          const isShareMutating = isMutating && pendingShareId === share.id;
+
+          return (
+            <Stack direction="row" spacing={0.5} justifyContent="center">
+              <Tooltip title="تغییر Permission">
+                <span>
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onPermission(share);
+                    }}
+                    disabled={isShareMutating}
+                  >
+                    <MdLockReset size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title="حذف Web Share">
+                <span>
+                  <IconButton
+                    size="small"
+                    color="error"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDelete(share);
+                    }}
+                    disabled={isShareMutating}
+                  >
+                    <MdDeleteOutline size={18} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Stack>
+          );
+        },
+      },
+    ],
+    [isMutating, onDelete, onPermission, pendingShareId]
+  );
+
+  return (
+    <DataTable<WebShareEntry>
+      detailViewId={detailViewId}
+      columns={columns}
+      data={shares}
+      getRowId={(share) => share.id}
+      isLoading={isLoading}
+      error={error}
+      bodyRowSx={{ transition: 'background-color 0.2s ease' }}
+      renderLoadingState={() => (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            alignItems: 'center',
+            py: 4,
+          }}
+        >
+          <CircularProgress color="primary" size={32} />
+          <Typography sx={{ color: 'var(--color-secondary)' }}>
+            در حال دریافت Web Shareها...
+          </Typography>
+        </Box>
+      )}
+      renderErrorState={(tableError) => (
+        <Typography sx={{ color: 'var(--color-error)', py: 3 }}>
+          خطا در دریافت Web Shareها: {tableError.message}
+        </Typography>
+      )}
+      renderEmptyState={() => (
+        <Typography sx={{ color: 'var(--color-secondary)', py: 3 }}>
+          Web Share فعالی ثبت نشده است.
+        </Typography>
+      )}
+    />
+  );
+};
+
+export default WebSharesTable;

--- a/src/pages/WebShare.tsx
+++ b/src/pages/WebShare.tsx
@@ -2,25 +2,12 @@ import {
   Alert,
   Box,
   Button,
-  Card,
-  CardContent,
-  CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   FormControl,
   FormHelperText,
   InputLabel,
   MenuItem,
   Select,
   Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   TextField,
   Typography,
 } from '@mui/material';
@@ -29,7 +16,10 @@ import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import type { FileSystemEntry } from '../@types/filesystem';
 import type { WebShareEntry } from '../@types/webshare';
+import BlurModal from '../components/BlurModal';
+import ModalActionButtons from '../components/common/ModalActionButtons';
 import PageContainer from '../components/PageContainer';
+import WebSharesTable from '../components/webshare/WebSharesTable';
 import { useFileSystems } from '../hooks/useFileSystems';
 import {
   extractWebShareErrorMessage,
@@ -39,6 +29,7 @@ import {
   useWebShares,
 } from '../hooks/useWebShares';
 
+const WEB_SHARE_DETAIL_VIEW_ID = 'web-shares';
 const permissionPattern = /^[0-7]{3,4}$/;
 
 const createFilesystemKey = (poolName: string, fsName: string) =>
@@ -126,7 +117,9 @@ const WebShare = () => {
           toast.success('Web Share با موفقیت ایجاد شد.');
         },
         onError: (error) => {
-          toast.error(`ایجاد Web Share با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`);
+          toast.error(
+            `ایجاد Web Share با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`
+          );
         },
       }
     );
@@ -168,7 +161,9 @@ const WebShare = () => {
           toast.success('Permission با موفقیت به‌روزرسانی شد.');
         },
         onError: (error) => {
-          toast.error(`تغییر Permission با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`);
+          toast.error(
+            `تغییر Permission با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`
+          );
         },
       }
     );
@@ -198,7 +193,9 @@ const WebShare = () => {
           toast.success('Web Share با موفقیت حذف شد.');
         },
         onError: (error) => {
-          toast.error(`حذف Web Share با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`);
+          toast.error(
+            `حذف Web Share با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`
+          );
         },
       }
     );
@@ -209,38 +206,39 @@ const WebShare = () => {
 
   const isPermissionInvalid =
     permissionValue.length > 0 && !permissionPattern.test(permissionValue);
+  const pendingShareId = permissionShare?.id ?? deleteShare?.id ?? null;
+  const isMutating = setWebSharePermission.isPending || deleteWebShare.isPending;
 
   return (
     <PageContainer>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: -5 }}>
         <Box
           sx={{
             display: 'flex',
-            alignItems: 'flex-start',
+            alignItems: 'center',
             justifyContent: 'space-between',
             gap: 2,
             flexWrap: 'wrap',
           }}
         >
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <Typography
-              variant="h5"
-              sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
-            >
-              اشتراک‌های Web Share
-            </Typography>
-            <Typography variant="body2" sx={{ color: 'var(--color-text)' }}>
-              مدیریت Location Blockهای NGINX برای فایل‌سیستم‌ها و مسیرهای قابل
-              ارائه از طریق وب.
-            </Typography>
-          </Box>
+          <Typography
+            variant="h5"
+            sx={{ color: 'var(--color-primary)', fontWeight: 700 }}
+          >
+            اشتراک‌های Web Share
+          </Typography>
 
           <Stack direction="row" spacing={1.5} useFlexGap flexWrap="wrap">
             <Button
               onClick={() => void refetchWebShares()}
               variant="outlined"
               disabled={isWebSharesFetching}
-              sx={{ borderColor: 'var(--color-primary)', color: 'var(--color-primary)' }}
+              sx={{
+                borderColor: 'var(--color-primary)',
+                color: 'var(--color-primary)',
+                borderRadius: '3px',
+                fontWeight: 700,
+              }}
             >
               به‌روزرسانی لیست
             </Button>
@@ -253,220 +251,136 @@ const WebShare = () => {
                 py: 1.25,
                 borderRadius: '3px',
                 fontWeight: 700,
+                fontSize: '0.95rem',
                 background:
                   'linear-gradient(135deg, var(--color-primary) 0%, rgba(31, 182, 255, 0.95) 100%)',
                 color: 'var(--color-bg)',
+                boxShadow: '0 16px 32px -18px rgba(31, 182, 255, 0.85)',
               }}
             >
               ایجاد Web Share
             </Button>
           </Stack>
         </Box>
-
-        <Card sx={{ backgroundColor: 'var(--color-card-bg)', color: 'var(--color-text)' }}>
-          <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <Typography variant="overline" sx={{ color: 'var(--color-primary)' }}>
-              خلاصه
-            </Typography>
-            <Typography variant="h4" sx={{ fontWeight: 800 }}>
-              {webShares.length}
-            </Typography>
-            <Typography variant="body2">
-              API این صفحه Web Shareها را به‌صورت Location Blockهای NGINX برای
-              فایل‌سیستم‌ها مدیریت می‌کند و ایجاد/حذف این رکوردها با
-              save_to_db=false ارسال می‌شود.
-            </Typography>
-          </CardContent>
-        </Card>
-
-        {webSharesError ? (
-          <Alert severity="error">دریافت لیست Web Shareها با خطا مواجه شد.</Alert>
-        ) : null}
-
-        {filesystemsError ? (
-          <Alert severity="warning">
-            دریافت لیست فایل‌سیستم‌ها با خطا مواجه شد؛ ایجاد Web Share ممکن است
-            در دسترس نباشد.
-          </Alert>
-        ) : null}
-
-        <TableContainer
-          sx={{
-            backgroundColor: 'var(--color-card-bg)',
-            borderRadius: 2,
-            border: '1px solid rgba(148, 163, 184, 0.18)',
-          }}
-        >
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>نام Web Share</TableCell>
-                <TableCell>Pool</TableCell>
-                <TableCell>FileSystem</TableCell>
-                <TableCell>مسیر/Location</TableCell>
-                <TableCell>Permission</TableCell>
-                <TableCell align="center">عملیات</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {isWebSharesLoading ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center">
-                    <CircularProgress size={28} />
-                  </TableCell>
-                </TableRow>
-              ) : webShares.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center">
-                    هیچ Web Shareای وجود ندارد.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                webShares.map((share) => (
-                  <TableRow key={share.id} hover>
-                    <TableCell>{share.targetName}</TableCell>
-                    <TableCell>{share.poolName}</TableCell>
-                    <TableCell>{share.fsName}</TableCell>
-                    <TableCell sx={{ direction: 'ltr', textAlign: 'left' }}>
-                      {share.path}
-                    </TableCell>
-                    <TableCell>{share.permission ?? '—'}</TableCell>
-                    <TableCell align="center">
-                      <Stack direction="row" spacing={1} justifyContent="center">
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          onClick={() => openPermissionDialog(share)}
-                          disabled={setWebSharePermission.isPending}
-                        >
-                          Permission
-                        </Button>
-                        <Button
-                          size="small"
-                          color="error"
-                          variant="outlined"
-                          onClick={() => setDeleteShare(share)}
-                          disabled={deleteWebShare.isPending}
-                        >
-                          حذف
-                        </Button>
-                      </Stack>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
       </Box>
 
-      <Dialog open={isCreateOpen} onClose={closeCreateDialog} fullWidth maxWidth="sm">
-        <DialogTitle>ایجاد Web Share</DialogTitle>
-        <DialogContent sx={{ pt: 2 }}>
-          <FormControl fullWidth disabled={isFilesystemsLoading || createWebShare.isPending}>
-            <InputLabel id="webshare-filesystem-label">FileSystem</InputLabel>
-            <Select
-              labelId="webshare-filesystem-label"
-              label="FileSystem"
-              value={selectedFilesystemKey}
-              onChange={(event: SelectChangeEvent) =>
-                setSelectedFilesystemKey(event.target.value)
-              }
-            >
-              {availableFilesystems.map((filesystem) => {
-                const key = createFilesystemKey(
-                  filesystem.poolName,
-                  filesystem.filesystemName
-                );
-                return (
-                  <MenuItem key={key} value={key}>
-                    {renderFilesystemLabel(filesystem)}
-                  </MenuItem>
-                );
-              })}
-            </Select>
-            <FormHelperText>
-              {availableFilesystems.length === 0
-                ? 'همه فایل‌سیستم‌های موجود Web Share دارند یا لیست در دسترس نیست.'
-                : 'فایل‌سیستم‌های دارای Web Share تکراری نمایش داده نمی‌شوند.'}
-            </FormHelperText>
-          </FormControl>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeCreateDialog} disabled={createWebShare.isPending}>
-            انصراف
-          </Button>
-          <Button
-            onClick={handleCreateSubmit}
-            variant="contained"
-            disabled={!selectedFilesystem || createWebShare.isPending}
-          >
-            ایجاد
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {filesystemsError ? (
+        <Alert severity="warning" sx={{ mt: 3 }}>
+          دریافت لیست فایل‌سیستم‌ها با خطا مواجه شد؛ ایجاد Web Share ممکن است در
+          دسترس نباشد.
+        </Alert>
+      ) : null}
 
-      <Dialog
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, mt: 3 }}>
+        <WebSharesTable
+          detailViewId={WEB_SHARE_DETAIL_VIEW_ID}
+          shares={webShares}
+          isLoading={isWebSharesLoading}
+          error={webSharesError ?? null}
+          onDelete={setDeleteShare}
+          onPermission={openPermissionDialog}
+          pendingShareId={pendingShareId}
+          isMutating={isMutating}
+        />
+      </Box>
+
+      <BlurModal
+        open={isCreateOpen}
+        onClose={closeCreateDialog}
+        title="ایجاد Web Share"
+        maxWidth="560px"
+        actions={
+          <ModalActionButtons
+            onCancel={closeCreateDialog}
+            onConfirm={handleCreateSubmit}
+            confirmLabel="ایجاد"
+            disabled={!selectedFilesystem || createWebShare.isPending}
+            isLoading={createWebShare.isPending}
+          />
+        }
+      >
+        <FormControl fullWidth disabled={isFilesystemsLoading || createWebShare.isPending}>
+          <InputLabel id="webshare-filesystem-label">FileSystem</InputLabel>
+          <Select
+            labelId="webshare-filesystem-label"
+            label="FileSystem"
+            value={selectedFilesystemKey}
+            onChange={(event: SelectChangeEvent) =>
+              setSelectedFilesystemKey(event.target.value)
+            }
+          >
+            {availableFilesystems.map((filesystem) => {
+              const key = createFilesystemKey(
+                filesystem.poolName,
+                filesystem.filesystemName
+              );
+              return (
+                <MenuItem key={key} value={key}>
+                  {renderFilesystemLabel(filesystem)}
+                </MenuItem>
+              );
+            })}
+          </Select>
+          <FormHelperText>
+            {availableFilesystems.length === 0
+              ? 'همه فایل‌سیستم‌های موجود Web Share دارند یا لیست در دسترس نیست.'
+              : 'فایل‌سیستم‌های دارای Web Share تکراری نمایش داده نمی‌شوند.'}
+          </FormHelperText>
+        </FormControl>
+      </BlurModal>
+
+      <BlurModal
         open={Boolean(permissionShare)}
         onClose={closePermissionDialog}
-        fullWidth
-        maxWidth="xs"
-      >
-        <DialogTitle>تغییر Permission</DialogTitle>
-        <DialogContent sx={{ pt: 2 }}>
-          <TextField
-            fullWidth
-            label="Permission"
-            value={permissionValue}
-            error={isPermissionInvalid}
-            helperText="نمونه معتبر: 755 یا 0755"
-            onChange={(event) => setPermissionValue(event.target.value.trim())}
-            disabled={setWebSharePermission.isPending}
-            inputProps={{ inputMode: 'numeric', dir: 'ltr' }}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={closePermissionDialog}
-            disabled={setWebSharePermission.isPending}
-          >
-            انصراف
-          </Button>
-          <Button
-            onClick={handlePermissionSubmit}
-            variant="contained"
+        title="تغییر Permission"
+        maxWidth="420px"
+        actions={
+          <ModalActionButtons
+            onCancel={closePermissionDialog}
+            onConfirm={handlePermissionSubmit}
+            confirmLabel="ذخیره"
             disabled={
               !permissionPattern.test(permissionValue) ||
               setWebSharePermission.isPending
             }
-          >
-            ذخیره
-          </Button>
-        </DialogActions>
-      </Dialog>
+            isLoading={setWebSharePermission.isPending}
+          />
+        }
+      >
+        <TextField
+          fullWidth
+          label="Permission"
+          value={permissionValue}
+          error={isPermissionInvalid}
+          helperText="نمونه معتبر: 755 یا 0755"
+          onChange={(event) => setPermissionValue(event.target.value.trim())}
+          disabled={setWebSharePermission.isPending}
+          inputProps={{ inputMode: 'numeric', dir: 'ltr' }}
+        />
+      </BlurModal>
 
-      <Dialog open={Boolean(deleteShare)} onClose={closeDeleteDialog} fullWidth maxWidth="xs">
-        <DialogTitle>حذف Web Share</DialogTitle>
-        <DialogContent>
-          <Typography sx={{ color: 'var(--color-text)' }}>
-            آیا از حذف Web Share برای {deleteShare?.poolName}/{deleteShare?.fsName}
-            مطمئن هستید؟
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeDeleteDialog} disabled={deleteWebShare.isPending}>
-            انصراف
-          </Button>
-          <Button
-            onClick={handleDeleteSubmit}
-            color="error"
-            variant="contained"
+      <BlurModal
+        open={Boolean(deleteShare)}
+        onClose={closeDeleteDialog}
+        title="حذف Web Share"
+        maxWidth="420px"
+        actions={
+          <ModalActionButtons
+            onCancel={closeDeleteDialog}
+            onConfirm={handleDeleteSubmit}
+            confirmLabel="حذف"
             disabled={deleteWebShare.isPending}
-          >
-            حذف
-          </Button>
-        </DialogActions>
-      </Dialog>
+            isLoading={deleteWebShare.isPending}
+            disableConfirmGradient
+            confirmProps={{ color: 'error', variant: 'contained' }}
+          />
+        }
+      >
+        <Typography sx={{ color: 'var(--color-text)' }}>
+          آیا از حذف Web Share برای {deleteShare?.poolName}/{deleteShare?.fsName}{' '}
+          مطمئن هستید؟
+        </Typography>
+      </BlurModal>
     </PageContainer>
   );
 };


### PR DESCRIPTION
### Motivation
- Unify the Web Share page UI/structure with existing table pages (NFS/SMB) by removing ad-hoc Card/Table/Dialog usage and using shared components and patterns. 
- Remove the unwanted summary card and the subtitle under the page title while preserving existing business logic and RTL/Persian styling.

### Description
- Replaced raw MUI table/card/dialog in `src/pages/WebShare.tsx` with a header that matches `ShareNfs.tsx`, the `WebSharesTable` DataTable, and `BlurModal` + `ModalActionButtons` for create/permission/delete flows while keeping the NFS-like gradient create button. 
- Added `src/components/webshare/WebSharesTable.tsx` which implements a `DataTableColumn<WebShareEntry>[]` table using `DataTable`, shows permission as a `Chip` (or `—` when missing), renders path with `direction: 'ltr'` and `wordBreak: 'break-all'`, and provides icon-only action buttons (`MdLockReset`, `MdDeleteOutline`) that stop event propagation. 
- Preserved all business logic and API behavior: duplicate prevention via `${poolName}_${fsName}`, create/delete payloads include `{ pool_name, fs_name, save_to_db: false }`, permission payload `{ pool_name, fs_name, permission }`, permission regex `/^[0-7]{3,4}$/`, default permission `755`, and existing toast success/error behavior. 
- Removed the summary/stat Card and the extra subtitle under `اشتراک‌های Web Share` and eliminated imports of raw MUI `Card`, `CardContent`, table components, and dialog components from the page. 
- Did not change SMB/NFS behavior, routes, `useWebShares` API, or `src/@types/webshare.ts`.

### Testing
- Ran scoped ESLint: `npx eslint src/pages/WebShare.tsx src/components/webshare/WebSharesTable.tsx` — succeeded with no reported issues. 
- Ran build: `npm run build` — failed due to unrelated existing TypeScript errors in NFS code and not changes made here; errors are: `src/components/nfs/NfsShareModal.tsx(28,1): error TS6133: 'useNfsShareDetails' is declared but its value is never read.` and `src/components/nfs/NfsShareModal.tsx(100,10): error TS6133: 'hasAdjustedOptions' is declared but its value is never read.`

Files changed:
- `src/pages/WebShare.tsx` (refactor to use DataTable + BlurModal + ModalActionButtons, removed summary/subtitle and raw table/dialog)
- `src/components/webshare/WebSharesTable.tsx` (new DataTable-backed component)

Compact diff summary:
- `src/pages/WebShare.tsx`: removed Card/CardContent/summary, removed raw MUI table and Dialog usage, added imports for `WebSharesTable`, `BlurModal`, and `ModalActionButtons`, reworked header and modal flows, preserved all hook interactions and payloads.
- `src/components/webshare/WebSharesTable.tsx`: new file implementing the requested columns, Persian loading/error/empty states, permission chip display, LTR path styling, and icon actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3637694a7c8327bfa771dbfc08bb9c)