### PR TITLE
Add notification bell UI and startup bootstrapper

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -24,6 +24,8 @@ import { useTheme as useThemeContext } from '../contexts/ThemeContext';
 import useLogout from '../hooks/useLogout';
 import { usePowerAction, type PowerAction } from '../hooks/usePowerAction';
 import NavigationDrawer from './NavigationDrawer';
+import NotificationBell from './notifications/NotificationBell';
+import NotificationBootstrapper from './notifications/NotificationBootstrapper';
 import PowerActionConfirmDialog from './PowerActionConfirmDialog';
 import PowerActionCountdownOverlay from './PowerActionCountdownOverlay';
 import QuickActionsMenu from './QuickActionsMenu';
@@ -54,6 +56,7 @@ const MainLayout: React.FC = () => {
   const { isDark, toggleTheme } = useThemeContext();
 
   const displayUsername = username || 'admin';
+  const notificationUserKey = username || undefined;
 
   const { mutate: triggerPowerAction, isPending: isPowerActionPending } =
     usePowerAction({
@@ -151,6 +154,7 @@ const MainLayout: React.FC = () => {
         backgroundSize: '400% 400%',
       }}
     >
+      <NotificationBootstrapper userKey={notificationUserKey} />
       <AppBar
         position="fixed"
         sx={{
@@ -206,6 +210,7 @@ const MainLayout: React.FC = () => {
               order: { xs: 3, sm: 'initial' },
             }}
           >
+            <NotificationBell userKey={notificationUserKey} />
             {isMobile ? (
               <IconButton
                 aria-label="منوی کاربر"

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,214 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Popover,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { useMemo, useState } from 'react';
+import type { MouseEvent } from 'react';
+import { MdClose, MdDeleteOutline, MdDone, MdNotificationsNone } from 'react-icons/md';
+import type { LocalNotification, LocalNotificationSeverity } from '../../@types/notification';
+import { useLocalNotifications } from '../../hooks/useLocalNotifications';
+
+type NotificationBellProps = {
+  userKey?: string;
+  maxItems?: number;
+};
+
+const severityLabelByType: Record<LocalNotificationSeverity, string> = {
+  info: 'اطلاع‌رسانی',
+  warning: 'هشدار',
+  critical: 'بحرانی',
+};
+
+const formatNotificationDate = (dateValue: string) =>
+  new Intl.DateTimeFormat('fa-IR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(dateValue));
+
+const NotificationBell = ({ userKey, maxItems = 10 }: NotificationBellProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const { notifications, unreadCount, markAsRead, markAllAsRead, clearNotification } =
+    useLocalNotifications(userKey);
+
+  const visibleNotifications = useMemo(
+    () => notifications.slice(0, maxItems),
+    [maxItems, notifications],
+  );
+  const isOpen = Boolean(anchorEl);
+
+  const handleOpen = (event: MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const getSeverityColor = (severity: LocalNotification['severity']) => {
+    if (severity === 'critical') {
+      return 'error';
+    }
+
+    if (severity === 'warning') {
+      return 'warning';
+    }
+
+    return 'default';
+  };
+
+  return (
+    <>
+      <IconButton
+        aria-label="اعلان‌ها"
+        aria-controls={isOpen ? 'notification-popover' : undefined}
+        aria-haspopup="true"
+        onClick={handleOpen}
+        size="small"
+        sx={{ color: 'var(--color-bg-primary)' }}
+      >
+        <Badge badgeContent={unreadCount} color="error" max={99} overlap="circular">
+          <MdNotificationsNone size={24} />
+        </Badge>
+      </IconButton>
+      <Popover
+        id="notification-popover"
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{
+          sx: (theme) => ({
+            mt: 1.5,
+            width: { xs: 'calc(100vw - 32px)', sm: 420 },
+            maxWidth: '100%',
+            borderRadius: 2,
+            direction: 'rtl',
+            border: `1px solid ${alpha(theme.palette.divider, 0.6)}`,
+            backgroundColor:
+              theme.palette.mode === 'dark' ? alpha('#121212', 0.96) : alpha('#ffffff', 0.98),
+            backdropFilter: 'blur(12px)',
+          }),
+        }}
+      >
+        <Box sx={{ p: 2 }}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1}>
+            <Box>
+              <Typography variant="subtitle1" sx={{ fontWeight: 700, color: 'var(--color-text)' }}>
+                اعلان‌ها
+              </Typography>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                {unreadCount > 0 ? `${unreadCount} اعلان خوانده‌نشده` : 'همه اعلان‌ها خوانده شده‌اند'}
+              </Typography>
+            </Box>
+            <Button size="small" disabled={unreadCount === 0} onClick={markAllAsRead}>
+              خواندن همه
+            </Button>
+          </Stack>
+        </Box>
+        <Divider />
+        {visibleNotifications.length === 0 ? (
+          <Typography sx={{ px: 2, py: 4, textAlign: 'center', color: 'text.secondary' }}>
+            اعلانی برای نمایش وجود ندارد.
+          </Typography>
+        ) : (
+          <List disablePadding sx={{ maxHeight: 460, overflowY: 'auto' }}>
+            {visibleNotifications.map((notification) => {
+              const isUnread = notification.readAt === null;
+              const isCritical = notification.severity === 'critical';
+
+              return (
+                <ListItem
+                  key={notification.id}
+                  alignItems="flex-start"
+                  sx={(theme) => ({
+                    gap: 1,
+                    borderBottom: `1px solid ${alpha(theme.palette.divider, 0.55)}`,
+                    backgroundColor: isUnread ? alpha(theme.palette.primary.main, 0.06) : 'transparent',
+                    borderRight: `4px solid ${
+                      isCritical ? theme.palette.error.main : theme.palette.warning.main
+                    }`,
+                  })}
+                  secondaryAction={
+                    <Stack direction="row" spacing={0.5}>
+                      <IconButton
+                        edge="end"
+                        aria-label="خوانده شد"
+                        disabled={!isUnread}
+                        size="small"
+                        onClick={() => markAsRead(notification.id)}
+                      >
+                        <MdDone />
+                      </IconButton>
+                      <IconButton
+                        edge="end"
+                        aria-label="حذف اعلان"
+                        size="small"
+                        onClick={() => clearNotification(notification.id)}
+                      >
+                        <MdDeleteOutline />
+                      </IconButton>
+                    </Stack>
+                  }
+                >
+                  <ListItemText
+                    sx={{ pr: 7, my: 0 }}
+                    primary={
+                      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.75 }}>
+                        <Chip
+                          size="small"
+                          color={getSeverityColor(notification.severity)}
+                          label={severityLabelByType[notification.severity]}
+                          variant={isCritical ? 'filled' : 'outlined'}
+                          sx={{ fontWeight: isCritical ? 800 : 600 }}
+                        />
+                        {isUnread ? (
+                          <Chip size="small" label="جدید" color="primary" variant="outlined" />
+                        ) : null}
+                      </Stack>
+                    }
+                    secondary={
+                      <Box component="span">
+                        <Typography
+                          component="span"
+                          display="block"
+                          sx={{ fontWeight: isCritical ? 800 : 700, color: 'var(--color-text)' }}
+                        >
+                          {notification.title}
+                        </Typography>
+                        <Typography component="span" display="block" variant="body2" color="text.secondary">
+                          {notification.message}
+                        </Typography>
+                        <Typography component="span" display="block" variant="caption" color="text.secondary" sx={{ mt: 0.75 }}>
+                          {formatNotificationDate(notification.updatedAt)}
+                        </Typography>
+                      </Box>
+                    }
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 1 }}>
+          <Button size="small" startIcon={<MdClose />} onClick={handleClose}>
+            بستن
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  );
+};
+
+export default NotificationBell;

--- a/src/components/notifications/NotificationBootstrapper.tsx
+++ b/src/components/notifications/NotificationBootstrapper.tsx
@@ -1,7 +1,13 @@
 import { useStartupNotificationChecks } from '../../hooks/useStartupNotificationChecks';
 
-export const NotificationBootstrapper = () => {
-  useStartupNotificationChecks();
+type NotificationBootstrapperProps = {
+  userKey?: string;
+};
+
+const NotificationBootstrapper = ({ userKey }: NotificationBootstrapperProps) => {
+  useStartupNotificationChecks(userKey);
 
   return null;
 };
+
+export default NotificationBootstrapper;

--- a/src/hooks/useLocalNotifications.ts
+++ b/src/hooks/useLocalNotifications.ts
@@ -68,8 +68,17 @@ export const useLocalNotifications = (userKey?: string) => {
       }
     };
 
+    const handleNotificationChange = () => {
+      refreshNotifications();
+    };
+
     window.addEventListener('storage', handleStorage);
-    return () => window.removeEventListener('storage', handleStorage);
+    window.addEventListener('soho:notifications:capacity-summary', handleNotificationChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('soho:notifications:capacity-summary', handleNotificationChange);
+    };
   }, [refreshNotifications, userKey]);
 
   const unreadCount = useMemo(


### PR DESCRIPTION
### Motivation
- Provide an in-app notification bell UI to surface local startup and user notifications with Persian/RTL labels and minimal layout impact.
- Ensure startup capacity checks are mounted once in the authenticated layout so notifications created on startup are reflected in the UI without duplicates.

### Description
- Added `src/components/notifications/NotificationBell.tsx` which implements an MUI `IconButton` with `Badge`, a RTL `Popover`, Persian labels, unread count, latest notifications (default 10), and actions to mark single read, mark all read, and delete single notifications, with `warning`/`critical` severity presentation.
- Added `src/components/notifications/NotificationBootstrapper.tsx` as a null-render component that calls `useStartupNotificationChecks(userKey)` and is safe to mount once.
- Integrated the UI and bootstrapper into the authenticated layout by importing and mounting `NotificationBell` and `NotificationBootstrapper` in `src/components/MainLayout.tsx`; the bell is placed in the app bar action area before the user menu and the bootstrapper is mounted once at the layout root.
- Updated `src/hooks/useLocalNotifications.ts` to listen for the same-tab `soho:notifications:capacity-summary` event so the bell refreshes when startup checks create notifications, without modifying the localStorage utilities.

### Testing
- Ran `npm run build` which completed successfully and produced a production build.
- Ran `npm run lint` which reported failures due to pre-existing repository lint errors outside the changed files and therefore exited non-zero.
- Ran `npm exec -- eslint src/components/MainLayout.tsx src/components/notifications/NotificationBell.tsx src/components/notifications/NotificationBootstrapper.tsx src/hooks/useLocalNotifications.ts` which succeeded for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410393cc18832783fb863add4529f8)