### PR TITLE
Local notification storage foundation

### DIFF
--- a/src/@types/notification.ts
+++ b/src/@types/notification.ts
@@ -1,0 +1,27 @@
+export type LocalNotificationSeverity = 'info' | 'warning' | 'critical';
+
+export type LocalNotificationSource = 'startup-capacity-check' | 'user-action';
+
+export type LocalNotificationEntityType =
+  | 'pool'
+  | 'filesystem'
+  | 'disk'
+  | 'service'
+  | 'snmp'
+  | 'share';
+
+export interface LocalNotification {
+  id: string;
+  fingerprint: string;
+  title: string;
+  message: string;
+  severity: LocalNotificationSeverity;
+  source: LocalNotificationSource;
+  entityType?: LocalNotificationEntityType;
+  entityId?: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string;
+  readAt: string | null;
+  metadata?: Record<string, unknown>;
+}

--- a/src/hooks/useLocalNotifications.ts
+++ b/src/hooks/useLocalNotifications.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { LocalNotification } from '../@types/notification';
+import {
+  cleanupExpiredNotifications,
+  clearNotification as clearStoredNotification,
+  getNotificationStorageKey,
+  markAllNotificationsRead,
+  markNotificationRead,
+  upsertNotification,
+  type UpsertLocalNotificationInput,
+} from '../utils/notificationStorage';
+
+export const useLocalNotifications = (userKey?: string) => {
+  const [notifications, setNotifications] = useState<LocalNotification[]>(() =>
+    cleanupExpiredNotifications(userKey),
+  );
+
+  const refreshNotifications = useCallback(() => {
+    setNotifications(cleanupExpiredNotifications(userKey));
+  }, [userKey]);
+
+  const addOrUpdateNotification = useCallback(
+    (input: UpsertLocalNotificationInput) => {
+      const updatedNotifications = upsertNotification(input, userKey);
+      setNotifications(updatedNotifications);
+      return updatedNotifications;
+    },
+    [userKey],
+  );
+
+  const markAsRead = useCallback(
+    (id: string) => {
+      const updatedNotifications = markNotificationRead(id, userKey);
+      setNotifications(updatedNotifications);
+      return updatedNotifications;
+    },
+    [userKey],
+  );
+
+  const markAllAsRead = useCallback(() => {
+    const updatedNotifications = markAllNotificationsRead(userKey);
+    setNotifications(updatedNotifications);
+    return updatedNotifications;
+  }, [userKey]);
+
+  const clearNotification = useCallback(
+    (id: string) => {
+      const updatedNotifications = clearStoredNotification(id, userKey);
+      setNotifications(updatedNotifications);
+      return updatedNotifications;
+    },
+    [userKey],
+  );
+
+  useEffect(() => {
+    refreshNotifications();
+  }, [refreshNotifications]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const storageKey = getNotificationStorageKey(userKey);
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === storageKey) {
+        refreshNotifications();
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [refreshNotifications, userKey]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => notification.readAt === null).length,
+    [notifications],
+  );
+
+  return {
+    notifications,
+    unreadCount,
+    refreshNotifications,
+    addOrUpdateNotification,
+    markAsRead,
+    markAllAsRead,
+    clearNotification,
+  };
+};

--- a/src/utils/notificationStorage.ts
+++ b/src/utils/notificationStorage.ts
@@ -1,0 +1,175 @@
+import type { LocalNotification } from '../@types/notification';
+
+export const NOTIFICATION_STORAGE_KEY_PREFIX = 'soho:notifications';
+export const NOTIFICATION_TTL_DAYS = 10;
+
+const TTL_IN_MS = NOTIFICATION_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+type StoredNotification = Partial<LocalNotification>;
+
+export type UpsertLocalNotificationInput = Omit<
+  LocalNotification,
+  'id' | 'createdAt' | 'updatedAt' | 'expiresAt' | 'readAt'
+> &
+  Partial<Pick<LocalNotification, 'id' | 'createdAt' | 'updatedAt' | 'expiresAt' | 'readAt'>>;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+export const getNotificationStorageKey = (userKey?: string) =>
+  `${NOTIFICATION_STORAGE_KEY_PREFIX}:${userKey || 'default'}`;
+
+const isValidNotification = (notification: StoredNotification): notification is LocalNotification =>
+  typeof notification.id === 'string' &&
+  typeof notification.fingerprint === 'string' &&
+  typeof notification.title === 'string' &&
+  typeof notification.message === 'string' &&
+  (notification.severity === 'info' ||
+    notification.severity === 'warning' ||
+    notification.severity === 'critical') &&
+  (notification.source === 'startup-capacity-check' || notification.source === 'user-action') &&
+  typeof notification.createdAt === 'string' &&
+  typeof notification.updatedAt === 'string' &&
+  typeof notification.expiresAt === 'string' &&
+  (notification.readAt === null || typeof notification.readAt === 'string');
+
+const sortNotifications = (notifications: LocalNotification[]) =>
+  [...notifications].sort(
+    (first, second) => new Date(second.updatedAt).getTime() - new Date(first.updatedAt).getTime(),
+  );
+
+const isExpired = (notification: LocalNotification, now = Date.now()) =>
+  new Date(notification.expiresAt).getTime() <= now;
+
+const createExpiresAt = (updatedAt: string) => new Date(new Date(updatedAt).getTime() + TTL_IN_MS).toISOString();
+
+const createNotificationId = () => {
+  if (isBrowser() && window.crypto && typeof window.crypto.randomUUID === 'function') {
+    return window.crypto.randomUUID();
+  }
+
+  return `notification-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export const getNotifications = (userKey?: string): LocalNotification[] => {
+  if (!isBrowser()) {
+    return [];
+  }
+
+  const storageKey = getNotificationStorageKey(userKey);
+  const storedValue = window.localStorage.getItem(storageKey);
+
+  if (!storedValue) {
+    return [];
+  }
+
+  try {
+    const parsedValue: unknown = JSON.parse(storedValue);
+
+    if (!Array.isArray(parsedValue)) {
+      window.localStorage.removeItem(storageKey);
+      return [];
+    }
+
+    return sortNotifications(parsedValue.filter(isValidNotification));
+  } catch {
+    window.localStorage.removeItem(storageKey);
+    return [];
+  }
+};
+
+export const saveNotifications = (notifications: LocalNotification[], userKey?: string): void => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  window.localStorage.setItem(getNotificationStorageKey(userKey), JSON.stringify(sortNotifications(notifications)));
+};
+
+export const cleanupExpiredNotifications = (userKey?: string): LocalNotification[] => {
+  const activeNotifications = getNotifications(userKey).filter((notification) => !isExpired(notification));
+  saveNotifications(activeNotifications, userKey);
+  return activeNotifications;
+};
+
+export const upsertNotification = (
+  input: UpsertLocalNotificationInput,
+  userKey?: string,
+): LocalNotification[] => {
+  const notifications = cleanupExpiredNotifications(userKey);
+  const now = new Date().toISOString();
+  const existingNotification = notifications.find(
+    (notification) => notification.fingerprint === input.fingerprint,
+  );
+
+  if (existingNotification) {
+    const updatedNotification: LocalNotification = {
+      ...existingNotification,
+      title: input.title,
+      message: input.message,
+      severity: input.severity,
+      source: input.source,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      updatedAt: now,
+      expiresAt: createExpiresAt(now),
+      readAt:
+        existingNotification.severity === 'warning' && input.severity === 'critical'
+          ? null
+          : existingNotification.readAt,
+      metadata: input.metadata,
+    };
+
+    const updatedNotifications = notifications.map((notification) =>
+      notification.id === existingNotification.id ? updatedNotification : notification,
+    );
+    saveNotifications(updatedNotifications, userKey);
+    return sortNotifications(updatedNotifications);
+  }
+
+  const newNotification: LocalNotification = {
+    id: input.id ?? createNotificationId(),
+    fingerprint: input.fingerprint,
+    title: input.title,
+    message: input.message,
+    severity: input.severity,
+    source: input.source,
+    entityType: input.entityType,
+    entityId: input.entityId,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: createExpiresAt(now),
+    readAt: input.readAt ?? null,
+    metadata: input.metadata,
+  };
+
+  const updatedNotifications = [...notifications, newNotification];
+  saveNotifications(updatedNotifications, userKey);
+  return sortNotifications(updatedNotifications);
+};
+
+export const markNotificationRead = (id: string, userKey?: string): LocalNotification[] => {
+  const now = new Date().toISOString();
+  const updatedNotifications = cleanupExpiredNotifications(userKey).map((notification) =>
+    notification.id === id ? { ...notification, readAt: notification.readAt ?? now } : notification,
+  );
+  saveNotifications(updatedNotifications, userKey);
+  return sortNotifications(updatedNotifications);
+};
+
+export const markAllNotificationsRead = (userKey?: string): LocalNotification[] => {
+  const now = new Date().toISOString();
+  const updatedNotifications = cleanupExpiredNotifications(userKey).map((notification) => ({
+    ...notification,
+    readAt: notification.readAt ?? now,
+  }));
+  saveNotifications(updatedNotifications, userKey);
+  return sortNotifications(updatedNotifications);
+};
+
+export const clearNotification = (id: string, userKey?: string): LocalNotification[] => {
+  const updatedNotifications = cleanupExpiredNotifications(userKey).filter(
+    (notification) => notification.id !== id,
+  );
+  saveNotifications(updatedNotifications, userKey);
+  return sortNotifications(updatedNotifications);
+};


### PR DESCRIPTION
### Motivation
- Provide a safe, framework-level foundation for persisting and managing local notifications in the browser using `localStorage` while avoiding UI, API, routing, or auth changes.

### Description
- Add `src/@types/notification.ts` which defines `LocalNotification` and related types (`severity`, `source`, `entityType`).
- Add `src/utils/notificationStorage.ts` implementing `getNotifications`, `saveNotifications`, `cleanupExpiredNotifications`, `upsertNotification`, `markNotificationRead`, `markAllNotificationsRead`, and `clearNotification` with per-user keys, prefix `soho:notifications`, a 10-day TTL, JSON corruption recovery, browser guards, `crypto.randomUUID()` fallback, fingerprint deduplication (preserves `createdAt`, updates content and `updatedAt`/`expiresAt`, and resets `readAt` when severity escalates from `warning` to `critical`), and sorting newest `updatedAt` first.
- Add `src/hooks/useLocalNotifications.ts` hook exposing `notifications`, `unreadCount`, `refreshNotifications`, `addOrUpdateNotification`, `markAsRead`, `markAllAsRead`, and `clearNotification`, which initializes by cleaning up expired notifications and keeps state in sync after operations and via the `storage` event for the same key.
- Files changed: `src/@types/notification.ts`, `src/utils/notificationStorage.ts`, and `src/hooks/useLocalNotifications.ts`.

### Testing
- `npm run build` — passed.
- `npm run lint` — failed due to pre-existing lint errors in unrelated files, while linting of the added files passed via `npx eslint src/@types/notification.ts src/utils/notificationStorage.ts src/hooks/useLocalNotifications.ts`.
- LocalStorage key used is `soho:notifications:${userKey}` when `userKey` is provided and `soho:notifications:default` otherwise.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40dd60dd788327b78b46ba6d892fa2)