### PR TITLE
Premium navigation shell redesign (sidebar + top bar)

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -178,64 +178,138 @@ const MainLayout: React.FC = () => {
         position="fixed"
         sx={{
           zIndex: (theme) => theme.zIndex.drawer + 1,
-          backgroundColor: 'var(--color-card-bg)',
-          backdropFilter: 'saturate(140%) blur(8px)',
+          background:
+            'linear-gradient(90deg, color-mix(in srgb, var(--color-card-bg) 94%, var(--color-primary) 6%), var(--color-card-bg))',
+          backdropFilter: 'saturate(155%) blur(14px)',
+          borderBottom:
+            '1px solid color-mix(in srgb, var(--color-input-border) 68%, transparent)',
           boxShadow: (theme) =>
-            `0 4px 20px ${
-              theme.palette.mode === 'dark' ? '#00000066' : '#00000022'
-            }`,
+            `0 14px 34px ${alpha(
+              theme.palette.common.black,
+              theme.palette.mode === 'dark' ? 0.24 : 0.08
+            )}, inset 0 -1px 0 ${alpha(theme.palette.common.white, 0.05)}`,
         }}
       >
         <Toolbar
           variant="dense"
           sx={{
-            gap: { xs: 1, sm: 3 },
-            // minHeight: '50px',
-            flexWrap: { xs: 'wrap', sm: 'nowrap' },
+            gap: { xs: 1, sm: 1.5 },
+            minHeight: { xs: 58, sm: 62 },
+            flexWrap: 'nowrap',
             alignItems: 'center',
             width: '100%',
+            px: { xs: 1, sm: 2 },
           }}
         >
-          <IconButton
-            onClick={() => setDrawerOpen((prev) => !prev)}
-            sx={{ color: 'var(--color-bg-primary)' }}
-          >
-            {drawerOpen ? <MdClose /> : <MdMenu />}
-          </IconButton>
-          <Box
-            component="img"
-            src="/logo/Logo.png"
-            alt="لوگو"
-            sx={{ height: 30 }}
-          />
-
-          <Typography
-            variant="h4"
-            component="div"
-            sx={{
-              color: 'var(--color-primary)',
-              flexShrink: 0,
-              fontFamily: 'var(--font-didot)',
-            }}
-          >
-            StoreX
-          </Typography>
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: { xs: 1, sm: 4 },
-              ml: 'auto',
-              order: { xs: 3, sm: 'initial' },
+              gap: { xs: 1, sm: 1.5 },
+              minWidth: 0,
             }}
           >
-            <NotificationBell userKey={notificationUserKey} />
+            <IconButton
+              aria-label={
+                drawerOpen ? 'بستن منوی کناری' : 'باز کردن منوی کناری'
+              }
+              onClick={() => setDrawerOpen((prev) => !prev)}
+              sx={{
+                color: 'var(--color-text)',
+                border:
+                  '1px solid color-mix(in srgb, var(--color-input-border) 62%, transparent)',
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-background) 54%, transparent)',
+                '&:hover': {
+                  backgroundColor:
+                    'color-mix(in srgb, var(--color-primary) 14%, transparent)',
+                },
+              }}
+            >
+              {drawerOpen ? <MdClose /> : <MdMenu />}
+            </IconButton>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                minWidth: 0,
+              }}
+            >
+              <Box
+                component="img"
+                src="/logo/Logo.png"
+                alt="لوگو"
+                sx={{
+                  height: 32,
+                  width: 32,
+                  objectFit: 'contain',
+                  filter: 'drop-shadow(0 8px 14px rgba(0,0,0,0.22))',
+                }}
+              />
+              <Box sx={{ minWidth: 0, display: { xs: 'none', sm: 'block' } }}>
+                <Typography
+                  variant="h5"
+                  component="div"
+                  sx={{
+                    color: 'var(--color-primary)',
+                    flexShrink: 0,
+                    fontFamily: 'var(--font-didot)',
+                    fontWeight: 900,
+                    lineHeight: 1,
+                  }}
+                >
+                  StoreX
+                </Typography>
+                <Typography
+                  component="div"
+                  sx={{
+                    color: 'var(--color-secondary)',
+                    fontSize: 11,
+                    letterSpacing: '.08em',
+                    lineHeight: 1.4,
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  SOHO Command Console
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: { xs: 0.75, sm: 1.25 },
+              ml: 'auto',
+              minWidth: 0,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                borderRadius: 999,
+                border:
+                  '1px solid color-mix(in srgb, var(--color-input-border) 54%, transparent)',
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-background) 48%, transparent)',
+              }}
+            >
+              <NotificationBell userKey={notificationUserKey} />
+            </Box>
             {isMobile ? (
               <IconButton
                 aria-label="منوی کاربر"
                 onClick={handleUserMenuOpen}
                 size="small"
-                sx={{ color: 'var(--color-bg-primary)' }}
+                sx={{
+                  color: 'var(--color-text)',
+                  border:
+                    '1px solid color-mix(in srgb, var(--color-input-border) 58%, transparent)',
+                  backgroundColor:
+                    'color-mix(in srgb, var(--color-background) 50%, transparent)',
+                }}
               >
                 <IoPersonCircleOutline size={24} />
               </IconButton>
@@ -244,34 +318,37 @@ const MainLayout: React.FC = () => {
                 onClick={handleUserMenuOpen}
                 endIcon={<IoPersonCircleOutline size={24} />}
                 sx={{
-                  color: 'var(--color-bg-primary)',
+                  color: 'var(--color-text)',
                   display: 'flex',
                   alignItems: 'center',
                   gap: 1,
                   px: 1.5,
-                  py: 0.75,
-                  borderRadius: 2,
+                  py: 0.7,
+                  borderRadius: 999,
                   fontFamily: 'var(--font-vazir)',
                   fontWeight: 500,
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                  border: '1px solid rgba(255, 255, 255, 0.12)',
+                  backgroundColor:
+                    'color-mix(in srgb, var(--color-background) 50%, transparent)',
+                  border:
+                    '1px solid color-mix(in srgb, var(--color-input-border) 58%, transparent)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
                   transition:
-                    'background-color 0.2s ease, border-color 0.2s ease',
+                    'background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease',
                   '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.12)',
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    backgroundColor:
+                      'color-mix(in srgb, var(--color-primary) 12%, transparent)',
+                    borderColor:
+                      'color-mix(in srgb, var(--color-primary) 38%, var(--color-input-border))',
+                    transform: 'translateY(-1px)',
                   },
                 }}
               >
                 <Typography
                   component="span"
                   sx={{
-                    fontSize: '0.9rem',
+                    fontSize: '0.82rem',
                     fontWeight: 400,
-                    color: (theme) =>
-                      theme.palette.mode === 'dark'
-                        ? 'rgba(255, 255, 255, 0.7)'
-                        : 'rgba(0, 0, 0, 0.7)',
+                    color: 'var(--color-secondary)',
                   }}
                 >
                   خوش آمدید،
@@ -279,11 +356,11 @@ const MainLayout: React.FC = () => {
                 <Typography
                   component="span"
                   sx={{
-                    fontSize: '1rem',
+                    fontSize: '0.95rem',
                     fontFamily: 'var(--font-didot)',
                     fontWeight: 900,
                     letterSpacing: '0.05em',
-                    color: 'var(--color-primary-light)',
+                    color: 'var(--color-primary)',
                   }}
                 >
                   {displayUsername}

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -9,29 +9,27 @@ import {
   ListItemText,
   Drawer as MuiDrawer,
   Toolbar,
+  Tooltip,
   Typography,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
 import type { CSSObject, Theme } from '@mui/material/styles';
-import { styled } from '@mui/material/styles';
-import React from 'react';
-import {
-  MdClose,
-  MdKeyboardArrowDown,
-  MdKeyboardArrowUp,
-} from 'react-icons/md';
-import { Link, useLocation } from 'react-router-dom';
+import { alpha, styled } from '@mui/material/styles';
 import type { MouseEvent } from 'react';
+import React, { useCallback } from 'react';
+import { MdClose, MdKeyboardArrowDown } from 'react-icons/md';
+import { Link, useLocation } from 'react-router-dom';
 import type {
   NavigationDrawerProps,
   NavigationItem,
 } from '../@types/navigationDrawer';
 import { drawerWidth, navItems } from '../constants/navigationDrawer';
 
+const getItemKey = (item: NavigationItem): string => item.path || item.text;
+
 const drawerPaperLayout = (theme: Theme): CSSObject => {
   const drawerOffset = theme.spacing(1);
-
   return {
     position: 'sticky',
     top: drawerOffset,
@@ -39,8 +37,12 @@ const drawerPaperLayout = (theme: Theme): CSSObject => {
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',
-    backgroundColor: 'var(--color-card-bg)',
-    backdropFilter: 'saturate(140%) blur(8px)',
+    background:
+      'linear-gradient(180deg, color-mix(in srgb, var(--color-card-bg) 96%, var(--color-primary) 4%) 0%, var(--color-card-bg) 50%, color-mix(in srgb, var(--color-background) 84%, var(--color-card-bg) 16%) 100%)',
+    backdropFilter: 'saturate(150%) blur(14px)',
+    borderRight:
+      '1px solid color-mix(in srgb, var(--color-input-border) 70%, transparent)',
+    boxShadow: `inset -1px 0 0 ${alpha(theme.palette.common.white, 0.05)}, inset 0 1px 0 ${alpha(theme.palette.common.white, 0.06)}, 14px 0 34px ${alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.24 : 0.08)}`,
     boxSizing: 'border-box' as const,
   };
 };
@@ -53,9 +55,6 @@ const openedMixin = (theme: Theme): CSSObject => ({
     duration: theme.transitions.duration.enteringScreen,
   }),
   overflowX: 'hidden',
-  // backgroundColor: 'var(--color-card-bg)',
-  // backdropFilter: 'saturate(140%) blur(8px)',
-  // boxSizing: 'border-box' as const,
 });
 
 const closedMixin = (theme: Theme): CSSObject => ({
@@ -65,13 +64,8 @@ const closedMixin = (theme: Theme): CSSObject => ({
     duration: theme.transitions.duration.leavingScreen,
   }),
   overflowX: 'hidden',
-  // backgroundColor: 'var(--color-card-bg)',
-  // backdropFilter: 'saturate(140%) blur(8px)',
-  // boxSizing: 'border-box' as const,
   width: `calc(${theme.spacing(7)} + 1px)`,
-  [theme.breakpoints.up('sm')]: {
-    width: `calc(${theme.spacing(8)} + 1px)`,
-  },
+  [theme.breakpoints.up('sm')]: { width: `calc(${theme.spacing(8)} + 1px)` },
 });
 
 const StyledDrawer = styled(MuiDrawer, {
@@ -89,10 +83,7 @@ const StyledDrawer = styled(MuiDrawer, {
     ...closedMixin(theme),
     '& .MuiDrawer-paper': closedMixin(theme),
   }),
-  '& .MuiDrawer-paper > .MuiList-root': {
-    flexGrow: 1,
-    // overflowY: 'auto',
-  },
+  '& .MuiDrawer-paper > .MuiList-root': { flexGrow: 1 },
 }));
 
 const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
@@ -106,208 +97,268 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
     Record<string, boolean>
   >({});
 
-  const handleItemClick = () => {
-    if (!isDesktop) {
-      onClose();
-    }
-  };
+  const handleItemClick = useCallback(() => {
+    if (!isDesktop) onClose();
+  }, [isDesktop, onClose]);
 
-  const isItemActive = (item: NavigationItem): boolean => {
-    const matchesCurrentPath =
-      location.pathname === item.path ||
-      location.pathname.startsWith(`${item.path}/`);
-
-    return (
-      matchesCurrentPath ||
-      (item.children?.some((child) => isItemActive(child)) ?? false)
-    );
-  };
+  const isItemActive = useCallback(
+    (item: NavigationItem): boolean => {
+      const matchesCurrentPath = Boolean(
+        item.path &&
+        (location.pathname === item.path ||
+          location.pathname.startsWith(`${item.path}/`))
+      );
+      return (
+        matchesCurrentPath ||
+        (item.children?.some((child) => isItemActive(child)) ?? false)
+      );
+    },
+    [location.pathname]
+  );
 
   React.useEffect(() => {
-  setExpandedItems((prev) => {
-    const next = { ...prev };
-
-    const ensureActiveParentsExpanded = (items: NavigationItem[]) => {
-      items.forEach((item) => {
-        if (item.children?.length) {
-          const itemKey = getItemKey(item); // استفاده از تابع getItemKey
-          if (isItemActive(item) && next[itemKey] === undefined) {
-            next[itemKey] = true;
+    setExpandedItems((prev) => {
+      const next = { ...prev };
+      const ensureActiveParentsExpanded = (items: NavigationItem[]) => {
+        items.forEach((item) => {
+          if (item.children?.length) {
+            const itemKey = getItemKey(item);
+            if (isItemActive(item) && next[itemKey] === undefined)
+              next[itemKey] = true;
+            ensureActiveParentsExpanded(item.children);
           }
-          ensureActiveParentsExpanded(item.children);
-        }
-      });
-    };
+        });
+      };
+      ensureActiveParentsExpanded(navItems);
+      return next;
+    });
+  }, [isItemActive]);
 
-    ensureActiveParentsExpanded(navItems);
-
-    return next;
-  });
-}, [location.pathname]);
-
-  const getItemKey = (item: NavigationItem): string => {
-    return item.path || item.text; // اگر path وجود داشت از آن استفاده کن، در غیر این صورت از text
-  };
+  const renderIdentity = () => (
+    <Box
+      sx={{
+        px: open ? 1.5 : 1,
+        py: 1.25,
+        mx: 1,
+        mb: 1,
+        mt: isDesktop ? 0 : 1,
+        borderRadius: 3,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: open ? 'flex-start' : 'center',
+        gap: 1.25,
+        background:
+          'linear-gradient(135deg, color-mix(in srgb, var(--color-primary) 16%, transparent), color-mix(in srgb, var(--color-secondary) 8%, transparent))',
+        border:
+          '1px solid color-mix(in srgb, var(--color-input-border) 58%, transparent)',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.08)',
+      }}
+    >
+      <Box
+        component="img"
+        src="/logo/Logo.png"
+        alt="SOHO"
+        sx={{
+          width: 34,
+          height: 34,
+          objectFit: 'contain',
+          filter: 'drop-shadow(0 8px 14px rgba(0,0,0,0.22))',
+        }}
+      />
+      {open && (
+        <Box sx={{ overflow: 'hidden' }}>
+          <Typography
+            sx={{
+              color: 'var(--color-text)',
+              fontFamily: 'var(--font-didot)',
+              fontSize: 20,
+              fontWeight: 900,
+              lineHeight: 1,
+            }}
+          >
+            SOHO
+          </Typography>
+          <Typography
+            sx={{
+              color: 'var(--color-secondary)',
+              fontSize: 11.5,
+              letterSpacing: '.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Storage Operations
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
 
   const renderNavItems = (
     items: NavigationItem[],
     depth = 0
   ): React.ReactNode => (
-    <List disablePadding={depth > 0} sx={{ pl: open && depth > 0 ? 2 : 0 }}>
+    <List
+      disablePadding={depth > 0}
+      sx={{
+        px: depth === 0 ? 0.75 : 0,
+        py: depth === 0 ? 0.5 : 0,
+        position: 'relative',
+        ...(open && depth > 0
+          ? {
+              ml: 2,
+              pl: 1.2,
+              '&::before': {
+                content: '""',
+                position: 'absolute',
+                top: 4,
+                bottom: 8,
+                left: 11,
+                width: 1,
+                background:
+                  'linear-gradient(180deg, transparent, var(--color-input-border), transparent)',
+              },
+            }
+          : {}),
+      }}
+    >
       {items.map((item) => {
         const itemKey = getItemKey(item);
         const isActive = isItemActive(item);
         const hasChildren = Boolean(item.children?.length);
-        const hasPath = item.path && item.path.length > 0;
+        const hasPath = Boolean(item.path);
         const isExpanded = hasChildren
-        ? (expandedItems[itemKey] ?? false)
-        : false;
-
+          ? (expandedItems[itemKey] ?? false)
+          : false;
+        const button = (
+          <ListItemButton
+            component={hasChildren ? 'div' : Link}
+            to={!hasChildren && hasPath ? item.path : undefined}
+            onClick={(
+              event: MouseEvent<HTMLAnchorElement | HTMLDivElement>
+            ) => {
+              if (hasChildren) {
+                event.preventDefault();
+                event.stopPropagation();
+                setExpandedItems((prev) => ({
+                  ...prev,
+                  [itemKey]: !(prev[itemKey] ?? false),
+                }));
+              } else if (hasPath) handleItemClick();
+            }}
+            selected={isActive}
+            sx={(theme) => ({
+              minHeight: depth > 0 ? 38 : 44,
+              position: 'relative',
+              overflow: 'hidden',
+              justifyContent: open ? 'initial' : 'center',
+              px: open ? 1.5 : 0,
+              mx: open ? 0.5 : 0.65,
+              my: 0.35,
+              borderRadius: 2.25,
+              color: 'var(--color-text)',
+              cursor: 'pointer',
+              transition: theme.transitions.create(
+                ['background-color', 'box-shadow', 'color', 'transform'],
+                {
+                  duration: theme.transitions.duration.shorter,
+                  easing: theme.transitions.easing.easeInOut,
+                }
+              ),
+              '&::before': {
+                content: '""',
+                position: 'absolute',
+                top: 7,
+                bottom: 7,
+                left: 0,
+                width: 3,
+                borderRadius: 6,
+                background:
+                  'linear-gradient(180deg, var(--color-primary), var(--color-secondary))',
+                opacity: 0,
+                boxShadow: '0 0 14px var(--color-primary)',
+              },
+              '&:hover': {
+                backgroundColor:
+                  'color-mix(in srgb, var(--color-primary) 10%, transparent)',
+                transform: open ? 'translateX(2px)' : 'none',
+              },
+              '&.Mui-selected': {
+                background:
+                  'linear-gradient(90deg, color-mix(in srgb, var(--color-primary) 24%, transparent), color-mix(in srgb, var(--color-secondary) 10%, transparent))',
+                boxShadow:
+                  'inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 30%, transparent)',
+                color: 'var(--color-text)',
+              },
+              '&.Mui-selected::before': { opacity: 1 },
+              '&.Mui-selected:hover': {
+                background:
+                  'linear-gradient(90deg, color-mix(in srgb, var(--color-primary) 28%, transparent), color-mix(in srgb, var(--color-secondary) 12%, transparent))',
+              },
+            })}
+          >
+            <ListItemIcon
+              sx={{
+                minWidth: 0,
+                mr: open ? 1.2 : 'auto',
+                justifyContent: 'center',
+                color: isActive
+                  ? 'var(--color-primary)'
+                  : 'var(--color-secondary)',
+                fontSize: depth > 0 ? 18 : 20,
+                transition: (theme) =>
+                  theme.transitions.create('color', {
+                    duration: theme.transitions.duration.shorter,
+                  }),
+              }}
+            >
+              {item.icon}
+            </ListItemIcon>
+            <ListItemText
+              primary={item.text}
+              sx={{
+                opacity: open ? 1 : 0,
+                zIndex: 1,
+                '& .MuiTypography-root': {
+                  fontFamily: 'var(--font-vazir)',
+                  fontSize: depth > 0 ? 13 : 14.5,
+                  fontWeight: isActive ? 800 : depth > 0 ? 500 : 650,
+                },
+              }}
+            />
+            {hasChildren && open && (
+              <Box
+                component="span"
+                sx={{
+                  display: 'flex',
+                  ml: 'auto',
+                  color: isActive
+                    ? 'var(--color-primary)'
+                    : 'var(--color-secondary)',
+                  transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                  transition: (theme) =>
+                    theme.transitions.create('transform', {
+                      duration: theme.transitions.duration.shorter,
+                    }),
+                }}
+              >
+                <MdKeyboardArrowDown />
+              </Box>
+            )}
+          </ListItemButton>
+        );
         return (
           <React.Fragment key={`${item.text}-${itemKey}`}>
             <ListItem disablePadding sx={{ display: 'block' }}>
-              <ListItemButton
-                component={hasChildren ? 'div' : Link}
-                to={!hasChildren && hasPath ? item.path : undefined}
-                onClick={(event: MouseEvent<HTMLAnchorElement | HTMLDivElement>) => {
-                if (hasChildren) {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  setExpandedItems((prev) => ({
-                    ...prev,
-                    [itemKey]: !(prev[itemKey] ?? false),
-                  }));
-                } else if (hasPath) {
-                  handleItemClick();
-                }
-              }}
-              selected={isActive}
-                sx={(theme) => ({
-                  position: 'relative',
-                  overflow: 'hidden',
-                  color: 'var(--color-bg-primary)',
-                  justifyContent: open ? 'initial' : 'center',
-                  px: 2.5,
-                  mx: 1,
-                  my: 0.25,
-                  transform: 'translateX(0)',
-                  borderRadius: 1.5,
-                  transition: theme.transitions.create(['color', 'transform'], {
-                    duration: theme.transitions.duration.shorter,
-                    easing: theme.transitions.easing.easeInOut,
-                  }),
-                  ...(depth > 0 && open
-                    ? {
-                        pl: 2.5 + depth * 2,
-                      }
-                    : {}),
-                  '&::before': {
-                    content: '""',
-                    position: 'absolute',
-                    inset: theme.spacing(0.5),
-                    borderRadius: 1.5,
-                    backgroundColor: 'var(--color-primary)',
-                    transform: 'scaleX(0)',
-                    transformOrigin: 'left center',
-                    transition: theme.transitions.create(
-                      ['transform', 'opacity'],
-                      {
-                        duration: theme.transitions.duration.standard,
-                        easing: theme.transitions.easing.easeInOut,
-                      }
-                    ),
-                    opacity: 0,
-                    zIndex: -1,
-                  },
-                  '&:hover::before': {
-                    transform: 'scaleX(1)',
-                    opacity: 1,
-                  },
-                  '&.Mui-selected::before': {
-                    transform: 'scaleX(1)',
-                    opacity: 1,
-                  },
-                  '&:hover': {
-                    color: 'var(--color-card-bg)',
-                    transform: 'translateX(2px)',
-                    '& .MuiListItemIcon-root': {
-                      color: 'var(--color-card-bg)',
-                    },
-                  },
-                  '&.Mui-selected': {
-                    backgroundColor: 'transparent',
-                    color: 'var(--color-card-bg)',
-                    '& .MuiListItemIcon-root': {
-                      color: 'var(--color-card-bg)',
-                    },
-                  },
-                  '&.Mui-selected:hover': {
-                    backgroundColor: 'transparent',
-                    transform: 'translateX(2px)',
-                  },
-                  // اضافه کردن cursor pointer برای آیتم‌های دارای زیرمنو
-                  cursor:  'pointer',
-                })}
-              >
-                <ListItemIcon
-                  sx={(theme) => ({
-                    minWidth: 0,
-                    mr: open ? 1 : 'auto',
-                    justifyContent: 'center',
-                    color: 'var(--color-bg-primary)',
-                    transition: theme.transitions.create('color', {
-                      duration: theme.transitions.duration.shorter,
-                      easing: theme.transitions.easing.easeInOut,
-                    }),
-                    zIndex: 1,
-                  })}
-                >
-                  {item.icon}
-                </ListItemIcon>
-                <ListItemText
-                  primary={item.text}
-                  sx={{
-                    opacity: open ? 1 : 0,
-                    zIndex: 1,
-                    transition: (theme) =>
-                      theme.transitions.create('opacity', {
-                        duration: theme.transitions.duration.shorter,
-                        easing: theme.transitions.easing.easeInOut,
-                      }),
-                  }}
-                  primaryTypographyProps={{
-                    sx: { fontFamily: 'var(--font-vazir)' },
-                  }}
-                />
-                {hasChildren && open && (
-                  <Box
-                    component="span"
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      ml: 'auto',
-                      color: 'var(--color-bg-primary)',
-                      backgroundColor: 'var(--color-input-border)',
-                      borderRadius: '9999px',
-                      p: 0.25,
-                    }}
-                  >
-                    {isExpanded ? (
-                      <MdKeyboardArrowUp />
-                    ) : (
-                      <MdKeyboardArrowDown />
-                    )}
-                  </Box>
-                )}
-              </ListItemButton>
+              {open ? (
+                button
+              ) : (
+                <Tooltip title={item.text} placement="right" arrow>
+                  {button}
+                </Tooltip>
+              )}
             </ListItem>
             {item.children && (
-              <Collapse
-                in={isExpanded}
-                timeout="auto"
-                unmountOnExit
-                sx={{ ml: -2 }}
-              >
+              <Collapse in={isExpanded && open} timeout="auto" unmountOnExit>
                 {renderNavItems(item.children, depth + 1)}
               </Collapse>
             )}
@@ -333,13 +384,11 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
         }}
       >
         <Toolbar variant="dense" sx={{ justifyContent: 'space-between' }}>
-          <IconButton
-            onClick={onClose}
-            sx={{ color: 'var(--color-bg-primary)' }}
-          >
+          <IconButton onClick={onClose} sx={{ color: 'var(--color-text)' }}>
             <MdClose />
           </IconButton>
         </Toolbar>
+        {renderIdentity()}
         {renderNavItems(navItems)}
       </MuiDrawer>
     );
@@ -347,26 +396,16 @@ const NavigationDrawer: React.FC<NavigationDrawerProps> = ({
 
   return (
     <StyledDrawer variant="permanent" open={open}>
-      <Toolbar
-        variant="dense"
-        sx={{ justifyContent: open ? 'flex-end' : 'center' }}
-      >
-        {/*{open && (*/}
-        {/*  <IconButton*/}
-        {/*    onClick={onClose}*/}
-        {/*    sx={{ color: 'var(--color-bg-primary)' }}*/}
-        {/*  >*/}
-        {/*    <MdClose />*/}
-        {/*  </IconButton>*/}
-        {/*)}*/}
-      </Toolbar>
+      <Toolbar variant="dense" sx={{ minHeight: 52 }} />
+      {renderIdentity()}
       {renderNavItems(navItems)}
       <Typography
         variant="h6"
         color="var(--color-secondary)"
         sx={{
-          fontSize: 15,
-          pb: 1,
+          fontSize: 13,
+          pb: 1.5,
+          mt: 'auto',
           textAlign: 'center',
           visibility: open ? 'visible' : 'hidden',
         }}

--- a/src/constants/navigationDrawer.ts
+++ b/src/constants/navigationDrawer.ts
@@ -1,16 +1,19 @@
 import { createElement } from 'react';
 // import { BiHistory } from 'react-icons/bi';
-import { BsFillShareFill } from "react-icons/bs";
+import { BsFillShareFill } from 'react-icons/bs';
 // import { FiUsers } from 'react-icons/fi';
 import { GrServices, GrStorage } from 'react-icons/gr';
-import { MdOutlineSdStorage, MdSpaceDashboard, MdStorage } from 'react-icons/md';
+import {
+  MdFolderShared,
+  MdOutlineSdStorage,
+  MdSpaceDashboard,
+  MdStorage,
+} from 'react-icons/md';
 import { RiSettings3Fill } from 'react-icons/ri';
-import { TbHeartRateMonitor } from "react-icons/tb";
-import { MdFolderShared } from "react-icons/md";
+import { TbHeartRateMonitor } from 'react-icons/tb';
 import type { NavigationItem } from '../@types/navigationDrawer';
 
-
-export const drawerWidth = 210;
+export const drawerWidth = 250;
 
 export const navItems: NavigationItem[] = [
   {
@@ -38,23 +41,36 @@ export const navItems: NavigationItem[] = [
     icon: createElement(MdStorage),
     path: '/file-system',
   },
-  { text: 'اشتراک گذاری',
+  {
+    text: 'اشتراک گذاری',
     icon: createElement(BsFillShareFill),
     // path: '/share',
-    children:[
-      {text:"SMB" , icon:createElement(BsFillShareFill), path:"/share"},
-      {text:"NFS" , icon:createElement(MdFolderShared), path:"/share-nfs"},
-      {text:"Web Share" , icon:createElement(MdFolderShared), path:"/web-share"},
-    ] 
+    children: [
+      { text: 'SMB', icon: createElement(BsFillShareFill), path: '/share' },
+      { text: 'NFS', icon: createElement(MdFolderShared), path: '/share-nfs' },
+      {
+        text: 'Web Share',
+        icon: createElement(MdFolderShared),
+        path: '/web-share',
+      },
+    ],
   },
   {
     text: 'سرویس ها',
     icon: createElement(GrServices),
     // path: '/',
-    children:[
-      {text:'سرویس ها' , icon:createElement(TbHeartRateMonitor), path:"/services"},
-      {text:"سرویس SNMP" , icon:createElement(TbHeartRateMonitor), path:"/snmp-service"}
-    ]
+    children: [
+      {
+        text: 'سرویس ها',
+        icon: createElement(TbHeartRateMonitor),
+        path: '/services',
+      },
+      {
+        text: 'سرویس SNMP',
+        icon: createElement(TbHeartRateMonitor),
+        path: '/snmp-service',
+      },
+    ],
   },
 
   {


### PR DESCRIPTION
### Motivation
- Upgrade the app shell to a premium, enterprise-grade navigation and top bar while preserving existing behavior, routes, and business logic. 
- Make the drawer feel more intentional, technical and polished while keeping RTL/Persian labels and responsive/collapsed behavior intact.

### Description
- Redesigned the left navigation drawer surface to a glass/dark-panel style with subtle border, inner glow and depth using existing CSS variables; added stronger active indicator and smoother hover/expand states. (changed: `src/components/NavigationDrawer.tsx`)
- Added compact branding identity block at the top of the drawer showing logo, product title `SOHO` and subtitle `Storage Operations`, with a compact icon-only view when collapsed. (changed: `src/components/NavigationDrawer.tsx`)
- Improved navigation grouping visuals: nested rail/connector for children, clearer parent/child indentation, expand/collapse rotation animation and tooltip support in collapsed mode while preserving all existing nav items. (changed: `src/components/NavigationDrawer.tsx`, `src/constants/navigationDrawer.ts`)
- Increased `drawerWidth` from 210 to 250 (kept under 260px) to accommodate the refined layout; otherwise preserved nav data structure and routes. (changed: `src/constants/navigationDrawer.ts`)
- Refined the top AppBar in `MainLayout` to visually match the drawer: grouped drawer toggle + identity on the left, notification cluster and user/profile controls on the right, improved spacing and styling while keeping notification, session timeout, logout and power actions untouched. (changed: `src/components/MainLayout.tsx`)
- Small code quality fixes: addressed a hook dependency/lint pattern in `NavigationDrawer` by wrapping `isItemActive`/`handleItemClick` in `useCallback` and cleaned up obsolete commented code. (changed: `src/components/NavigationDrawer.tsx`)

### Testing
- `npm run build` — succeeded (production build completed).
- `npm run lint` — failed due to pre-existing/unrelated lint errors in other files (did not come from changed files); notable lint failures live outside the changed files (examples: `src/contexts/AuthContext.tsx`, `src/contexts/ThemeContext.tsx`, various hooks). 

Files changed: `src/components/NavigationDrawer.tsx`, `src/components/MainLayout.tsx`, `src/constants/navigationDrawer.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a414320df108327932e66698b95f141)