### PR TITLE
Add controlled session inactivity timeout

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useTheme as useThemeContext } from '../contexts/ThemeContext';
 import useLogout from '../hooks/useLogout';
 import { usePowerAction, type PowerAction } from '../hooks/usePowerAction';
+import { useSessionActivityTimeout } from '../hooks/useSessionActivityTimeout';
 import NavigationDrawer from './NavigationDrawer';
 import NotificationBell from './notifications/NotificationBell';
 import NotificationBootstrapper from './notifications/NotificationBootstrapper';
@@ -33,7 +34,7 @@ import QuickActionsMenu from './QuickActionsMenu';
 const MainLayout: React.FC = () => {
   const Navigate = useNavigate();
   const location = useLocation();
-  const { username } = useAuth();
+  const { logout, username } = useAuth();
   const { logout: triggerLogout, isLoggingOut } = useLogout();
   const [drawerOpen, setDrawerOpen] = useState(true);
   const [activePowerAction, setActivePowerAction] =
@@ -57,6 +58,24 @@ const MainLayout: React.FC = () => {
 
   const displayUsername = username || 'admin';
   const notificationUserKey = username || undefined;
+
+  useSessionActivityTimeout({
+    enabled: true,
+    onTimeout: async () => {
+      try {
+        await logout();
+      } catch (error) {
+        if (import.meta.env.DEV) {
+          console.warn('[auth] idle timeout logout request failed', error);
+        }
+      } finally {
+        toast.error(
+          'نشست شما به دلیل عدم فعالیت منقضی شد. لطفاً دوباره وارد شوید.'
+        );
+        Navigate('/login', { replace: true });
+      }
+    },
+  });
 
   const { mutate: triggerPowerAction, isPending: isPowerActionPending } =
     usePowerAction({

--- a/src/hooks/useSessionActivityTimeout.ts
+++ b/src/hooks/useSessionActivityTimeout.ts
@@ -1,0 +1,157 @@
+import { useEffect, useRef } from 'react';
+
+const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const SESSION_IDLE_CHECK_INTERVAL_MS = 30 * 1000;
+const LAST_ACTIVITY_STORAGE_KEY = 'auth:last-activity-at';
+
+const ACTIVITY_WRITE_THROTTLE_MS = 5 * 1000;
+
+const getCurrentTimestamp = () => Date.now();
+
+const readLastActivityAt = (): number | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const storedValue = window.sessionStorage.getItem(
+      LAST_ACTIVITY_STORAGE_KEY
+    );
+    if (!storedValue) {
+      return null;
+    }
+
+    const parsedValue = Number(storedValue);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[auth] unable to read last activity timestamp', error);
+    }
+    return null;
+  }
+};
+
+const writeLastActivityAt = (timestamp: number) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(LAST_ACTIVITY_STORAGE_KEY, String(timestamp));
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('[auth] unable to write last activity timestamp', error);
+    }
+  }
+};
+
+export const useSessionActivityTimeout = ({
+  enabled,
+  onTimeout,
+}: {
+  enabled: boolean;
+  onTimeout: () => void | Promise<void>;
+}) => {
+  const onTimeoutRef = useRef(onTimeout);
+  const timeoutFiredRef = useRef(false);
+  const lastActivityWriteRef = useRef(0);
+
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  }, [onTimeout]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') {
+      return;
+    }
+
+    timeoutFiredRef.current = false;
+
+    let intervalId: number | null = null;
+    let listenersActive = true;
+
+    const recordActivity = (timestamp = getCurrentTimestamp()) => {
+      lastActivityWriteRef.current = timestamp;
+      writeLastActivityAt(timestamp);
+    };
+
+    const handleActivity = () => {
+      if (timeoutFiredRef.current) {
+        return;
+      }
+
+      const now = getCurrentTimestamp();
+      if (now - lastActivityWriteRef.current < ACTIVITY_WRITE_THROTTLE_MS) {
+        return;
+      }
+
+      recordActivity(now);
+    };
+
+    const stopTracking = () => {
+      if (intervalId) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+
+      if (!listenersActive) {
+        return;
+      }
+
+      window.removeEventListener('click', handleActivity);
+      window.removeEventListener('keydown', handleActivity);
+      window.removeEventListener('scroll', handleActivity);
+      window.removeEventListener('touchstart', handleActivity);
+      window.removeEventListener('pointerdown', handleActivity);
+      window.removeEventListener('focus', handleActivity);
+      listenersActive = false;
+    };
+
+    const handleTimeout = () => {
+      if (timeoutFiredRef.current) {
+        return;
+      }
+
+      timeoutFiredRef.current = true;
+      stopTracking();
+      void onTimeoutRef.current();
+    };
+
+    const checkIdleTimeout = () => {
+      if (timeoutFiredRef.current) {
+        return;
+      }
+
+      const lastActivityAt = readLastActivityAt();
+      const now = getCurrentTimestamp();
+      const effectiveLastActivityAt = lastActivityAt ?? now;
+
+      if (!lastActivityAt) {
+        recordActivity(now);
+        return;
+      }
+
+      if (now - effectiveLastActivityAt >= SESSION_IDLE_TIMEOUT_MS) {
+        handleTimeout();
+      }
+    };
+
+    recordActivity(getCurrentTimestamp());
+
+    window.addEventListener('click', handleActivity);
+    window.addEventListener('keydown', handleActivity);
+    window.addEventListener('scroll', handleActivity, { passive: true });
+    window.addEventListener('touchstart', handleActivity, { passive: true });
+    window.addEventListener('pointerdown', handleActivity, { passive: true });
+    window.addEventListener('focus', handleActivity);
+
+    intervalId = window.setInterval(
+      checkIdleTimeout,
+      SESSION_IDLE_CHECK_INTERVAL_MS
+    );
+
+    return () => {
+      stopTracking();
+    };
+  }, [enabled]);
+};

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -1,9 +1,9 @@
 import axios, { type AxiosError, type AxiosRequestConfig } from 'axios';
+import { setupAxiosMockAdapter } from '../mocks/setupMocks';
+import { logApiErrorDetails } from '../utils/apiError';
 import { refreshAccessToken } from './authApi';
 import { emitSessionCleared, emitTokenRefreshed } from './authEvents';
 import tokenStorage from './tokenStorage';
-import { setupAxiosMockAdapter } from '../mocks/setupMocks';
-import { logApiErrorDetails } from '../utils/apiError';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -64,9 +64,7 @@ const processQueue = (error: unknown, token: string | null) => {
       };
     }
 
-    axiosInstance(config)
-      .then(resolve)
-      .catch(reject);
+    axiosInstance(config).then(resolve).catch(reject);
   }
 };
 
@@ -76,14 +74,23 @@ axiosInstance.interceptors.response.use(
     logApiErrorDetails(error);
 
     const status = error.response?.status;
-    const originalRequest = error.config as (AxiosRequestConfig & {
-      _retry?: boolean;
-    }) | undefined;
+    const originalRequest = error.config as
+      | (AxiosRequestConfig & {
+          _retry?: boolean;
+        })
+      | undefined;
 
     if (status === 401 && originalRequest && !originalRequest._retry) {
+      if (import.meta.env.DEV) {
+        console.warn('[auth] 401 received', originalRequest.url);
+      }
+
       const refresh = tokenStorage.getRefreshToken();
 
       if (!refresh) {
+        if (import.meta.env.DEV) {
+          console.warn('[auth] refresh token missing; clearing session');
+        }
         tokenStorage.clear();
         emitSessionCleared();
         return Promise.reject(error);
@@ -112,6 +119,12 @@ axiosInstance.interceptors.response.use(
             return axiosInstance(originalRequest).then(resolve).catch(reject);
           })
           .catch((refreshError) => {
+            if (import.meta.env.DEV) {
+              console.warn(
+                '[auth] refresh failed; clearing session',
+                refreshError
+              );
+            }
             processQueue(refreshError, null);
             tokenStorage.clear();
             emitSessionCleared();

--- a/src/lib/tokenStorage.ts
+++ b/src/lib/tokenStorage.ts
@@ -1,43 +1,37 @@
 const REFRESH_TOKEN_KEY = 'auth:refresh-token';
 const USERNAME_KEY = 'auth:username';
 
-const getWebStorage = (): Storage | null => {
+const getSessionStorage = (): Storage | null => {
   if (typeof window === 'undefined') {
     return null;
   }
 
-  const candidates: (Storage | undefined)[] = [
-    window.sessionStorage,
-    window.localStorage,
-  ];
-
-  for (const storage of candidates) {
-    if (!storage) {
-      continue;
-    }
-
-    try {
-      const testKey = '__auth_storage_test__';
-      storage.setItem(testKey, '1');
-      storage.removeItem(testKey);
-      return storage;
-    } catch (error) {
-      console.warn('Web storage is not available, falling back to in-memory tokens.', error);
-    }
+  try {
+    const testKey = '__auth_storage_test__';
+    window.sessionStorage.setItem(testKey, '1');
+    window.sessionStorage.removeItem(testKey);
+    return window.sessionStorage;
+  } catch (error) {
+    console.warn(
+      'Session storage is not available, falling back to in-memory tokens.',
+      error
+    );
+    return null;
   }
-
-  return null;
 };
 
-const storageRef = getWebStorage();
+const storageRef = getSessionStorage();
 
-// Clean up any legacy access tokens that might have been persisted previously so
-// they are not exposed to long-lived storage and can only live in-memory.
-if (storageRef) {
+// Clean up any legacy tokens that might have been persisted previously so access
+// tokens stay memory-only and refresh tokens stay scoped to sessionStorage.
+if (typeof window !== 'undefined') {
   try {
-    storageRef.removeItem('auth:access-token');
+    window.sessionStorage.removeItem('auth:access-token');
+    window.localStorage.removeItem('auth:access-token');
+    window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+    window.localStorage.removeItem(USERNAME_KEY);
   } catch (error) {
-    console.warn('Unable to remove legacy access token from storage', error);
+    console.warn('Unable to remove legacy auth values from storage', error);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure users are required to re-login after closing a tab and to be automatically logged out after 30 minutes of real inactivity while keeping tokens stored per existing rules.
- Provide a frontend-only, controlled idle timeout that does not move tokens to `localStorage` and respects current auth flow and refresh handling.

### Description
- Added a new hook `src/hooks/useSessionActivityTimeout.ts` that writes `auth:last-activity-at` into `sessionStorage`, listens for real user interactions (`click`, `keydown`, `scroll`, `touchstart`, `pointerdown`, `focus`), throttles writes, checks idle state every 30s, and invokes a single `onTimeout` callback when idle for 30 minutes.
- Mounted the hook in the authenticated area in `src/components/MainLayout.tsx` so the timeout calls `useAuth().logout()`, navigates to `/login` with `replace`, and shows the Persian toast `نشست شما به دلیل عدم فعالیت منقضی شد. لطفاً دوباره وارد شوید.` without triggering duplicate logout/toast flows.
- Ensured storage changes in `src/lib/tokenStorage.ts` restrict web storage to `sessionStorage` only (refresh token + username) while keeping the access token memory-only and cleaning legacy `localStorage`/session keys; all web storage access is guarded for SSR and wrapped in try/catch.
- Added development-only diagnostics to `src/lib/axiosInstance.ts` around 401 and refresh failures (`console.warn`), without logging tokens, and left existing axios refresh logic intact.

### Testing
- Ran `npm run build` which completed successfully and produced the production build without TypeScript errors.
- Ran `npm run lint` which failed due to pre-existing unrelated lint errors and warnings in other files (errors reported in `src/contexts/AuthContext.tsx`, `src/contexts/ThemeContext.tsx`, `src/hooks/useDeleteFileSystem.ts`, `src/hooks/useFileSystems.ts`, `src/hooks/useSambaUserAccountFlags.ts` plus several hook dependency warnings), so lint did not pass end-to-end here.
- Manual verification checklist was not executed in this environment; the branch includes instructions to manually verify: `login`, refresh page to remain logged in, close/open tab requires login, remain active to avoid logout, and idle for 30 minutes to observe automatic logout (or set a shorter timeout in dev to test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a413e1018148327b0923e4148b8a99a)