### PR TITLE
Add importable pools import flow and storage name validation

### DIFF
--- a/src/components/file-system/CreateFileSystemModal.tsx
+++ b/src/components/file-system/CreateFileSystemModal.tsx
@@ -1,4 +1,4 @@
-﻿import {
+import {
   Box,
   Checkbox,
   IconButton,
@@ -107,10 +107,6 @@ const CreateFileSystemModal = ({
 
     const timeoutId = window.setTimeout(() => {
       setHasPersianQuota(false);
-      setIsEncryptionEnabled(false);
-      setEncryptionPassword('');
-      setIsEncryptionTouched(false);
-      setShowEncryptionPassword(false);
     }, 3000);
 
     return () => {
@@ -184,12 +180,12 @@ const CreateFileSystemModal = ({
     trimmedPool.length > 0 &&
     trimmedName.length > 0 &&
     trimmedName.toLowerCase() === normalizedPool;
-  const hasOnlyEnglishAlphanumeric =
-    trimmedName.length === 0 || /^[A-Za-z0-9]+$/.test(trimmedName);
-  const startsWithNumber =
-    trimmedName.length > 0 && /^[0-9]/.test(trimmedName);
+  const hasValidEnglishStorageName =
+    trimmedName.length === 0 || /^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmedName);
+  const startsWithInvalidCharacter =
+    trimmedName.length > 0 && /^[0-9_-]/.test(trimmedName);
   const isNameFormatValid =
-    trimmedName.length === 0 || (hasOnlyEnglishAlphanumeric && !startsWithNumber);
+    trimmedName.length === 0 || (hasValidEnglishStorageName && !startsWithInvalidCharacter);
   const shouldShowSuccess =
     trimmedPool.length > 0 &&
     trimmedName.length > 0 &&
@@ -226,15 +222,15 @@ const CreateFileSystemModal = ({
       return;
     }
 
-    if (!hasOnlyEnglishAlphanumeric && trimmedName.length > 0) {
+    if (!hasValidEnglishStorageName && trimmedName.length > 0) {
       event.preventDefault();
-      setNameError('نام فضای فایلی باید فقط شامل حروف انگلیسی و اعداد باشد.');
+      setNameError('نام فضای فایلی باید فقط شامل حروف انگلیسی، اعداد، خط تیره (-) و زیرخط (_) باشد و با حرف انگلیسی شروع شود.');
       return;
     }
 
-    if (startsWithNumber) {
+    if (startsWithInvalidCharacter) {
       event.preventDefault();
-      setNameError('نام فضای فایلی نمی‌تواند با عدد شروع شود.');
+      setNameError('نام فضای فایلی باید با حرف انگلیسی شروع شود.');
       return;
     }
 
@@ -341,8 +337,8 @@ const CreateFileSystemModal = ({
             placeholder="نامی یکتا برای فضای فایلی وارد کنید."
             error={
               Boolean(nameError) ||
-              (!hasOnlyEnglishAlphanumeric && trimmedName.length > 0) ||
-              startsWithNumber ||
+              (!hasValidEnglishStorageName && trimmedName.length > 0) ||
+              startsWithInvalidCharacter ||
               isDuplicate ||
               isSameAsPool ||
               hasPersianName
@@ -351,11 +347,11 @@ const CreateFileSystemModal = ({
               (hasPersianName &&
                 'استفاده از حروف فارسی در این فیلد مجاز نیست.') ||
               nameError ||
-              (!hasOnlyEnglishAlphanumeric &&
+              (!hasValidEnglishStorageName &&
                 trimmedName.length > 0 &&
-                'نام فضای فایلی باید فقط شامل حروف انگلیسی و اعداد باشد.') ||
-              (startsWithNumber &&
-                'نام فضای فایلی نمی‌تواند با عدد شروع شود.') ||
+                'نام فضای فایلی باید فقط شامل حروف انگلیسی، اعداد، خط تیره (-) و زیرخط (_) باشد و با حرف انگلیسی شروع شود.') ||
+              (startsWithInvalidCharacter &&
+                'نام فضای فایلی باید با حرف انگلیسی شروع شود.') ||
               (isDuplicate &&
                 'فضای فایلی با این نام در این فضای یکپارچه وجود دارد.') ||
               (isSameAsPool &&

--- a/src/components/integrated-storage/CreatePoolModal.tsx
+++ b/src/components/integrated-storage/CreatePoolModal.tsx
@@ -122,12 +122,12 @@ const CreatePoolModal = ({
   const isDuplicate =
     trimmedPoolName.length > 0 &&
     normalizedExistingNames.includes(normalizedPoolName);
-  const hasOnlyEnglishAlphanumeric =
-    trimmedPoolName.length === 0 || /^[A-Za-z0-9]+$/.test(trimmedPoolName);
-  const startsWithNumber =
-    trimmedPoolName.length > 0 && /^[0-9]/.test(trimmedPoolName);
+  const hasValidEnglishStorageName =
+    trimmedPoolName.length === 0 || /^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmedPoolName);
+  const startsWithInvalidCharacter =
+    trimmedPoolName.length > 0 && /^[0-9_-]/.test(trimmedPoolName);
   const isNameFormatValid =
-    trimmedPoolName.length === 0 || (hasOnlyEnglishAlphanumeric && !startsWithNumber);
+    trimmedPoolName.length === 0 || (hasValidEnglishStorageName && !startsWithInvalidCharacter);
   const shouldShowSuccess =
     trimmedPoolName.length > 0 && isNameFormatValid && !isDuplicate;
 
@@ -155,17 +155,17 @@ const CreatePoolModal = ({
   };
 
   const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
-    if (!hasOnlyEnglishAlphanumeric && trimmedPoolName.length > 0) {
+    if (!hasValidEnglishStorageName && trimmedPoolName.length > 0) {
       event.preventDefault();
       setPoolNameError(
-        'نام فضای یکپارچه باید فقط شامل حروف انگلیسی و اعداد باشد.'
+        'نام فضای یکپارچه باید فقط شامل حروف انگلیسی، اعداد، خط تیره (-) و زیرخط (_) باشد و با حرف انگلیسی شروع شود.'
       );
       return;
     }
 
-    if (startsWithNumber) {
+    if (startsWithInvalidCharacter) {
       event.preventDefault();
-      setPoolNameError('نام فضای یکپارچه نمی‌تواند با عدد شروع شود.');
+      setPoolNameError('نام فضای یکپارچه باید با حرف انگلیسی شروع شود.');
       return;
     }
 
@@ -219,8 +219,8 @@ const CreatePoolModal = ({
             size="small"
             error={
               Boolean(poolNameError) ||
-              (!hasOnlyEnglishAlphanumeric && trimmedPoolName.length > 0) ||
-              startsWithNumber ||
+              (!hasValidEnglishStorageName && trimmedPoolName.length > 0) ||
+              startsWithInvalidCharacter ||
               isDuplicate ||
               hasPersianPoolName
             }
@@ -228,11 +228,11 @@ const CreatePoolModal = ({
               (hasPersianPoolName &&
                 'استفاده از حروف فارسی در این فیلد مجاز نیست.') ||
               poolNameError ||
-              (!hasOnlyEnglishAlphanumeric &&
+              (!hasValidEnglishStorageName &&
                 trimmedPoolName.length > 0 &&
-                'نام فضای یکپارچه باید فقط شامل حروف انگلیسی و اعداد باشد.') ||
-              (startsWithNumber &&
-                'نام فضای یکپارچه نمی‌تواند با عدد شروع شود.') ||
+                'نام فضای یکپارچه باید فقط شامل حروف انگلیسی، اعداد، خط تیره (-) و زیرخط (_) باشد و با حرف انگلیسی شروع شود.') ||
+              (startsWithInvalidCharacter &&
+                'نام فضای یکپارچه باید با حرف انگلیسی شروع شود.') ||
               (isDuplicate && 'فضای یکپارچه‌ای با این نام از قبل وجود دارد.') ||
               undefined
             }

--- a/src/components/integrated-storage/ImportPoolModal.tsx
+++ b/src/components/integrated-storage/ImportPoolModal.tsx
@@ -1,4 +1,15 @@
-import { Box, TextField } from '@mui/material';
+import {
+  Alert,
+  Box,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
 import type { UseImportPoolReturn } from '../../hooks/useImportPool';
 import BlurModal from '../BlurModal';
 import ModalActionButtons from '../common/ModalActionButtons';
@@ -14,9 +25,17 @@ const ImportPoolModal = ({ controller }: ImportPoolModalProps) => {
     setPoolName,
     errorMessage,
     isImporting,
+    importablePools,
+    isImportablePoolsLoading,
+    importablePoolsError,
     handleSubmit,
     closeModal,
   } = controller;
+
+  const hasImportablePools = importablePools.length > 0;
+  const handlePoolSelect = (event: SelectChangeEvent<string>) => {
+    setPoolName(event.target.value);
+  };
 
   return (
     <BlurModal
@@ -31,37 +50,86 @@ const ImportPoolModal = ({ controller }: ImportPoolModalProps) => {
           confirmLabel="فراخوانی"
           loadingLabel="در حال فراخوانی..."
           isLoading={isImporting}
-          disabled={isImporting}
+          disabled={isImporting || isImportablePoolsLoading}
           disableConfirmGradient
         />
       }
     >
       <form onSubmit={handleSubmit}>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            label="نام فضای یکپارچه"
-            value={poolName}
-            onChange={(event) => setPoolName(event.target.value)}
-            fullWidth
-            autoFocus
-            size="small"
-            error={Boolean(errorMessage)}
-            helperText={
-              errorMessage ||
-              'نام فضای یکپارچه‌ای که قصد فراخوانی آن را دارید وارد کنید.'
-            }
-            sx={{
-              '& .MuiOutlinedInput-input': {
-                color: 'var(--color-text)', // اینجا رنگ متن کاربر رو عوض کن
-              },
-            }}
-          />
+          {importablePoolsError && (
+            <Alert severity="warning">
+              {importablePoolsError.message ||
+                'فهرست فضاهای قابل فراخوانی دریافت نشد؛ نام را به‌صورت دستی وارد کنید.'}
+            </Alert>
+          )}
 
-          {/* {errorMessage && (
-            <Typography sx={{ color: 'var(--color-error)', fontWeight: 600 }}>
-              {errorMessage}
+          {!isImportablePoolsLoading && !importablePoolsError && !hasImportablePools && (
+            <Alert severity="info">
+              فضای یکپارچه‌ای برای فراخوانی پیدا نشد. در صورت اطمینان می‌توانید نام را دستی وارد کنید.
+            </Alert>
+          )}
+
+          {hasImportablePools ? (
+            <FormControl fullWidth size="small" error={Boolean(errorMessage)}>
+              <InputLabel id="importable-pool-select-label">
+                نام فضای یکپارچه
+              </InputLabel>
+              <Select
+                labelId="importable-pool-select-label"
+                label="نام فضای یکپارچه"
+                value={poolName}
+                onChange={handlePoolSelect}
+                autoFocus
+                sx={{ color: 'var(--color-text)' }}
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      backgroundColor: 'var(--color-card-bg)',
+                      color: 'var(--color-text)',
+                    },
+                  },
+                }}
+              >
+                {importablePools.map((pool) => (
+                  <MenuItem key={pool.id} value={pool.name}>
+                    {pool.name}
+                  </MenuItem>
+                ))}
+              </Select>
+              <FormHelperText>
+                {errorMessage || 'یکی از فضاهای قابل فراخوانی را انتخاب کنید.'}
+              </FormHelperText>
+            </FormControl>
+          ) : (
+            <TextField
+              label="نام فضای یکپارچه"
+              value={poolName}
+              onChange={(event) => setPoolName(event.target.value)}
+              fullWidth
+              autoFocus
+              size="small"
+              disabled={isImportablePoolsLoading}
+              error={Boolean(errorMessage)}
+              helperText={
+                errorMessage ||
+                (isImportablePoolsLoading
+                  ? 'در حال دریافت فهرست فضاهای قابل فراخوانی...'
+                  : 'نام فضای یکپارچه‌ای که قصد فراخوانی آن را دارید وارد کنید.')
+              }
+              sx={{
+                '& .MuiOutlinedInput-input': {
+                  color: 'var(--color-text)',
+                },
+              }}
+            />
+          )}
+
+          {isImportablePoolsLoading && (
+            <Typography variant="body2" sx={{ color: 'var(--color-muted)' }}>
+              در حال دریافت فهرست فضاهای قابل فراخوانی...
             </Typography>
-          )} */}
+          )}
         </Box>
       </form>
     </BlurModal>

--- a/src/hooks/useCreateFileSystem.ts
+++ b/src/hooks/useCreateFileSystem.ts
@@ -133,11 +133,11 @@ export const useCreateFileSystem = ({
       if (!trimmedName) {
         setNameError('نام فضای فایلی را وارد کنید.');
         hasError = true;
-      } else if (!/^[A-Za-z0-9]+$/.test(trimmedName)) {
-        setNameError('نام فضای فایلی باید فقط شامل حروف انگلیسی و اعداد باشد.');
+      } else if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmedName)) {
+        setNameError('نام فضای فایلی باید فقط شامل حروف انگلیسی، اعداد، خط تیره (-) و زیرخط (_) باشد و با حرف انگلیسی شروع شود.');
         hasError = true;
-      } else if (/^[0-9]/.test(trimmedName)) {
-        setNameError('نام فضای فایلی نمی‌تواند با عدد شروع شود.');
+      } else if (/^[0-9_-]/.test(trimmedName)) {
+        setNameError('نام فضای فایلی باید با حرف انگلیسی شروع شود.');
         hasError = true;
       }
 

--- a/src/hooks/useCreatePool.ts
+++ b/src/hooks/useCreatePool.ts
@@ -3,7 +3,7 @@ import type { AxiosError } from 'axios';
 import type { FormEvent } from 'react';
 import { useCallback, useState } from 'react';
 import axiosInstance from '../lib/axiosInstance';
-import { validateEnglishAlphanumericName } from '../utils/text';
+import { validateEnglishStorageName } from '../utils/text';
 
 interface ApiErrorResponse {
   detail?: string;
@@ -22,7 +22,7 @@ interface CreatePoolPayload {
 export type VdevType = 'disk' | 'mirror' | 'raidz' | '';
 
 const validatePoolName = (trimmedName: string): string | null =>
-  validateEnglishAlphanumericName(trimmedName, 'نام فضای یکپارچه');
+  validateEnglishStorageName(trimmedName, 'نام فضای یکپارچه');
 
 const vdevSpecificDeviceRules: Record<Exclude<VdevType, ''>, (count: number) => string | null> = {
   disk: () => null,

--- a/src/hooks/useImportPool.ts
+++ b/src/hooks/useImportPool.ts
@@ -1,10 +1,19 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { FormEvent, MouseEvent } from 'react';
 import { useCallback, useState } from 'react';
 import axiosInstance from '../lib/axiosInstance';
 import extractApiErrorMessage from '../utils/apiError';
 
 const DEFAULT_IMPORT_POOL_ERROR_MESSAGE = 'امکان درون‌ریزی فضای یکپارچه وجود ندارد.';
+const DEFAULT_IMPORTABLE_POOLS_ERROR_MESSAGE = 'امکان دریافت فهرست فضاهای قابل فراخوانی وجود ندارد.';
+
+export const importablePoolsQueryKey = ['zpool', 'importable'] as const;
+
+export interface ImportablePoolEntry {
+  id: string;
+  name: string;
+  raw: unknown;
+}
 
 interface ImportPoolPayload {
   pool_name: string;
@@ -16,11 +25,91 @@ interface UseImportPoolOptions {
   onError?: (error: Error, poolName: string) => void;
 }
 
+const extractPoolName = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value.trim() || null;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const candidateKeys = ['name', 'pool_name', 'poolName', 'pool', 'id'];
+
+  for (const key of candidateKeys) {
+    const candidate = record[key];
+    if (typeof candidate === 'string' || typeof candidate === 'number') {
+      const resolvedName = String(candidate).trim();
+      if (resolvedName) {
+        return resolvedName;
+      }
+    }
+  }
+
+  return null;
+};
+
+const normalizeImportablePools = (payload: unknown): ImportablePoolEntry[] => {
+  const responseBody =
+    payload && typeof payload === 'object' && 'data' in payload
+      ? (payload as { data: unknown }).data
+      : payload;
+
+  const rawItems = Array.isArray(responseBody)
+    ? responseBody
+    : responseBody && typeof responseBody === 'object'
+      ? Object.entries(responseBody as Record<string, unknown>).map(([key, value]) => {
+          if (value && typeof value === 'object') {
+            return { id: key, ...(value as Record<string, unknown>) };
+          }
+
+          return { id: key, name: value };
+        })
+      : [];
+
+  return rawItems
+    .map((item, index): ImportablePoolEntry | null => {
+      const name = extractPoolName(item);
+      if (!name) {
+        return null;
+      }
+
+      const id =
+        item && typeof item === 'object' && 'id' in item
+          ? String((item as { id: unknown }).id ?? name)
+          : name;
+
+      return {
+        id: `${id}-${index}`,
+        name,
+        raw: item,
+      };
+    })
+    .filter((item): item is ImportablePoolEntry => item !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
 export const useImportPool = ({ onSuccess, onError }: UseImportPoolOptions = {}) => {
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [poolName, setPoolName] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const importablePoolsQuery = useQuery<ImportablePoolEntry[], Error>({
+    queryKey: importablePoolsQueryKey,
+    enabled: isOpen,
+    queryFn: async () => {
+      try {
+        const response = await axiosInstance.get<unknown>('/api/zpool/import/');
+        return normalizeImportablePools(response.data);
+      } catch (error) {
+        throw new Error(
+          extractApiErrorMessage(error, DEFAULT_IMPORTABLE_POOLS_ERROR_MESSAGE)
+        );
+      }
+    },
+  });
 
   const importMutation = useMutation<unknown, Error, ImportPoolPayload>({
     mutationFn: async (payload) => {
@@ -32,6 +121,7 @@ export const useImportPool = ({ onSuccess, onError }: UseImportPoolOptions = {})
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['zpool'] });
+      queryClient.invalidateQueries({ queryKey: importablePoolsQueryKey });
       onSuccess?.(variables.pool_name);
       handleClose();
     },
@@ -78,6 +168,10 @@ export const useImportPool = ({ onSuccess, onError }: UseImportPoolOptions = {})
     poolName,
     errorMessage,
     isImporting: importMutation.isPending,
+    importablePools: importablePoolsQuery.data ?? [],
+    isImportablePoolsLoading: importablePoolsQuery.isFetching,
+    importablePoolsError: importablePoolsQuery.error,
+    refetchImportablePools: importablePoolsQuery.refetch,
     setPoolName,
     openModal: handleOpen,
     closeModal: handleClose,

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -34,7 +34,7 @@ export const isLowercaseEnglishAlphabet = (value: string) =>
 export const lowercaseEnglishWarningMessage =
   'نام کاربری فقط می‌تواند شامل حروف انگلیسی کوچک و اعداد باشد و نباید با عدد شروع شود.';
 
-  export const validateEnglishAlphanumericName = (
+export const validateEnglishAlphanumericName = (
   trimmedName: string,
   label: string
 ): string | null => {
@@ -48,6 +48,22 @@ export const lowercaseEnglishWarningMessage =
 
   if (/^[0-9]/.test(trimmedName)) {
     return `${label} نمی‌تواند با عدد شروع شود.`;
+  }
+
+  return null;
+};
+
+
+export const validateEnglishStorageName = (
+  trimmedName: string,
+  label: string
+): string | null => {
+  if (!trimmedName) {
+    return `لطفاً ${label} را وارد کنید.`;
+  }
+
+  if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmedName)) {
+    return `${label} باید فقط شامل حروف انگلیسی، اعداد، خط تیره (-) و زیرخط (_) باشد و با حرف انگلیسی شروع شود.`;
   }
 
   return null;


### PR DESCRIPTION
### Motivation
- Add a typed, defensive GET API for listing importable zpools and surface those choices in the Integrated Storage import modal to simplify imports.
- Allow hyphen (`-`) and underscore (`_`) in pool/filesystem names while still requiring an English-letter prefix and rejecting Persian characters and leading digits/specials.
- Fix a small side-effect in the filesystem modal where a Persian-quota warning cleared encryption fields; keep resets limited and side-effect free.

### Description
- Added a React Query GET flow to `src/hooks/useImportPool.ts` with `export const importablePoolsQueryKey = ['zpool','importable']`, `ImportablePoolEntry` type, defensive response normalization for arrays / `data` wrappers / object maps, name extraction from keys `name|pool_name|poolName|pool|id`, and sorting by name; existing POST import mutation is preserved and now also invalidates the importable-pools cache on success.
- Reworked `src/components/integrated-storage/ImportPoolModal.tsx` to fetch and render importable pools as a `Select` when available, show warning/empty info states, and keep a manual `TextField` fallback when the list fails or is empty; selection sets `poolName` and submit still calls the existing import mutation (`POST /api/zpool/import/` with `{ pool_name, save_to_db: true }`).
- Introduced `validateEnglishStorageName` in `src/utils/text.ts` (regex `^[A-Za-z][A-Za-z0-9_-]*$`) and applied it in pool/filesystem creation paths (`useCreatePool`, `useCreateFileSystem`, plus modal validation/helper text) with updated Persian helper messages that mention hyphen/underscore and starting-with-letter requirement.
- Removed the behavior in `CreateFileSystemModal.tsx` where the `hasPersianQuota` timeout also reset encryption-related state; the timeout now only clears `hasPersianQuota` and encryption fields are reset only when the modal closes.

### Testing
- Ran `npm run build` which completed successfully (TypeScript build and Vite bundle succeeded).
- Ran `npm run lint` which failed due to pre-existing unrelated lint errors in other files (errors reported in `src/contexts/AuthContext.tsx`, `src/contexts/ThemeContext.tsx`, `src/hooks/useDeleteFileSystem.ts`, `src/hooks/useFileSystems.ts`, and `src/hooks/useSambaUserAccountFlags.ts`); the files changed by this PR are not the source of those lint errors.
- Files changed: `src/hooks/useImportPool.ts`, `src/components/integrated-storage/ImportPoolModal.tsx`, `src/components/integrated-storage/CreatePoolModal.tsx`, `src/components/file-system/CreateFileSystemModal.tsx`, `src/hooks/useCreateFileSystem.ts`, `src/hooks/useCreatePool.ts`, `src/utils/text.ts`.
- Short diff summary: added typed importable-pools query and normalization (hooks), replaced import modal input with conditional `Select` + fallback and warnings (component), relaxed storage-name validation to accept `-`/`_` with a leading-letter constraint and updated Persian messages (utils/hooks/components), and removed encryption reset side-effect (filesystem modal).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37e2ffb5fc83278b04094fd737cf28)