### PR TITLE
Add resource status change notifications

### DIFF
--- a/src/@types/notification.ts
+++ b/src/@types/notification.ts
@@ -1,6 +1,9 @@
 export type LocalNotificationSeverity = 'info' | 'warning' | 'critical';
 
-export type LocalNotificationSource = 'startup-capacity-check' | 'user-action';
+export type LocalNotificationSource =
+  | 'startup-capacity-check'
+  | 'resource-status-change-check'
+  | 'user-action';
 
 export type LocalNotificationEntityType =
   | 'pool'

--- a/src/components/notifications/NotificationBootstrapper.tsx
+++ b/src/components/notifications/NotificationBootstrapper.tsx
@@ -1,3 +1,4 @@
+import { useResourceStatusChangeNotifications } from '../../hooks/useResourceStatusChangeNotifications';
 import { useStartupNotificationChecks } from '../../hooks/useStartupNotificationChecks';
 
 type NotificationBootstrapperProps = {
@@ -6,6 +7,7 @@ type NotificationBootstrapperProps = {
 
 const NotificationBootstrapper = ({ userKey }: NotificationBootstrapperProps) => {
   useStartupNotificationChecks(userKey);
+  useResourceStatusChangeNotifications(userKey);
 
   return null;
 };

--- a/src/hooks/useResourceStatusChangeNotifications.ts
+++ b/src/hooks/useResourceStatusChangeNotifications.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DiskDevice } from '../@types/disk';
+import type { ZpoolCapacityEntry } from '../@types/zpool';
+import { cleanupExpiredNotifications, upsertNotification } from '../utils/notificationStorage';
+import {
+  createResourceStatusChangeNotification,
+  normalizeResourceStatus,
+  type ResourceStatusSnapshotItem,
+} from '../utils/notificationStatusRules';
+import {
+  loadResourceStatusSnapshot,
+  saveResourceStatusSnapshot,
+} from '../utils/resourceStatusSnapshotStorage';
+import { useDisk } from './useDisk';
+import { useZpool } from './useZpool';
+
+const POOL_STATUS_FIELDS = ['health', 'status', 'state', 'وضعیت'] as const;
+const DISK_NAME_DETAIL_FIELDS = ['disk', 'name', 'device_path'] as const;
+const DISK_STATUS_FIELDS = ['state', 'status', 'health', 'وضعیت'] as const;
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const getRecordValue = (record: Record<string, unknown> | undefined, keys: readonly string[]) => {
+  if (record == null) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      return record[key];
+    }
+  }
+
+  return undefined;
+};
+
+const normalizeName = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+};
+
+const resolvePoolStatus = (pool: ZpoolCapacityEntry) =>
+  normalizeResourceStatus(pool.health) ?? normalizeResourceStatus(getRecordValue(pool.raw, POOL_STATUS_FIELDS));
+
+const createPoolSnapshotItem = (pool: ZpoolCapacityEntry): ResourceStatusSnapshotItem | null => {
+  const entityName = normalizeName(pool.name);
+  const status = resolvePoolStatus(pool);
+
+  if (entityName == null || status == null) {
+    return null;
+  }
+
+  return {
+    entityType: 'pool',
+    entityId: entityName,
+    entityName,
+    status,
+  };
+};
+
+const resolveDiskName = (disk: DiskDevice, index: number) =>
+  normalizeName(disk.device) ??
+  normalizeName(getRecordValue(disk.details, DISK_NAME_DETAIL_FIELDS)) ??
+  `Disk #${index + 1}`;
+
+const resolveDiskStatus = (disk: DiskDevice) =>
+  normalizeResourceStatus(getRecordValue(disk.details, DISK_STATUS_FIELDS)) ??
+  normalizeResourceStatus(getRecordValue(disk as unknown as Record<string, unknown>, DISK_STATUS_FIELDS));
+
+const createDiskSnapshotItem = (disk: DiskDevice, index: number): ResourceStatusSnapshotItem | null => {
+  const entityName = resolveDiskName(disk, index);
+  const status = resolveDiskStatus(disk);
+
+  if (status == null) {
+    return null;
+  }
+
+  const entityId =
+    normalizeName(disk.details?.wwn) ??
+    normalizeName(disk.details?.wwid) ??
+    entityName;
+
+  return {
+    entityType: 'disk',
+    entityId,
+    entityName,
+    status,
+  };
+};
+
+const createSnapshotSignature = (items: ResourceStatusSnapshotItem[], userKey?: string) =>
+  JSON.stringify({
+    userKey: userKey || 'default',
+    items: items.map((item) => [item.entityType, item.entityId, item.entityName, item.status]),
+  });
+
+type ResourceStatusChangeNotificationsResult = {
+  isChecking: boolean;
+  lastCheckAt: string | null;
+  error: Error | null;
+};
+
+export const useResourceStatusChangeNotifications = (
+  userKey?: string,
+): ResourceStatusChangeNotificationsResult => {
+  const zpoolQuery = useZpool();
+  const diskQuery = useDisk();
+  const [isChecking, setIsChecking] = useState(false);
+  const [lastCheckAt, setLastCheckAt] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const checkedDataSignatureRef = useRef<string | null>(null);
+
+  const buildCurrentSnapshot = useCallback(() => {
+    const poolItems = zpoolQuery.data?.pools
+      .map(createPoolSnapshotItem)
+      .filter((item): item is ResourceStatusSnapshotItem => item != null) ?? [];
+    const diskItems = diskQuery.data?.disks
+      .map(createDiskSnapshotItem)
+      .filter((item): item is ResourceStatusSnapshotItem => item != null) ?? [];
+
+    return [...poolItems, ...diskItems];
+  }, [diskQuery.data, zpoolQuery.data]);
+
+  const runStatusChangeChecks = useCallback(() => {
+    if (!isBrowser()) {
+      return;
+    }
+
+    setIsChecking(true);
+    setError(null);
+
+    try {
+      const currentSnapshotItems = buildCurrentSnapshot();
+      const previousSnapshot = loadResourceStatusSnapshot(userKey);
+
+      if (previousSnapshot == null) {
+        saveResourceStatusSnapshot(currentSnapshotItems, userKey);
+        setLastCheckAt(new Date().toISOString());
+        return;
+      }
+
+      const previousItemByKey = new Map(
+        previousSnapshot.items.map((item) => [`${item.entityType}:${item.entityId}`, item]),
+      );
+
+      cleanupExpiredNotifications(userKey);
+      let generatedCount = 0;
+
+      currentSnapshotItems.forEach((currentItem) => {
+        const previousItem = previousItemByKey.get(`${currentItem.entityType}:${currentItem.entityId}`);
+
+        if (previousItem == null || previousItem.status === currentItem.status) {
+          return;
+        }
+
+        upsertNotification(
+          createResourceStatusChangeNotification({
+            entityType: currentItem.entityType,
+            entityId: currentItem.entityId,
+            entityName: currentItem.entityName,
+            previousStatus: previousItem.status,
+            currentStatus: currentItem.status,
+          }),
+          userKey,
+        );
+        generatedCount += 1;
+      });
+
+      saveResourceStatusSnapshot(currentSnapshotItems, userKey);
+      setLastCheckAt(new Date().toISOString());
+
+      if (generatedCount > 0) {
+        window.dispatchEvent(
+          new CustomEvent('soho:notifications:status-change-summary', {
+            detail: {
+              count: generatedCount,
+              message: 'چند تغییر وضعیت در منابع سامانه شناسایی شد.',
+            },
+          }),
+        );
+      }
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError : new Error('Resource status notification check failed'));
+    } finally {
+      setIsChecking(false);
+    }
+  }, [buildCurrentSnapshot, userKey]);
+
+  useEffect(() => {
+    if (!zpoolQuery.isSuccess || !diskQuery.isSuccess || zpoolQuery.data == null || diskQuery.data == null) {
+      return;
+    }
+
+    const currentSnapshotItems = buildCurrentSnapshot();
+    const dataSignature = createSnapshotSignature(currentSnapshotItems, userKey);
+
+    if (checkedDataSignatureRef.current === dataSignature) {
+      return;
+    }
+
+    checkedDataSignatureRef.current = dataSignature;
+    runStatusChangeChecks();
+  }, [buildCurrentSnapshot, diskQuery.data, diskQuery.isSuccess, runStatusChangeChecks, zpoolQuery.data, zpoolQuery.isSuccess]);
+
+  return { isChecking, lastCheckAt, error };
+};

--- a/src/utils/notificationStatusRules.ts
+++ b/src/utils/notificationStatusRules.ts
@@ -1,0 +1,101 @@
+import type { LocalNotificationSeverity } from '../@types/notification';
+import type { UpsertLocalNotificationInput } from './notificationStorage';
+
+export type ResourceStatusEntityType = 'pool' | 'disk';
+
+export interface ResourceStatusSnapshotItem {
+  entityType: ResourceStatusEntityType;
+  entityId: string;
+  entityName: string;
+  status: string;
+}
+
+export interface ResourceStatusChange {
+  entityType: ResourceStatusEntityType;
+  entityId: string;
+  entityName: string;
+  previousStatus: string;
+  currentStatus: string;
+}
+
+const EMPTY_STATUS_VALUES = new Set(['', '-', 'UNKNOWN', 'N/A', 'NULL']);
+const HEALTHY_STATUSES = new Set(['ONLINE', 'OK', 'HEALTHY', 'AVAILABLE', 'ACTIVE', 'READY']);
+const WARNING_STATUSES = new Set(['DEGRADED', 'WARNING', 'WARN', 'REMOVED', 'SUSPENDED']);
+const CRITICAL_STATUSES = new Set([
+  'FAULTED',
+  'FAILED',
+  'FAIL',
+  'OFFLINE',
+  'UNAVAIL',
+  'UNAVAILABLE',
+  'ERROR',
+  'CRITICAL',
+]);
+
+export const normalizeResourceStatus = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalizedValue = value.trim().toUpperCase();
+  return EMPTY_STATUS_VALUES.has(normalizedValue) ? null : normalizedValue;
+};
+
+export const resolveStatusSeverity = (
+  _previousStatus: string,
+  currentStatus: string,
+): LocalNotificationSeverity => {
+  const normalizedCurrentStatus = normalizeResourceStatus(currentStatus) ?? currentStatus.trim().toUpperCase();
+
+  if (HEALTHY_STATUSES.has(normalizedCurrentStatus)) {
+    return 'info';
+  }
+
+  if (CRITICAL_STATUSES.has(normalizedCurrentStatus)) {
+    return 'critical';
+  }
+
+  if (WARNING_STATUSES.has(normalizedCurrentStatus)) {
+    return 'warning';
+  }
+
+  return 'warning';
+};
+
+const resolveStatusTitle = (severity: LocalNotificationSeverity) => {
+  if (severity === 'info') {
+    return 'بازگشت وضعیت به حالت عادی';
+  }
+
+  if (severity === 'critical') {
+    return 'تغییر وضعیت بحرانی';
+  }
+
+  return 'تغییر وضعیت هشدارآمیز';
+};
+
+const resolveEntityLabel = (entityType: ResourceStatusEntityType) =>
+  entityType === 'pool' ? 'Pool' : 'دیسک';
+
+export const createResourceStatusChangeNotification = (
+  change: ResourceStatusChange,
+): UpsertLocalNotificationInput => {
+  const severity = resolveStatusSeverity(change.previousStatus, change.currentStatus);
+  const detectedAt = new Date().toISOString();
+
+  return {
+    fingerprint: `status-change:${change.entityType}:${change.entityId}:${change.previousStatus}->${change.currentStatus}`,
+    title: resolveStatusTitle(severity),
+    message: `وضعیت ${resolveEntityLabel(change.entityType)} «${change.entityName}» از «${change.previousStatus}» به «${change.currentStatus}» تغییر کرد.`,
+    severity,
+    source: 'resource-status-change-check',
+    entityType: change.entityType,
+    entityId: change.entityId,
+    metadata: {
+      previousStatus: change.previousStatus,
+      currentStatus: change.currentStatus,
+      entityName: change.entityName,
+      detectedAt,
+    },
+  };
+};

--- a/src/utils/notificationStorage.ts
+++ b/src/utils/notificationStorage.ts
@@ -26,7 +26,9 @@ const isValidNotification = (notification: StoredNotification): notification is 
   (notification.severity === 'info' ||
     notification.severity === 'warning' ||
     notification.severity === 'critical') &&
-  (notification.source === 'startup-capacity-check' || notification.source === 'user-action') &&
+  (notification.source === 'startup-capacity-check' ||
+    notification.source === 'resource-status-change-check' ||
+    notification.source === 'user-action') &&
   typeof notification.createdAt === 'string' &&
   typeof notification.updatedAt === 'string' &&
   typeof notification.expiresAt === 'string' &&

--- a/src/utils/resourceStatusSnapshotStorage.ts
+++ b/src/utils/resourceStatusSnapshotStorage.ts
@@ -1,0 +1,96 @@
+import type { ResourceStatusSnapshotItem } from './notificationStatusRules';
+
+const RESOURCE_STATUS_SNAPSHOT_KEY_PREFIX = 'soho:notifications:resource-status-snapshot';
+
+interface ResourceStatusSnapshotStorageValue {
+  version: 1;
+  updatedAt: string;
+  items: ResourceStatusSnapshotItem[];
+}
+
+const isBrowser = () => typeof window !== 'undefined';
+
+export const getResourceStatusSnapshotStorageKey = (userKey?: string) =>
+  `${RESOURCE_STATUS_SNAPSHOT_KEY_PREFIX}:${userKey || 'default'}`;
+
+const isValidSnapshotItem = (item: unknown): item is ResourceStatusSnapshotItem => {
+  if (item == null || typeof item !== 'object') {
+    return false;
+  }
+
+  const candidate = item as Partial<ResourceStatusSnapshotItem>;
+  return (
+    (candidate.entityType === 'pool' || candidate.entityType === 'disk') &&
+    typeof candidate.entityId === 'string' &&
+    candidate.entityId.trim().length > 0 &&
+    typeof candidate.entityName === 'string' &&
+    candidate.entityName.trim().length > 0 &&
+    typeof candidate.status === 'string' &&
+    candidate.status.trim().length > 0
+  );
+};
+
+const isValidSnapshotValue = (value: unknown): value is ResourceStatusSnapshotStorageValue => {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<ResourceStatusSnapshotStorageValue>;
+  return (
+    candidate.version === 1 &&
+    typeof candidate.updatedAt === 'string' &&
+    !Number.isNaN(new Date(candidate.updatedAt).getTime()) &&
+    Array.isArray(candidate.items) &&
+    candidate.items.every(isValidSnapshotItem)
+  );
+};
+
+export const loadResourceStatusSnapshot = (
+  userKey?: string,
+): ResourceStatusSnapshotStorageValue | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const storageKey = getResourceStatusSnapshotStorageKey(userKey);
+
+  try {
+    const storedValue = window.localStorage.getItem(storageKey);
+    if (!storedValue) {
+      return null;
+    }
+
+    const parsedValue: unknown = JSON.parse(storedValue);
+    if (!isValidSnapshotValue(parsedValue)) {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    return parsedValue;
+  } catch {
+    window.localStorage.removeItem(storageKey);
+    return null;
+  }
+};
+
+export const saveResourceStatusSnapshot = (
+  items: ResourceStatusSnapshotItem[],
+  userKey?: string,
+): ResourceStatusSnapshotStorageValue | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  const snapshot: ResourceStatusSnapshotStorageValue = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    items,
+  };
+
+  try {
+    window.localStorage.setItem(getResourceStatusSnapshotStorageKey(userKey), JSON.stringify(snapshot));
+    return snapshot;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
### Motivation
- Detect and notify users in the frontend whenever the `وضعیت` / status of pools or disks changes so users receive precise transition alerts without changing backend APIs.
- Reuse existing `useZpool` and `useDisk` hooks and the current local notification store so capacity notifications and `NotificationBell` behavior remain unchanged.
- Avoid duplicate or spammy alerts by persisting a snapshot of last-seen statuses per user and only notifying on real transitions.

### Description
- Added `resource-status-change-check` to `LocalNotificationSource` and updated notification validation to accept the new source in `src/@types/notification.ts` and `src/utils/notificationStorage.ts`.
- Implemented status rules and notification creation in `src/utils/notificationStatusRules.ts`, including `normalizeResourceStatus`, `resolveStatusSeverity`, Persian titles/messages, and transition-based fingerprinting `status-change:${entityType}:${entityId}:${previousStatus}->${currentStatus}`.
- Added local snapshot persistence in `src/utils/resourceStatusSnapshotStorage.ts` using `localStorage` with key `soho:notifications:resource-status-snapshot:<userKey>` and robust validation/cleanup guards.
- Added `useResourceStatusChangeNotifications` hook in `src/hooks/useResourceStatusChangeNotifications.ts` that uses `useZpool` and `useDisk`, builds and compares snapshots, cleans expired notifications, upserts status-change notifications on transitions, and dispatches the `soho:notifications:status-change-summary` event; the hook is integrated into `NotificationBootstrapper` in `src/components/notifications/NotificationBootstrapper.tsx`.

### Testing
- Ran `npm run build` and the build completed successfully (`vite` production build succeeded). 
- Ran `npm run lint` and linting failed due to pre-existing repository lint errors unrelated to these changes (existing `react-refresh/only-export-components`, `@typescript-eslint/no-explicit-any`, and other issues). 
- Files changed: `src/@types/notification.ts`, `src/components/notifications/NotificationBootstrapper.tsx`, `src/utils/notificationStorage.ts`, and added `src/hooks/useResourceStatusChangeNotifications.ts`, `src/utils/notificationStatusRules.ts`, `src/utils/resourceStatusSnapshotStorage.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4227b9b0b08327a91a8a949f64bbfd)