### PR TITLE
Guard session activity writes to avoid resetting expired idle timeout

### DIFF
--- a/src/hooks/useSessionActivityTimeout.ts
+++ b/src/hooks/useSessionActivityTimeout.ts
@@ -70,9 +70,28 @@ export const useSessionActivityTimeout = ({
     let intervalId: number | null = null;
     let listenersActive = true;
 
-    const recordActivity = (timestamp = getCurrentTimestamp()) => {
+    const recordActivity = (timestamp: number) => {
       lastActivityWriteRef.current = timestamp;
       writeLastActivityAt(timestamp);
+    };
+
+    const isPastIdleTimeout = (
+      previousLastActivityAt: number,
+      timestamp: number
+    ) => timestamp - previousLastActivityAt >= SESSION_IDLE_TIMEOUT_MS;
+
+    const recordActivityUnlessTimedOut = (timestamp: number) => {
+      const previousLastActivityAt = readLastActivityAt();
+
+      if (
+        previousLastActivityAt !== null &&
+        isPastIdleTimeout(previousLastActivityAt, timestamp)
+      ) {
+        handleTimeout();
+        return;
+      }
+
+      recordActivity(timestamp);
     };
 
     const handleActivity = () => {
@@ -85,7 +104,7 @@ export const useSessionActivityTimeout = ({
         return;
       }
 
-      recordActivity(now);
+      recordActivityUnlessTimedOut(now);
     };
 
     const stopTracking = () => {
@@ -104,6 +123,7 @@ export const useSessionActivityTimeout = ({
       window.removeEventListener('touchstart', handleActivity);
       window.removeEventListener('pointerdown', handleActivity);
       window.removeEventListener('focus', handleActivity);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       listenersActive = false;
     };
 
@@ -124,19 +144,24 @@ export const useSessionActivityTimeout = ({
 
       const lastActivityAt = readLastActivityAt();
       const now = getCurrentTimestamp();
-      const effectiveLastActivityAt = lastActivityAt ?? now;
 
-      if (!lastActivityAt) {
+      if (lastActivityAt === null) {
         recordActivity(now);
         return;
       }
 
-      if (now - effectiveLastActivityAt >= SESSION_IDLE_TIMEOUT_MS) {
+      if (isPastIdleTimeout(lastActivityAt, now)) {
         handleTimeout();
       }
     };
 
-    recordActivity(getCurrentTimestamp());
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        checkIdleTimeout();
+      }
+    };
+
+    recordActivityUnlessTimedOut(getCurrentTimestamp());
 
     window.addEventListener('click', handleActivity);
     window.addEventListener('keydown', handleActivity);
@@ -144,6 +169,7 @@ export const useSessionActivityTimeout = ({
     window.addEventListener('touchstart', handleActivity, { passive: true });
     window.addEventListener('pointerdown', handleActivity, { passive: true });
     window.addEventListener('focus', handleActivity);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     intervalId = window.setInterval(
       checkIdleTimeout,


### PR DESCRIPTION
### Motivation
- Prevent user activity from refreshing the session after the stored last-activity timestamp has already exceeded the 30-minute idle timeout. 
- Ensure visibility transitions re-check idle state so reopened tabs do not accidentally revive expired sessions. 
- Preserve existing auth/token storage architecture and sessionStorage usage while making timeout behavior deterministic.

### Description
- Read the previous `sessionStorage` `auth:last-activity-at` timestamp before recording new activity and, if that previous timestamp has already passed the 30-minute threshold, call the timeout handler instead of writing a new timestamp. 
- Add `isPastIdleTimeout` and `recordActivityUnlessTimedOut` helpers and route all activity writes through this guard. 
- Add a `visibilitychange` listener to run an immediate `checkIdleTimeout` when the document becomes visible and clean it up alongside other listeners. 
- Keep the existing throttling, `sessionStorage`-only last-activity storage, and the 30-minute timeout semantics intact while cleaning up all listeners on teardown.

### Testing
- Ran the production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4140cdaf888327971e9ef9e16368c1)