### PR TITLE
Fix NFS read/write rw/ro option mapping

### DIFF
--- a/src/utils/nfsDetails.ts
+++ b/src/utils/nfsDetails.ts
@@ -2,6 +2,10 @@ import type { NestedDetailTableData } from '../@types/detailComparison';
 import type { NfsShareClientEntry, NfsShareEntry } from '../@types/nfs';
 import type { ReactNode } from 'react';
 import { translateDetailKey } from './detailLabels';
+import {
+  resolveEnabledOptionKeys,
+  resolveOptionValues,
+} from './nfsShareOptions';
 
 const buildClientTitle = (client: NfsShareClientEntry, index: number) => {
   const trimmed = typeof client.client === 'string' ? client.client.trim() : '';
@@ -13,10 +17,12 @@ const buildOptionRows = (options: Record<string, unknown> | undefined) => {
     return {};
   }
 
+  const optionValues = resolveOptionValues(options);
+
   return Object.fromEntries(
-    Object.entries(options).map(([key, value]) => [
+    resolveEnabledOptionKeys(options).map((key) => [
       translateDetailKey(key),
-      value,
+      optionValues[key],
     ])
   ) as Record<string, ReactNode>;
 };

--- a/src/utils/nfsShareOptions.ts
+++ b/src/utils/nfsShareOptions.ts
@@ -23,8 +23,27 @@ const resolveOptionValue = (
   }
 
   if (key === 'read_write') {
-    const value = options.read_write ?? options.rw;
-    return typeof value === 'boolean' ? value : undefined;
+    if (typeof options.read_write === 'boolean') {
+      return options.read_write;
+    }
+
+    if (typeof options.rw === 'boolean' && options.rw) {
+      return true;
+    }
+
+    if (typeof options.ro === 'boolean' && options.ro) {
+      return false;
+    }
+
+    if (typeof options.rw === 'boolean') {
+      return options.rw;
+    }
+
+    if (typeof options.ro === 'boolean') {
+      return !options.ro;
+    }
+
+    return undefined;
   }
 
   if (key === 'sync') {


### PR DESCRIPTION
### Motivation
- Backend list API returns `rw`/`ro` flags instead of `read_write`, so the UI must normalize those aliases to a single `read_write` boolean to match create/update payloads and user expectations.

### Description
- Update `resolveOptionValue` for key `read_write` in `src/utils/nfsShareOptions.ts` to prefer an explicit `options.read_write` boolean, then map `rw: true` → `read_write: true`, `ro: true` → `read_write: false`, and defensively handle mixed or boolean `rw`/`ro` edge cases, falling back to `undefined` when unknown.
- Replace raw option rendering in `src/utils/nfsDetails.ts` to use `resolveEnabledOptionKeys` and `resolveOptionValues` so detail tables show normalized option keys and values rather than backend aliases.
- Verified existing submit behavior remains using `read_write` via `optionValues` in the modal and existing create/update hooks continue to send `read_write` (no `rw`/`ro` added).
- Files changed: `src/utils/nfsShareOptions.ts`, `src/utils/nfsDetails.ts`.

### Testing
- Ran `npm run build` which completed successfully (TypeScript compile + `vite build` succeeded).
- Ran `npm run lint` which failed due to pre-existing unrelated lint/type issues outside the changed NFS files, causing `eslint` to report errors in other parts of the project.
- No new unit test framework was added; verification was limited to build and lint outcomes and code inspection of modal/hooks to ensure payloads keep using `read_write`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37ece30e348327a86313a41bcd6f62)