### PR TITLE
Fix WebShare links & auto-777, NFS toggle, IntegratedStorage refresh and modal UX

### DIFF
--- a/src/components/file-system/CreateFileSystemModal.tsx
+++ b/src/components/file-system/CreateFileSystemModal.tsx
@@ -1,5 +1,7 @@
 ﻿import {
   Box,
+  Checkbox,
+  IconButton,
   FormControl,
   FormHelperText,
   InputLabel,
@@ -12,7 +14,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import type { ChangeEvent, FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { FiAlertCircle, FiCheckCircle } from 'react-icons/fi';
+import { FiAlertCircle, FiCheckCircle, FiEye, FiEyeOff } from 'react-icons/fi';
 import type { FileSystemEntry } from '../../@types/filesystem';
 import type { UseCreateFileSystemReturn } from '../../hooks/useCreateFileSystem';
 import { removePersianCharacters } from '../../utils/text';
@@ -68,11 +70,19 @@ const CreateFileSystemModal = ({
   } = controller;
   const [hasPersianName, setHasPersianName] = useState(false);
   const [hasPersianQuota, setHasPersianQuota] = useState(false);
+  const [isEncryptionEnabled, setIsEncryptionEnabled] = useState(false);
+  const [encryptionPassword, setEncryptionPassword] = useState('');
+  const [isEncryptionTouched, setIsEncryptionTouched] = useState(false);
+  const [showEncryptionPassword, setShowEncryptionPassword] = useState(false);
 
   useEffect(() => {
     if (!isOpen) {
       setHasPersianName(false);
       setHasPersianQuota(false);
+      setIsEncryptionEnabled(false);
+      setEncryptionPassword('');
+      setIsEncryptionTouched(false);
+      setShowEncryptionPassword(false);
     }
   }, [isOpen]);
 
@@ -97,6 +107,10 @@ const CreateFileSystemModal = ({
 
     const timeoutId = window.setTimeout(() => {
       setHasPersianQuota(false);
+      setIsEncryptionEnabled(false);
+      setEncryptionPassword('');
+      setIsEncryptionTouched(false);
+      setShowEncryptionPassword(false);
     }, 3000);
 
     return () => {
@@ -190,7 +204,28 @@ const CreateFileSystemModal = ({
       <FiCheckCircle color="var(--color-success)" size={18} />
     ) : null;
 
+  const encryptionRules = [
+    { label: 'وارد کردن رمز عبور', met: encryptionPassword.length > 0 },
+    { label: 'حداقل ۸ کاراکتر', met: encryptionPassword.length >= 8 },
+    { label: 'حداقل یک حرف انگلیسی', met: /[A-Za-z]/.test(encryptionPassword) },
+    {
+      label: 'حداقل یک عدد یا نماد',
+      met: /[0-9]|[^A-Za-z0-9؀-ۿ\s]/.test(encryptionPassword),
+    },
+    {
+      label: 'رمز نباید فقط فارسی باشد',
+      met: encryptionPassword.length === 0 || /[A-Za-z0-9]|[^؀-ۿ\s]/.test(encryptionPassword),
+    },
+  ];
+  const isEncryptionPasswordValid = encryptionRules.every((rule) => rule.met);
+
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (isEncryptionEnabled && !isEncryptionPasswordValid) {
+      event.preventDefault();
+      setIsEncryptionTouched(true);
+      return;
+    }
+
     if (!hasOnlyEnglishAlphanumeric && trimmedName.length > 0) {
       event.preventDefault();
       setNameError('نام فضای فایلی باید فقط شامل حروف انگلیسی و اعداد باشد.');
@@ -229,7 +264,7 @@ const CreateFileSystemModal = ({
           confirmLabel="ایجاد"
           loadingLabel="در حال ایجاد…"
           isLoading={isCreating}
-          disabled={isCreating}
+          disabled={isCreating || (isEncryptionEnabled && !isEncryptionPasswordValid)}
           confirmProps={{
             type: 'submit',
             form: 'create-filesystem-form',
@@ -392,6 +427,85 @@ const CreateFileSystemModal = ({
                 <MenuItem value="T">ترابایت</MenuItem>
               </Select>
             </FormControl>
+          </Box>
+
+
+          <Box
+            sx={{
+              border: '1px solid var(--color-input-border)',
+              borderRadius: '8px',
+              p: 2,
+              backgroundColor: 'rgba(31, 182, 255, 0.04)',
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Checkbox
+                checked={isEncryptionEnabled}
+                onChange={(event) => {
+                  setIsEncryptionEnabled(event.target.checked);
+                  setIsEncryptionTouched(false);
+                  if (!event.target.checked) {
+                    setEncryptionPassword('');
+                    setShowEncryptionPassword(false);
+                  }
+                }}
+                sx={{
+                  color: 'var(--color-secondary)',
+                  '&.Mui-checked': { color: 'var(--color-primary)' },
+                }}
+              />
+              <Typography sx={{ color: 'var(--color-text)', fontWeight: 700 }}>
+                رمز نگاری
+              </Typography>
+            </Box>
+
+            {isEncryptionEnabled && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 1.5 }}>
+                <TextField
+                  label="رمز رمزنگاری"
+                  value={encryptionPassword}
+                  onChange={(event) => setEncryptionPassword(event.target.value)}
+                  onBlur={() => setIsEncryptionTouched(true)}
+                  type={showEncryptionPassword ? 'text' : 'password'}
+                  fullWidth
+                  size="small"
+                  error={isEncryptionTouched && !isEncryptionPasswordValid}
+                  helperText="این گزینه فعلاً فقط برای تجربه کاربری است و به API ارسال نمی‌شود."
+                  InputProps={{
+                    sx: inputBaseStyles,
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          size="small"
+                          onClick={() => setShowEncryptionPassword((value) => !value)}
+                          edge="end"
+                        >
+                          {showEncryptionPassword ? <FiEyeOff /> : <FiEye />}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                <Box sx={{ display: 'grid', gap: 0.75 }}>
+                  {encryptionRules.map((rule) => {
+                    const color = rule.met
+                      ? 'var(--color-success)'
+                      : isEncryptionTouched
+                        ? 'var(--color-error)'
+                        : 'var(--color-secondary)';
+
+                    return (
+                      <Box key={rule.label} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                        <FiCheckCircle color={color} size={16} />
+                        <Typography variant="caption" sx={{ color }}>
+                          {rule.label}
+                        </Typography>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </Box>
+            )}
           </Box>
 
           {apiError && (

--- a/src/components/integrated-storage/CreatePoolModal.tsx
+++ b/src/components/integrated-storage/CreatePoolModal.tsx
@@ -1,4 +1,7 @@
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Checkbox,
   FormControl,
@@ -17,7 +20,7 @@ import {
 import type { SelectChangeEvent } from '@mui/material/Select';
 import type { ChangeEvent, FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { FiAlertCircle, FiCheckCircle } from 'react-icons/fi';
+import { FiAlertCircle, FiCheckCircle, FiChevronDown } from 'react-icons/fi';
 import type { UseCreatePoolReturn, VdevType } from '../../hooks/useCreatePool';
 import { removePersianCharacters } from '../../utils/text';
 import BlurModal from '../BlurModal';
@@ -282,6 +285,42 @@ const CreatePoolModal = ({
               <FormHelperText>{vdevTypeError}</FormHelperText>
             )}
           </FormControl>
+
+
+          <Accordion
+            disableGutters
+            sx={{
+              backgroundColor: 'rgba(31, 182, 255, 0.06)',
+              border: '1px solid rgba(31, 182, 255, 0.22)',
+              borderRadius: '8px !important',
+              boxShadow: 'none',
+              color: 'var(--color-text)',
+              '&::before': { display: 'none' },
+            }}
+          >
+            <AccordionSummary expandIcon={<FiChevronDown color="var(--color-primary)" />}>
+              <Typography sx={{ color: 'var(--color-primary)', fontWeight: 700 }}>
+                راهنمای سازگاری تعداد دیسک‌ها
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 0 }}>
+              <Typography sx={{ color: 'var(--color-secondary)', mb: 1 }}>
+                تعداد دیسک‌ها باید با نوع آرایه دیسک سازگار باشد:
+              </Typography>
+              {[
+                ['STRIP', 'هر چند دیسکی'],
+                ['MIRROR', 'حداقل ۲ دیسک (تعداد زوج)'],
+                ['RAID5', 'حداقل ۳ دیسک'],
+              ].map(([type, rule]) => (
+                <Typography key={type} sx={{ color: 'var(--color-text)', mb: 0.5 }}>
+                  <Box component="span" sx={{ color: 'var(--color-primary)', fontWeight: 800, ml: 0.75 }}>
+                    {type}:
+                  </Box>
+                  {rule}
+                </Typography>
+              ))}
+            </AccordionDetails>
+          </Accordion>
 
           <FormControl component="fieldset" error={Boolean(devicesError)}>
             <Typography

--- a/src/components/nfs/NfsShareModal.tsx
+++ b/src/components/nfs/NfsShareModal.tsx
@@ -25,7 +25,6 @@ import IPv4AddressInput from '../common/IPv4AddressInput';
 import ModalActionButtons from '../common/ModalActionButtons';
 import { useServiceAction } from '../../hooks/useServiceAction';
 import { toast } from 'react-hot-toast';
-import { useNfsShareDetails } from '../../hooks/useNfsShareDetails';
 
 const DISPLAY_OPTIONS = NFS_OPTION_KEYS.filter(
   (key) => key !== 'root_squash' && key !== 'no_subtree_check'
@@ -97,7 +96,6 @@ const NfsShareModal = ({
   const [client, setClient] = useState('');
   const [optionValues, setOptionValues] = useState(NFS_OPTION_DEFAULTS);
   const [formError, setFormError] = useState<string | null>(null);
-  const [hasAdjustedOptions, setHasAdjustedOptions] = useState(false);
 
   const isEditMode = mode === 'edit';
 
@@ -115,13 +113,11 @@ const NfsShareModal = ({
       setPathInput(initialPath);
       setClient(initialClient);
       setOptionValues(resolveOptionValues(initialOptions));
-      setHasAdjustedOptions(true);
     } else {
       setPath('');
       setPathInput('');
       setClient('');
       setOptionValues({ ...NFS_OPTION_DEFAULTS });
-      setHasAdjustedOptions(false);
     }
 
     setFormError(null);
@@ -148,11 +144,10 @@ const NfsShareModal = ({
     setPathInput(nextValue);
   };
 
-  const handleToggleOption = (key: NfsShareOptionKey) => {
-    setHasAdjustedOptions(true);
+  const handleToggleOption = (key: NfsShareOptionKey, checked: boolean) => {
     setOptionValues((prev) => ({
       ...prev,
-      [key]: !prev[key],
+      [key]: checked,
     }));
   };
 
@@ -198,7 +193,7 @@ const NfsShareModal = ({
       ...optionValues,
     };
 
-    onSubmit(basePayload as NfsSharePayload);
+    onSubmit(basePayload);
   };
 
   const isConfirmDisabled =
@@ -314,7 +309,7 @@ const NfsShareModal = ({
                   <ToggleBtn
                     id={`nfs-option-${optionKey}`}
                     checked={optionValues[optionKey]}
-                    onChange={() => handleToggleOption(optionKey)}
+                    onChange={(checked) => handleToggleOption(optionKey, checked)}
                   />
                   <Typography
                     variant="caption"

--- a/src/components/share/CreateShareModal.tsx
+++ b/src/components/share/CreateShareModal.tsx
@@ -336,9 +336,16 @@ const CreateShareModal = ({ controller }: CreateShareModalProps) => {
                 error={hasPathError}
                 helperText={pathHelperText}
                 InputLabelProps={{ ...params.InputLabelProps, shrink: true }}
+                inputProps={{
+                  ...params.inputProps,
+                  dir: 'ltr',
+                }}
                 InputProps={{
                   ...params.InputProps,
-                  sx: inputBaseStyles,
+                  sx: {
+                    ...inputBaseStyles,
+                    '& .MuiInputBase-input': { textAlign: 'left' },
+                  },
                   endAdornment: (
                     <Fragment>
                       {pathValidationAdornment}
@@ -383,6 +390,10 @@ const CreateShareModal = ({ controller }: CreateShareModalProps) => {
                 helperText={validUsersHelperText}
                 size="small"
                 InputLabelProps={{ ...params.InputLabelProps, shrink: true }}
+                inputProps={{
+                  ...params.inputProps,
+                  dir: 'ltr',
+                }}
                 InputProps={{
                   ...params.InputProps,
                   sx: inputBaseStyles,
@@ -422,6 +433,10 @@ const CreateShareModal = ({ controller }: CreateShareModalProps) => {
                 helperText={validGroupsHelperText}
                 size="small"
                 InputLabelProps={{ ...params.InputLabelProps, shrink: true }}
+                inputProps={{
+                  ...params.inputProps,
+                  dir: 'ltr',
+                }}
                 InputProps={{
                   ...params.InputProps,
                   sx: inputBaseStyles,

--- a/src/components/webshare/WebSharesTable.tsx
+++ b/src/components/webshare/WebSharesTable.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Chip,
   CircularProgress,
   IconButton,
   Stack,
@@ -8,7 +7,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useMemo } from 'react';
-import { MdDeleteOutline, MdLockReset } from 'react-icons/md';
+import { MdDeleteOutline } from 'react-icons/md';
 import type { DataTableColumn } from '../../@types/dataTable';
 import type { WebShareEntry } from '../../@types/webshare';
 import DataTable from '../DataTable';
@@ -19,7 +18,7 @@ interface WebSharesTableProps {
   isLoading: boolean;
   error: Error | null;
   onDelete: (share: WebShareEntry) => void;
-  onPermission: (share: WebShareEntry) => void;
+  host: string;
   pendingShareId?: string | null;
   isMutating?: boolean;
 }
@@ -30,7 +29,7 @@ const WebSharesTable = ({
   isLoading,
   error,
   onDelete,
-  onPermission,
+  host,
   pendingShareId = null,
   isMutating = false,
 }: WebSharesTableProps) => {
@@ -91,23 +90,38 @@ const WebSharesTable = ({
         ),
       },
       {
-        id: 'permission',
-        header: 'Permission',
+        id: 'links',
+        header: 'لینک ها',
         align: 'center',
-        renderCell: (share) =>
-          share.permission ? (
-            <Chip
-              label={share.permission}
-              size="small"
-              sx={{
-                fontWeight: 700,
-                color: 'var(--color-primary)',
-                backgroundColor: 'rgba(0, 198, 169, 0.12)',
-              }}
-            />
-          ) : (
-            <Typography sx={{ color: 'var(--color-secondary)' }}>—</Typography>
-          ),
+        renderCell: (share) => {
+          const link = `http://${host}/${share.poolName}/${share.targetName}/`;
+
+          return (
+            <Tooltip title={link}>
+              <Typography
+                component="a"
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(event) => event.stopPropagation()}
+                sx={{
+                  color: 'var(--color-primary)',
+                  direction: 'ltr',
+                  display: 'inline-block',
+                  fontWeight: 700,
+                  maxWidth: 260,
+                  overflow: 'hidden',
+                  textDecoration: 'none',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {link}
+              </Typography>
+            </Tooltip>
+          );
+        },
       },
       {
         id: 'actions',
@@ -119,21 +133,6 @@ const WebSharesTable = ({
 
           return (
             <Stack direction="row" spacing={0.5} justifyContent="center">
-              <Tooltip title="تغییر Permission">
-                <span>
-                  <IconButton
-                    size="small"
-                    color="primary"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onPermission(share);
-                    }}
-                    disabled={isShareMutating}
-                  >
-                    <MdLockReset size={18} />
-                  </IconButton>
-                </span>
-              </Tooltip>
               <Tooltip title="حذف Web Share">
                 <span>
                   <IconButton
@@ -154,7 +153,7 @@ const WebSharesTable = ({
         },
       },
     ],
-    [isMutating, onDelete, onPermission, pendingShareId]
+    [host, isMutating, onDelete, pendingShareId]
   );
 
   return (

--- a/src/hooks/useCreateNfsShare.ts
+++ b/src/hooks/useCreateNfsShare.ts
@@ -56,8 +56,7 @@ export const useCreateNfsShare = ({
 
   return useMutation<unknown, AxiosError<ApiErrorResponse>, NfsSharePayload>({
     mutationFn: async (payload) => {
-      // Map frontend option to exactly match backend YML specs
-      const { no_subtree_check, ...rest } = payload as any;
+      const { no_subtree_check, ...rest } = payload;
       const apiPayload = {
         ...rest,
         subtree_check: no_subtree_check === undefined ? false : !no_subtree_check,

--- a/src/hooks/usePoolDeviceSlots.ts
+++ b/src/hooks/usePoolDeviceSlots.ts
@@ -272,12 +272,15 @@ interface UsePoolDeviceSlotsOptions {
   refetchInterval?: number;
 }
 
+export const poolDeviceSlotsQueryKey = (poolNames: string[]) =>
+  ['zpool', 'devices', 'slots', poolNames.join(',')] as const;
+
 export const usePoolDeviceSlots = (
   poolNames: string[],
   options?: UsePoolDeviceSlotsOptions
 ) =>
   useQuery<PoolDeviceSlotsResult, Error>({
-    queryKey: ['zpool', 'devices', 'slots', poolNames.join(',')],
+    queryKey: poolDeviceSlotsQueryKey(poolNames),
     queryFn: ({ signal }) => fetchPoolDeviceSlots(poolNames, signal),
     enabled: (options?.enabled ?? true) && poolNames.length > 0,
     refetchInterval: options?.refetchInterval ?? 30000,

--- a/src/hooks/useUpdateNfsShare.ts
+++ b/src/hooks/useUpdateNfsShare.ts
@@ -56,8 +56,7 @@ export const useUpdateNfsShare = ({
 
   return useMutation<unknown, AxiosError<ApiErrorResponse>, NfsSharePayload>({
     mutationFn: async (payload) => {
-      // Map frontend option to exactly match backend YML specs
-      const { no_subtree_check, ...rest } = payload as any;
+      const { no_subtree_check, ...rest } = payload;
       const apiPayload = {
         ...rest,
         subtree_check: no_subtree_check === undefined ? false : !no_subtree_check,

--- a/src/hooks/useZpool.ts
+++ b/src/hooks/useZpool.ts
@@ -246,6 +246,7 @@ const fetchZpools = async (
 ): Promise<ZpoolQueryResult> => {
   const { data: listResponse } =
     await axiosInstance.get<ZpoolListResponse>(ZPOOL_LIST_ENDPOINT, {
+      params: { save_to_db: true },
       signal,
     });
 
@@ -288,7 +289,7 @@ export const useZpool = (options?: UseZpoolOptions) => {
     queryKey: zpoolQueryKey,
     queryFn: ({ signal }) => fetchZpools(signal),
     enabled: options?.enabled ?? true,
-    refetchInterval: options?.refetchInterval ?? 1 * 60 * 1000,
+    refetchInterval: options?.refetchInterval ?? 30 * 1000,
     retry: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,

--- a/src/hooks/useZpoolDetails.ts
+++ b/src/hooks/useZpoolDetails.ts
@@ -14,6 +14,7 @@ export const fetchZpoolDetails = async (
 ): Promise<ZpoolDetailEntry | null> => {
   const endpoint = `/api/zpool/${encodeURIComponent(poolName)}/`;
   const { data } = await axiosInstance.get<ZpoolDetailResponse>(endpoint, {
+    params: { save_to_db: true },
     signal,
   });
 

--- a/src/pages/IntegratedStorage.tsx
+++ b/src/pages/IntegratedStorage.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Tooltip, Typography } from '@mui/material';
-import { useQueries } from '@tanstack/react-query';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
 import {
   lazy,
   Suspense,
@@ -33,7 +33,7 @@ import {
   type ReplaceDevicePayload,
   useReplacePoolDisk,
 } from '../hooks/useReplacePoolDisk';
-import { useZpool } from '../hooks/useZpool';
+import { useZpool, zpoolQueryKey } from '../hooks/useZpool';
 import {
   fetchZpoolDetails,
   zpoolDetailQueryKey,
@@ -226,13 +226,35 @@ const mapPartitionedDisksToDeviceOptions = (
 
 const IntegratedStorage = () => {
   const location = useLocation();
+  const queryClient = useQueryClient();
 
   const isIntegratedStorageRoute =
     location.pathname.toLowerCase() === '/integrated-space';
 
+  const refreshIntegratedStorageData = useCallback(
+    async (poolName?: string) => {
+      if (!isIntegratedStorageRoute) {
+        return;
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: zpoolQueryKey }),
+        poolName
+          ? queryClient.invalidateQueries({
+              queryKey: zpoolDetailQueryKey(poolName),
+            })
+          : Promise.resolve(),
+        queryClient.invalidateQueries({ queryKey: ['zpool', 'devices'] }),
+        queryClient.invalidateQueries({ queryKey: ['disk', 'partitioned'] }),
+      ]);
+    },
+    [isIntegratedStorageRoute, queryClient]
+  );
+
   const createPool = useCreatePool({
     onSuccess: (poolName) => {
       toast.success(`فضای یکپارچه ${poolName} با موفقیت ایجاد شد.`);
+      void refreshIntegratedStorageData(poolName);
     },
     onError: (errorMessage: string) => {
       toast.error(`ایجاد فضای یکپارچه با خطا مواجه شد: ${errorMessage}`);
@@ -242,6 +264,7 @@ const IntegratedStorage = () => {
   const poolDeletion = useDeleteZpool({
     onSuccess: (poolName) => {
       toast.success(`فضای یکپارچه ${poolName} با موفقیت حذف شد.`);
+      void refreshIntegratedStorageData(poolName);
     },
     onError: (error, poolName) => {
       if (error.message.includes('shareConfiguration')) {
@@ -259,6 +282,7 @@ const IntegratedStorage = () => {
   const poolExport = useExportPool({
     onSuccess: (poolName) => {
       toast.success(`آزادسازی فضای یکپارچه ${poolName} با موفقیت انجام شد.`);
+      void refreshIntegratedStorageData(poolName);
     },
     onError: (error, poolName) => {
       toast.error(
@@ -270,6 +294,7 @@ const IntegratedStorage = () => {
   const poolImport = useImportPool({
     onSuccess: (poolName) => {
       toast.success(`فراخوانی فضای یکپارچه ${poolName} با موفقیت انجام شد.`);
+      void refreshIntegratedStorageData(poolName);
     },
     onError: (error, poolName) => {
       toast.error(
@@ -284,7 +309,7 @@ const IntegratedStorage = () => {
     error: zpoolError,
   } = useZpool({
     enabled: isIntegratedStorageRoute,
-    refetchInterval: 1 * 60 * 1000,
+    refetchInterval: 30 * 1000,
   });
 
   const [replacePoolName, setReplacePoolName] = useState<string | null>(null);
@@ -344,7 +369,7 @@ const IntegratedStorage = () => {
     refetch: refetchPoolSlots,
   } = usePoolDeviceSlots(poolNames, {
     enabled: shouldFetchPoolSlots,
-    refetchInterval: shouldFetchPoolSlots ? 60 * 1000 : undefined,
+    refetchInterval: shouldFetchPoolSlots ? 30 * 1000 : undefined,
   });
 
   const handleLoadPoolSlots = useCallback(() => {
@@ -367,7 +392,8 @@ const IntegratedStorage = () => {
   const addPoolDevices = useAddPoolDevices({
     onSuccess: (poolName) => {
       toast.success(`افزودن دیسک به ${poolName} ثبت شد.`);
-      refetchPoolSlots();
+      void refreshIntegratedStorageData(poolName);
+      void refetchPoolSlots();
     },
     onError: (message, poolName) => {
       toast.error(`افزودن دیسک به ${poolName} با خطا مواجه شد: ${message}`);
@@ -411,7 +437,8 @@ const IntegratedStorage = () => {
   const replaceDisk = useReplacePoolDisk({
     onSuccess: (poolName) => {
       toast.success(`جایگزینی دیسک برای فضای ${poolName} ثبت شد.`);
-      refetchPoolSlots();
+      void refreshIntegratedStorageData(poolName);
+      void refetchPoolSlots();
       setReplacePoolName(null);
     },
     onError: (message, poolName) => {
@@ -500,7 +527,6 @@ const IntegratedStorage = () => {
 
     return Array.from(ids).slice(0, MAX_COMPARISON_ITEMS);
   }, [activeItemId, isIntegratedStorageRoute, pinnedItemIds]);
-
   // Fetches details for each visible comparison item and refreshes them independently.
   const poolDetailQueries = useQueries({
     queries: poolDetailIds.map((poolName) => ({

--- a/src/pages/WebShare.tsx
+++ b/src/pages/WebShare.tsx
@@ -8,7 +8,6 @@ import {
   MenuItem,
   Select,
   Stack,
-  TextField,
   Typography,
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
@@ -30,18 +29,12 @@ import {
 } from '../hooks/useWebShares';
 
 const WEB_SHARE_DETAIL_VIEW_ID = 'web-shares';
-const permissionPattern = /^[0-7]{3,4}$/;
-
 const createFilesystemKey = (poolName: string, fsName: string) =>
   `${poolName}_${fsName}`;
 
 const WebShare = () => {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [selectedFilesystemKey, setSelectedFilesystemKey] = useState('');
-  const [permissionShare, setPermissionShare] = useState<WebShareEntry | null>(
-    null
-  );
-  const [permissionValue, setPermissionValue] = useState('755');
   const [deleteShare, setDeleteShare] = useState<WebShareEntry | null>(null);
 
   const {
@@ -91,7 +84,7 @@ const WebShare = () => {
   const deleteWebShare = useDeleteWebShare();
 
   const closeCreateDialog = () => {
-    if (createWebShare.isPending) {
+    if (createWebShare.isPending || setWebSharePermission.isPending) {
       return;
     }
     setIsCreateOpen(false);
@@ -112,57 +105,29 @@ const WebShare = () => {
       },
       {
         onSuccess: () => {
-          setIsCreateOpen(false);
-          setSelectedFilesystemKey('');
-          toast.success('Web Share با موفقیت ایجاد شد.');
+          setWebSharePermission.mutate(
+            {
+              pool_name: selectedFilesystem.poolName,
+              fs_name: selectedFilesystem.filesystemName,
+              permission: '777',
+            },
+            {
+              onSuccess: () => {
+                setIsCreateOpen(false);
+                setSelectedFilesystemKey('');
+                toast.success('Web Share با دسترسی 777 با موفقیت ایجاد شد.');
+              },
+              onError: (error) => {
+                toast.error(
+                  `اشتراک ایجاد شد اما تنظیم دسترسی 777 با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`
+                );
+              },
+            }
+          );
         },
         onError: (error) => {
           toast.error(
             `ایجاد Web Share با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`
-          );
-        },
-      }
-    );
-  };
-
-  const openPermissionDialog = (share: WebShareEntry) => {
-    setPermissionShare(share);
-    setPermissionValue(share.permission ?? '755');
-  };
-
-  const closePermissionDialog = () => {
-    if (setWebSharePermission.isPending) {
-      return;
-    }
-    setPermissionShare(null);
-    setPermissionValue('755');
-  };
-
-  const handlePermissionSubmit = () => {
-    if (!permissionShare) {
-      return;
-    }
-
-    if (!permissionPattern.test(permissionValue)) {
-      toast.error('Permission باید یک عدد سه یا چهار رقمی در مبنای هشت باشد.');
-      return;
-    }
-
-    setWebSharePermission.mutate(
-      {
-        pool_name: permissionShare.poolName,
-        fs_name: permissionShare.fsName,
-        permission: permissionValue,
-      },
-      {
-        onSuccess: () => {
-          setPermissionShare(null);
-          setPermissionValue('755');
-          toast.success('Permission با موفقیت به‌روزرسانی شد.');
-        },
-        onError: (error) => {
-          toast.error(
-            `تغییر Permission با خطا مواجه شد: ${extractWebShareErrorMessage(error)}`
           );
         },
       }
@@ -204,10 +169,10 @@ const WebShare = () => {
   const renderFilesystemLabel = (filesystem: FileSystemEntry) =>
     `${filesystem.poolName}/${filesystem.filesystemName}`;
 
-  const isPermissionInvalid =
-    permissionValue.length > 0 && !permissionPattern.test(permissionValue);
-  const pendingShareId = permissionShare?.id ?? deleteShare?.id ?? null;
-  const isMutating = setWebSharePermission.isPending || deleteWebShare.isPending;
+  const pendingShareId = deleteShare?.id ?? null;
+  const isMutating = deleteWebShare.isPending;
+  const webShareHost = window.location.hostname;
+  const isCreateMutating = createWebShare.isPending || setWebSharePermission.isPending;
 
   return (
     <PageContainer>
@@ -245,7 +210,7 @@ const WebShare = () => {
             <Button
               onClick={() => setIsCreateOpen(true)}
               variant="contained"
-              disabled={createWebShare.isPending}
+              disabled={isCreateMutating}
               sx={{
                 px: 3,
                 py: 1.25,
@@ -278,7 +243,7 @@ const WebShare = () => {
           isLoading={isWebSharesLoading}
           error={webSharesError ?? null}
           onDelete={setDeleteShare}
-          onPermission={openPermissionDialog}
+          host={webShareHost}
           pendingShareId={pendingShareId}
           isMutating={isMutating}
         />
@@ -294,12 +259,12 @@ const WebShare = () => {
             onCancel={closeCreateDialog}
             onConfirm={handleCreateSubmit}
             confirmLabel="ایجاد"
-            disabled={!selectedFilesystem || createWebShare.isPending}
-            isLoading={createWebShare.isPending}
+            disabled={!selectedFilesystem || isCreateMutating}
+            isLoading={isCreateMutating}
           />
         }
       >
-        <FormControl fullWidth disabled={isFilesystemsLoading || createWebShare.isPending}>
+        <FormControl fullWidth disabled={isFilesystemsLoading || isCreateMutating}>
           <InputLabel id="webshare-filesystem-label">FileSystem</InputLabel>
           <Select
             labelId="webshare-filesystem-label"
@@ -327,36 +292,6 @@ const WebShare = () => {
               : 'فایل‌سیستم‌های دارای Web Share تکراری نمایش داده نمی‌شوند.'}
           </FormHelperText>
         </FormControl>
-      </BlurModal>
-
-      <BlurModal
-        open={Boolean(permissionShare)}
-        onClose={closePermissionDialog}
-        title="تغییر Permission"
-        maxWidth="420px"
-        actions={
-          <ModalActionButtons
-            onCancel={closePermissionDialog}
-            onConfirm={handlePermissionSubmit}
-            confirmLabel="ذخیره"
-            disabled={
-              !permissionPattern.test(permissionValue) ||
-              setWebSharePermission.isPending
-            }
-            isLoading={setWebSharePermission.isPending}
-          />
-        }
-      >
-        <TextField
-          fullWidth
-          label="Permission"
-          value={permissionValue}
-          error={isPermissionInvalid}
-          helperText="نمونه معتبر: 755 یا 0755"
-          onChange={(event) => setPermissionValue(event.target.value.trim())}
-          disabled={setWebSharePermission.isPending}
-          inputProps={{ inputMode: 'numeric', dir: 'ltr' }}
-        />
       </BlurModal>
 
       <BlurModal


### PR DESCRIPTION
### Motivation
- Remove the manual Permission workflow from WebShare and provide direct clickable HTTP links for Web Shares while ensuring a newly created Web Share gets permission `777` automatically behind the scenes.
- Fix unreliable NFS `read_write` toggle so UI toggles immediately and the correct boolean is sent to the API.
- Keep Integrated-space data fresh and ensure immediate refetch after pool/disk operations while reducing periodic polling to 30s.
- Add UX improvements requested for modals: a UI-only encryption password in Create FileSystem, an expandable disk-array helper in Create Pool, and LTR left-alignment for the SMB full-path input.

### Description
- Replaced the `Permission` column and manual permission button in `src/components/webshare/WebSharesTable.tsx` with a `لینک ها` column that renders `http://{window.location.hostname}/{poolName}/{targetName}/` as an LTR clickable link that opens in a new tab (`target="_blank" rel="noopener noreferrer"`) and removed the lock/reset action; the table component now accepts a `host` prop.
- Updated `src/pages/WebShare.tsx` to automatically call `useSetWebSharePermission` with permission `"777"` after a successful `useCreateWebShare` mutation, show success/error toasts as requested, close/clear the modal on success, and disable the create button while create or permission mutation is pending; removed the manual permission modal/state from this page.
- Fixed NFS toggle behavior in `src/components/nfs/NfsShareModal.tsx` to use the `checked` value from `ToggleBtn` and write the checked boolean to option state, and removed casting `payload as any` in `src/hooks/useCreateNfsShare.ts` and `src/hooks/useUpdateNfsShare.ts` while preserving conversion of `no_subtree_check` → `subtree_check` for the API.
- Improved Integrated-space freshness in `src/hooks/useZpool.ts` and `src/hooks/useZpoolDetails.ts` by adding `save_to_db=true` to zpool API calls and lowering `refetchInterval` to 30s; added invalidation/refetch logic in `src/pages/IntegratedStorage.tsx` to immediately refresh zpool list, details and device/partition queries after pool create/delete/export/import/add/replace/property operations and adjusted pool-slot polling to 30s; exported a device-slots query key from `src/hooks/usePoolDeviceSlots.ts` for use in invalidation.
- Added a UI-only encryption checkbox + password input with a checklist validator and show/hide toggle to `src/components/file-system/CreateFileSystemModal.tsx` that does not affect API payloads and resets on modal close.
- Added an expandable disk-array compatibility helper (accordion) in `src/components/integrated-storage/CreatePoolModal.tsx` with highlighted STRIP/MIRROR/RAID5 rules, placed near vdev selection.
- Left-aligned the SMB "مسیر کامل" field in `src/components/share/CreateShareModal.tsx` by setting `inputProps={{ dir: 'ltr' }}` and input sx to left-align text.
- Other small cleanups: removed unused imports (e.g., `Chip`, `MdLockReset`) and eliminated a few `any` casts in NFS hooks; kept all API calls via existing `axiosInstance` and preserved existing API payload shapes.
- Files changed: src/components/webshare/WebSharesTable.tsx, src/pages/WebShare.tsx, src/components/nfs/NfsShareModal.tsx, src/hooks/useCreateNfsShare.ts, src/hooks/useUpdateNfsShare.ts, src/hooks/usePoolDeviceSlots.ts, src/hooks/useZpool.ts, src/hooks/useZpoolDetails.ts, src/pages/IntegratedStorage.tsx, src/components/file-system/CreateFileSystemModal.tsx, src/components/integrated-storage/CreatePoolModal.tsx, src/components/share/CreateShareModal.tsx.

### Testing
- Ran `npm run build` and the TypeScript build + Vite production build completed successfully.
- Ran `npm run lint` (project-wide) which failed due to pre-existing unrelated lint errors in files not changed by this PR, specifically: `src/contexts/AuthContext.tsx` and `src/contexts/ThemeContext.tsx` (rule `react-refresh/only-export-components`), `src/hooks/useDeleteFileSystem.ts` and `src/hooks/useFileSystems.ts` (existing `@typescript-eslint/no-explicit-any` uses), `src/hooks/useSambaUserAccountFlags.ts` (existing `no-useless-escape`), plus other unrelated warnings; these are pre-existing and outside the scope of this change.
- Ran targeted ESLint/TS checks on the modified files (the set of changed files listed above) and they passed lint/type checks.
- Summary: build succeeded; full repo lint failed for unrelated pre-existing issues; changed files are TypeScript- and lint-clean.

If you want, I can prepare a smaller follow-up PR to address the unrelated lint errors, but that is kept out of this change to respect the requirement to avoid modifying unrelated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37dbaa92308327bc0ef367bb092b92)