### PR TITLE
docs: establish SOHO documentation foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,114 @@
-## PreInstallation
+# SOHO UI
 
-- ابتدا باید کتابخانه curl را برای انتقال داده نصب کنیم
+SOHO UI is the React/TypeScript administrative frontend for the StoreX storage management system.
 
-```shell
+It provides authenticated operators with interfaces for monitoring system health and managing storage pools, disks, filesystems, block storage, shares, users, services, settings, SNMP, and related system operations.
+
+## Documentation
+
+The maintained engineering documentation starts at:
+
+- [`docs/index.md`](./docs/index.md) — documentation map and reading order
+- [`docs/01-overview/project-overview.md`](./docs/01-overview/project-overview.md) — system purpose, scope, and major runtime contracts
+- [`docs/02-architecture/frontend-architecture.md`](./docs/02-architecture/frontend-architecture.md) — frontend architecture and ownership boundaries
+- [`docs/03-development/project-structure.md`](./docs/03-development/project-structure.md) — repository navigation and change entry points
+- [`docs/03-development/code-commenting-guidelines.md`](./docs/03-development/code-commenting-guidelines.md) — Clean Code rules for useful source comments
+
+Existing detailed runtime notes are preserved under `docs/`, including state synchronization, API polling, notifications/data refresh, and general settings.
+
+## Tech stack
+
+Core technologies include React 19, TypeScript, Vite, React Router, TanStack React Query, Axios, Material UI, Zustand, React Hook Form, Zod, Tailwind CSS, and Three.js/React Three Fiber.
+
+See `package.json` for the exact dependency versions.
+
+## Prerequisites
+
+Use a supported Node.js LTS release with npm.
+
+On Debian/Ubuntu systems, one way to install Node.js through NodeSource is:
+
+```bash
 sudo apt install -y curl software-properties-common
-```
-
-- بعد از آن باید مخزن NodeSource را مطابق ورژن مورد نیاز اضافه کنیم (این کد آخرین ورژن LTS را اضافه میکند)
-
-```shell
 curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+sudo apt install -y nodejs
 ```
 
-- سپس باید ماژول مدیریت بسته های `Node.js` و `NPM` را نصب نماییم
+Verify the installation:
 
-```shell
-sudo apt install -y nodejs
+```bash
+node --version
+npm --version
 ```
 
 ## Installation
 
-- در این مرحله ابتدا باید dependencies های پروژه را نصب نمایم
+Install project dependencies from the repository root:
 
-```shell
-npm i
+```bash
+npm install
 ```
 
-- و سپس پروژه را شروع میکنیم
+## Environment configuration
 
-```shell
-npm run dev -- --host --port 5173
+The frontend reads its backend base URL from Vite environment configuration:
+
+```env
+VITE_API_BASE_URL=https://your-backend.example.com
 ```
 
-## Deploy
+The codebase also supports development-oriented flags such as mock API mode and an explicit development auth bypass. Do not enable development bypass behavior in production configuration.
 
-- در این مرحله ابتدا باید پروژه را build کنیم تا فولدر dist/ در ریپازیتوری پروژه ایجاد گردد
+## Development
 
-```shell
+Start the Vite development server:
+
+```bash
+npm run dev
+```
+
+The Vite configuration currently binds the dev server to `0.0.0.0:5173`.
+
+## Quality checks
+
+Run ESLint:
+
+```bash
+npm run lint
+```
+
+A dedicated automated test script is not currently defined in `package.json`. Do not treat a successful build as a substitute for future test coverage.
+
+## Production build
+
+Create a production bundle:
+
+```bash
 npm run build
 ```
 
-- سپس باید که آدرس فولدر dist/ را به Nginx یا هر وب سرور دیگری بدهیم تا بتوانیم پروژه را مشاهده کنیم
+The build script runs TypeScript project compilation and then Vite build. The generated static output is written to `dist/`.
+
+Preview the production bundle locally with Vite:
+
+```bash
+npm run preview
+```
+
+## Deployment model
+
+This repository builds to static frontend assets. A production web server such as Nginx should serve the generated `dist/` directory.
+
+Deployment-specific server configuration belongs in operations documentation rather than application source code.
+
+## Important maintenance contracts
+
+Before modifying authentication, Axios interceptors, token storage, React Query global defaults, state persistence, or polling behavior, read the corresponding documents under `docs/`.
+
+In particular, normal API requests and mutations do not own database snapshot persistence. Canonical persisted snapshots are coordinated by `StateSyncManager`; see [`docs/state-sync-save-to-db.md`](./docs/state-sync-save-to-db.md).
+
+## Source comments
+
+Source comments are intentionally selective. They should explain reasons, invariants, security constraints, lifecycle ordering, race protection, or non-obvious compatibility behavior—not restate readable code.
+
+Follow [`docs/03-development/code-commenting-guidelines.md`](./docs/03-development/code-commenting-guidelines.md) when adding or reviewing comments.

--- a/docs/01-overview/project-overview.md
+++ b/docs/01-overview/project-overview.md
@@ -1,0 +1,182 @@
+# Project Overview
+
+## Purpose
+
+SOHO UI is the browser-based administrative frontend for the StoreX storage management system. It gives operators a single interface for observing system health and managing storage, sharing, users, services, network-related settings, and selected system operations.
+
+This repository contains the frontend only. It does not own the underlying storage or operating-system state; it communicates with backend APIs that perform or report those operations.
+
+## Primary responsibilities
+
+The frontend is responsible for:
+
+- authenticating the operator and maintaining the browser session;
+- protecting application routes from unauthenticated access;
+- presenting system and storage state returned by backend APIs;
+- initiating administrative mutations through the API layer;
+- managing client-side server-state caching and refresh behavior;
+- coordinating canonical state snapshots after successful mutations;
+- presenting notifications and global loading/error feedback;
+- providing Persian/RTL administrative UI with light/dark theme support;
+- preventing unsafe duplicate or stale client-side behavior where the frontend owns the lifecycle.
+
+The frontend is not the source of truth for persisted infrastructure state. Backend/system state remains authoritative.
+
+## Main functional areas
+
+The route configuration currently exposes these application areas:
+
+| Area | Route | Primary purpose |
+| --- | --- | --- |
+| Login | `/login` | Authenticate the operator |
+| Dashboard | `/dashboard` | High-level system and storage monitoring |
+| Disks | `/disks` | Inspect and manage disk-related state |
+| Integrated Storage | `/Integrated-space` | Manage integrated/ZFS pool storage |
+| Block Storage | `/block-space` | Manage block-storage volumes |
+| File System | `/file-system` | Manage filesystems and related properties |
+| Services | `/services` | Inspect and control system services |
+| Users | `/users` | Manage supported user domains |
+| Settings | `/settings` | Configure system-level frontend-supported settings |
+| SMB Share | `/share` | Manage Samba/SMB sharing |
+| NFS Share | `/share-nfs` | Manage NFS shares |
+| Web Share | `/web-share` | Manage web-share functionality |
+| History | `/history` | Display historical/audit-oriented UI |
+| SNMP | `/snmp-service` | Inspect and configure SNMP behavior |
+
+All application routes except `/login` are mounted below a protected layout.
+
+## Technology stack
+
+The current frontend stack includes:
+
+- React 19
+- TypeScript 5.8
+- Vite 7
+- React Router 7
+- TanStack React Query 5
+- Axios
+- Material UI 7
+- Zustand 5
+- React Hook Form
+- Zod
+- Tailwind CSS 4
+- Emotion / Styled Components
+- Three.js with React Three Fiber and Drei
+- react-hot-toast
+
+The presence of a dependency does not imply that it is the preferred solution for every new feature. Follow the patterns already established in the relevant feature area unless an architectural change is intentional and documented.
+
+## Runtime ownership model
+
+At runtime, responsibilities are roughly divided as follows:
+
+```mermaid
+flowchart TD
+    User[Operator] --> UI[React UI / Pages]
+    UI --> Hooks[Feature Hooks]
+    Hooks --> RQ[TanStack React Query]
+    Hooks --> API[API Services / Axios]
+    RQ --> API
+    API --> Backend[SOHO Backend APIs]
+
+    Auth[AuthProvider] --> UI
+    Auth --> API
+    Sync[StateSyncManager] --> API
+    Theme[Theme + RTL Providers] --> UI
+```
+
+The diagram is intentionally high level. Detailed ownership is documented in the architecture and core-flow documents.
+
+## Application bootstrap
+
+`src/main.tsx` initializes the application-wide providers in this order:
+
+```text
+StrictMode
+└── AuthProvider
+    └── QueryClientProvider
+        └── Emotion CacheProvider (RTL)
+            └── ThemeProvider
+                └── App
+```
+
+`App` then connects the MUI theme, global toaster, global loader, and router.
+
+This provider structure matters because authentication, query caching, RTL styling, and theme state are cross-cutting concerns used by many otherwise independent feature modules.
+
+## Authentication and session model
+
+Authentication is coordinated through `AuthProvider`, `axiosInstance`, `authApi`, `authEvents`, `tokenStorage`, and the session-activity timeout hook.
+
+Important current contracts:
+
+- the access token is kept in memory rather than persisted to browser storage;
+- the refresh token and username are scoped to `sessionStorage` when available;
+- legacy persisted access-token values are proactively removed;
+- an existing access token is verified before an unnecessary refresh is attempted;
+- if the access token cannot be restored but a refresh token exists, the frontend attempts token refresh;
+- 401 handling in the Axios response interceptor serializes refresh behavior so simultaneous failed requests do not start independent refresh storms;
+- authenticated sessions use an idle-activity timeout;
+- protected routes wait for authentication initialization before redirecting;
+- authentication bypass is allowed only in development when the dedicated environment flag is enabled.
+
+These are security- and lifecycle-sensitive behaviors. Changes require review of the authentication flow documentation and relevant in-code comments.
+
+## Server state and React Query
+
+TanStack React Query owns cached server-state used by the UI.
+
+Current global query defaults include:
+
+- no automatic retry;
+- refetch on mount;
+- no refetch on window focus;
+- no refetch on reconnect;
+- a short stale window;
+- finite query garbage-collection time.
+
+Successful mutations trigger invalidation of active queries at the global mutation-cache level. Failed mutations do not trigger global invalidation.
+
+Feature hooks may define more specific polling or invalidation behavior. The polling audit is the current detailed reference for those exceptions.
+
+## Persistence and canonical state synchronization
+
+One of the most important project-specific contracts is the separation between normal API traffic and persisted state snapshots.
+
+Normal reads, polling requests, route-driven refetches, and mutations are not allowed to directly request database state persistence. They are normalized to `save_to_db=false` by the transport layer.
+
+`StateSyncManager` is the single owner of canonical persisted snapshots. After a successful mutation, the affected state domain or domains are resolved and a canonical GET snapshot is scheduled. These internal snapshot requests are the only requests that are converted to `save_to_db=true`.
+
+This design ensures that the database is updated from authoritative post-operation state rather than from an optimistic or incomplete mutation payload.
+
+The full contract is documented in [`../state-sync-save-to-db.md`](../state-sync-save-to-db.md).
+
+## Polling and refresh behavior
+
+Polling is intentionally selective. Live metrics such as CPU, memory, network bandwidth, and selected storage-health data may poll while their observers are mounted and the tab is visible. Administrative lists that do not need live updates are generally refreshed on mount or after mutation invalidation instead of polling continuously.
+
+The current detailed inventory is documented in [`../api-polling-audit.md`](../api-polling-audit.md).
+
+## UI language and direction
+
+The application is primarily a Persian administrative interface and uses RTL styling support. Source-code identifiers and engineering comments should remain in English so code, library conventions, and technical documentation stay consistent.
+
+User-facing copy may remain Persian where appropriate.
+
+## High-risk areas for future changes
+
+A developer returning to the project should take extra care when modifying:
+
+- `src/lib/axiosInstance.ts` — authentication refresh, transport policy, error handling, state-sync scheduling;
+- `src/lib/stateSyncManager.ts` — persistence ownership, cross-domain dependencies, coalescing, race protection;
+- `src/contexts/AuthContext.tsx` — session restoration, logout behavior, token lifecycle;
+- `src/lib/tokenStorage.ts` — security-sensitive token-storage policy;
+- `src/hooks/useSessionActivityTimeout.ts` — session expiry across reload/focus/visibility changes;
+- global React Query configuration in `src/main.tsx` — cache and refetch behavior across the entire UI;
+- feature mutation hooks that may contain historical/legacy request fields or duplicate invalidation logic.
+
+Before changing one of these areas, read the relevant core-flow documentation and inspect callers rather than treating the file as isolated code.
+
+## Current documentation status
+
+This documentation set is being built incrementally from the current codebase. Existing operational/runtime notes are preserved rather than rewritten prematurely. When a new document supersedes an existing note, the old document should either be migrated with history preserved or replaced by an explicit link to the new source of truth.

--- a/docs/02-architecture/frontend-architecture.md
+++ b/docs/02-architecture/frontend-architecture.md
@@ -1,0 +1,267 @@
+# Frontend Architecture
+
+## Architectural intent
+
+SOHO UI is organized around a React application shell, route-level feature pages, reusable components, feature/data hooks, a centralized HTTP transport, and a small number of cross-cutting providers and managers.
+
+The most important architectural rule is ownership: each class of state or side effect should have one clear owner. Future changes should preserve that ownership unless an intentional architecture decision replaces it.
+
+## Runtime layers
+
+```mermaid
+flowchart TB
+    Browser[Browser]
+
+    subgraph Bootstrap[Application Bootstrap]
+      Main[src/main.tsx]
+      App[src/App.tsx]
+    end
+
+    subgraph CrossCutting[Cross-cutting providers]
+      Auth[AuthProvider]
+      Query[QueryClientProvider]
+      RTL[Emotion RTL Cache]
+      Theme[ThemeProvider]
+    end
+
+    subgraph Routing[Routing and shell]
+      Router[React Router]
+      Guard[ProtectedRoute]
+      Layout[MainLayout]
+    end
+
+    subgraph Features[Feature layer]
+      Pages[Pages]
+      Components[Components]
+      Hooks[Feature Hooks]
+      Store[Zustand UI Store]
+    end
+
+    subgraph Data[Data / integration layer]
+      Services[API service modules]
+      Axios[axiosInstance]
+      Token[tokenStorage]
+      Sync[StateSyncManager]
+    end
+
+    Backend[Backend APIs]
+
+    Browser --> Main --> Auth --> Query --> RTL --> Theme --> App
+    App --> Router --> Guard --> Layout --> Pages
+    Pages --> Components
+    Pages --> Hooks
+    Components --> Hooks
+    Pages --> Store
+    Hooks --> Services
+    Hooks --> Axios
+    Services --> Axios
+    Auth --> Token
+    Auth --> Axios
+    Axios --> Token
+    Axios --> Sync
+    Sync --> Axios
+    Axios --> Backend
+```
+
+## Bootstrap and global providers
+
+`src/main.tsx` creates the application-wide React Query client and mounts the provider chain.
+
+The global QueryClient currently establishes shared defaults for query retry/refetch/staleness behavior. Its `MutationCache` invalidates active queries only after successful mutations.
+
+Because this configuration affects every feature, changes to it should be treated as architectural rather than local optimization.
+
+`src/App.tsx` is intentionally small. It derives the MUI theme from the custom theme context and mounts global UI infrastructure (`AppToaster`, `GlobalLoader`) before the router.
+
+## Routing and application shell
+
+`src/routes/Routes.tsx` is the route map.
+
+`/login` is public. The rest of the application is mounted beneath `ProtectedRoute` and `MainLayout`.
+
+`ProtectedRoute` has three responsibilities:
+
+1. allow a development-only explicit auth bypass;
+2. avoid redirecting while authentication restoration is still running;
+3. redirect unauthenticated users to `/login`.
+
+`MainLayout` is more than visual chrome. It currently owns or coordinates several application-shell behaviors, including:
+
+- navigation drawer state;
+- session idle timeout handling;
+- notification bootstrap;
+- theme controls;
+- user menu/logout interaction;
+- reboot/shutdown confirmation and countdown flow;
+- route outlet rendering.
+
+When adding new global behavior, first decide whether it truly belongs in the application shell. Feature-specific behavior should remain closer to the feature.
+
+## Authentication architecture
+
+Authentication spans several modules rather than one component:
+
+| Module | Responsibility |
+| --- | --- |
+| `src/contexts/AuthContext.tsx` | authenticated React state, session restoration, login/logout orchestration |
+| `src/lib/authApi.ts` | authentication API calls |
+| `src/lib/axiosInstance.ts` | bearer attachment, 401 handling, refresh serialization |
+| `src/lib/authEvents.ts` | communication from transport-level auth events back to React state |
+| `src/lib/tokenStorage.ts` | token/username storage policy |
+| `src/hooks/useSessionActivityTimeout.ts` | inactivity-based session expiry |
+| `src/routes/ProtectedRoute.tsx` | route access decision |
+
+### Token ownership
+
+The access token is deliberately memory-only. The refresh token and username may live in `sessionStorage`.
+
+This division is a security policy, not an incidental implementation detail. Do not move the access token to persistent browser storage merely to simplify reload behavior.
+
+### Session restoration
+
+At startup, `AuthProvider` attempts to restore an existing browser session. In simplified form:
+
+```mermaid
+flowchart TD
+    Start[AuthProvider initializes] --> Idle{Stored session already idle-expired?}
+    Idle -- yes --> Clear[Clear local auth state]
+    Idle -- no --> Access{Stored access token available?}
+    Access -- yes --> Verify[Verify access token]
+    Verify -- valid --> Authenticated[Set authenticated state]
+    Verify -- invalid --> RefreshCheck{Refresh token available?}
+    Access -- no --> RefreshCheck
+    RefreshCheck -- no --> Clear
+    RefreshCheck -- yes --> Refresh[Request new access token]
+    Refresh -- success --> Authenticated
+    Refresh -- failure --> Clear
+    Authenticated --> Baseline[Start one session baseline state sync]
+```
+
+### Concurrent 401 handling
+
+`axiosInstance` serializes access-token refresh. While one refresh request is running, other failed requests are queued. A successful refresh replays the queue with the new access token; a failed refresh clears the session and rejects queued work.
+
+This prevents simultaneous 401 responses from creating a refresh-request storm.
+
+## HTTP transport architecture
+
+`src/lib/axiosInstance.ts` is the shared transport boundary for application API requests.
+
+Its responsibilities currently include:
+
+- API base URL configuration;
+- common JSON headers;
+- optional mock-adapter setup;
+- bearer-token injection;
+- persistence-transport policy (`save_to_db`);
+- successful mutation detection for state synchronization;
+- error logging;
+- 401 refresh/retry behavior;
+- registration of the StateSyncManager HTTP executor.
+
+Because this file combines several global contracts, comments should explain policy and ordering constraints rather than restating individual Axios calls.
+
+## Server-state ownership
+
+TanStack React Query is the primary owner of remote/server state presented by the UI.
+
+Typical feature flow:
+
+```mermaid
+flowchart LR
+    Page[Page / Component] --> Hook[Feature Hook]
+    Hook --> Query[React Query]
+    Query --> API[API function / axiosInstance]
+    API --> Backend[Backend]
+    Backend --> API --> Query --> Page
+```
+
+Feature hooks should define query keys and feature-specific polling/invalidations. Components should avoid building independent request lifecycles when an existing hook already owns the same data.
+
+## Client/UI state ownership
+
+Local component state remains appropriate for transient UI state such as modal visibility, form fields, selected rows, countdowns, and temporary errors.
+
+Zustand is currently used selectively rather than as a universal state container. `src/stores/detailSplitViewStore.ts` is an example of shared UI state that benefits from surviving across related component boundaries.
+
+Do not move server state into Zustand merely because multiple components consume it; React Query already owns that category of state.
+
+## Persistence state synchronization
+
+Persistence synchronization is deliberately separated from normal fetching and mutation code.
+
+### Why
+
+The backend database should receive a snapshot of the authoritative post-operation system state rather than a mutation payload that may be partial, normalized differently by the backend, or followed by secondary system changes.
+
+### Ownership
+
+`src/lib/stateSyncManager.ts` owns:
+
+- the set of persisted state domains;
+- each domain's canonical GET snapshot endpoint;
+- mutation URL to affected-domain mapping;
+- mutation coalescing delay;
+- per-domain in-flight protection;
+- one follow-up sync when a new mutation occurs during an active snapshot;
+- one baseline sync per authenticated session.
+
+`axiosInstance` owns enforcing the transport-level rule that normal API requests use `save_to_db=false` and only internal canonical state-sync requests can become `save_to_db=true`.
+
+### Mutation lifecycle
+
+```mermaid
+flowchart TD
+    Action[User performs mutation] --> Mutation[POST / PUT / PATCH / DELETE]
+    Mutation --> Backend[Backend operation]
+    Backend --> Success{Succeeded?}
+    Success -- no --> Error[Surface error; no state snapshot scheduled]
+    Success -- yes --> Invalidate[React Query invalidates active UI queries]
+    Success -- yes --> Resolve[Resolve affected persisted domains]
+    Resolve --> Coalesce[Coalesce rapid mutations per domain]
+    Coalesce --> Snapshot[Canonical GET snapshot]
+    Snapshot --> Persist[Transport marks snapshot save_to_db=true]
+```
+
+The React Query refresh path and persistence snapshot path are related but separate responsibilities.
+
+## Polling architecture
+
+Polling is feature-specific and must be justified by the freshness requirement of the data.
+
+Live operational metrics may poll frequently. Static administrative lists generally should not.
+
+Polling should normally stop when its observer is unmounted and should not continue in a background tab unless there is a documented reason.
+
+See [`../api-polling-audit.md`](../api-polling-audit.md) for the current endpoint-level behavior.
+
+## Error and feedback surfaces
+
+The project uses several layers of feedback:
+
+- transport-level error logging utilities;
+- mutation/query error states inside hooks;
+- global loading UI;
+- toast notifications for user-facing outcomes;
+- feature-specific validation messages.
+
+Do not make the transport layer responsible for every user-facing error message. The layer that has enough business context to explain the failure should own presentation.
+
+## RTL and theme architecture
+
+RTL support is configured through an Emotion cache and the application theme. Theme state is provided through `ThemeContext`, while `App` converts that state into the active MUI theme.
+
+This is cross-cutting UI infrastructure. Directional styling fixes should prefer theme/RTL-aware solutions over one-off hardcoded left/right assumptions.
+
+## Architecture change rule
+
+A change should be accompanied by an Architecture Decision Record (ADR) when it intentionally changes a system-level ownership rule or long-lived architectural choice, for example:
+
+- replacing React Query as server-state owner;
+- changing token persistence policy;
+- moving persistence snapshots out of StateSyncManager;
+- introducing a second HTTP client with different interceptor behavior;
+- changing routing/access-control strategy;
+- adding a new global state-management system.
+
+Small implementation changes that preserve existing ownership do not need an ADR.

--- a/docs/03-development/code-commenting-guidelines.md
+++ b/docs/03-development/code-commenting-guidelines.md
@@ -1,0 +1,461 @@
+# Code Commenting Guidelines
+
+## Purpose
+
+Comments in SOHO UI exist to preserve reasoning that the code alone cannot communicate safely.
+
+The project does **not** aim for a high comment count. Clean code should remain readable through naming, structure, types, and small focused functions. A comment is justified when it preserves intent, constraints, risk, or historical context that a future maintainer could otherwise misinterpret.
+
+The core rule is:
+
+> Code should explain **what** and **how**. Comments should explain **why**, **constraints**, and **surprises**.
+
+## Language
+
+Engineering comments in source files should be written in English.
+
+Reasons:
+
+- source identifiers and library APIs are English;
+- existing high-value comments are already English;
+- one language reduces maintenance friction across the codebase;
+- technical terms do not need repeated translation.
+
+User-facing UI text may remain Persian.
+
+## The decision process before adding a comment
+
+Before writing a comment, use this sequence:
+
+```text
+Can the code be understood without a comment?
+│
+├── Yes → Do not add one.
+│
+└── No
+    │
+    ├── Is the code unnecessarily complicated?
+    │   ├── Yes → Refactor first.
+    │   └── No
+    │
+    └── Would the reason/constraint/side effect be easy to forget?
+        ├── No → Prefer clearer code.
+        └── Yes → Add a concise comment.
+```
+
+A comment must not become a substitute for refactoring.
+
+## Good comment categories
+
+### 1. Architectural contracts
+
+Use comments to protect global invariants that are not obvious from an individual statement.
+
+Good example from the transport/state-sync design:
+
+```ts
+/**
+ * Persistence contract:
+ * - normal API requests never persist snapshots;
+ * - only StateSyncManager may request save_to_db=true;
+ * - stale caller-level flags must not bypass the transport policy.
+ */
+```
+
+This comment is useful because removing or bypassing the behavior would change a system-wide persistence contract.
+
+### 2. Security-sensitive decisions
+
+Security behavior often looks simpler if a future developer removes it. Preserve the reason.
+
+Example:
+
+```ts
+// Access tokens remain memory-only. Persist only the refresh token for the
+// current browser session so a reload can restore authentication without
+// leaving the bearer token in persistent browser storage.
+```
+
+Do not write a security comment unless the code actually enforces the statement.
+
+### 3. Ordering and lifecycle constraints
+
+Use a comment when order is part of correctness.
+
+Example:
+
+```ts
+// Clear local auth state before notifying the backend so protected routes are
+// inaccessible even when the logout endpoint is slow or unavailable.
+clearAuthState();
+```
+
+Without the comment, a maintainer might move `clearAuthState()` after the request and unintentionally change failure behavior.
+
+### 4. Race-condition and concurrency protection
+
+If code exists to prevent duplicate work, stale overwrites, request storms, or re-entrancy, document the invariant rather than every branch.
+
+Example:
+
+```ts
+/**
+ * Coalesces rapid mutations into one canonical snapshot. If another mutation
+ * arrives while the snapshot is running, queue exactly one follow-up run so
+ * persisted state converges to the newest observed system state.
+ */
+```
+
+### 5. Business rules whose reason is not obvious
+
+Prefer expressive code first. Add a comment only when the rule's origin or reason is not evident.
+
+Weak:
+
+```ts
+// Mirror requires an even number of disks.
+if (count % 2 !== 0) { ... }
+```
+
+Better when domain context matters:
+
+```ts
+// The backend models MIRROR vdevs as disk pairs; reject an unmatched device
+// here so the user receives validation before the create request is sent.
+```
+
+If the rule is already self-explanatory and stable, no comment is needed.
+
+### 6. Compatibility and migration behavior
+
+Temporary compatibility logic must explain when it can be removed.
+
+Example:
+
+```ts
+// Compatibility: older callers may still include save_to_db in mutation
+// payloads. Force it to false here until those legacy payload fields have been
+// removed from all hooks.
+```
+
+When the compatibility code is removed, the comment must be removed with it.
+
+### 7. Non-obvious browser/framework behavior
+
+Document behavior that exists because of React StrictMode, browser lifecycle, storage availability, visibility changes, or library-specific semantics.
+
+Example:
+
+```ts
+// Reuse the same baseline promise so React StrictMode and repeated auth renders
+// cannot start multiple full state snapshots in one authenticated session.
+```
+
+## Comments that should usually be rejected
+
+### Restating the code
+
+Bad:
+
+```ts
+// Set authenticated to true.
+setIsAuthenticated(true);
+```
+
+Bad:
+
+```ts
+// Loop through domains.
+domains.forEach(...);
+```
+
+Bad:
+
+```ts
+// Return if there is an error.
+if (hasError) return;
+```
+
+These comments increase noise and become stale easily.
+
+### Decorative section comments
+
+Avoid large files split by comments such as:
+
+```ts
+// =============================
+// FUNCTIONS
+// =============================
+```
+
+If a file needs many visual sections, it may be carrying too many responsibilities. Prefer extraction and better naming.
+
+### Explaining bad names
+
+Bad:
+
+```ts
+// x is the number of selected disks.
+const x = selectedDevices.length;
+```
+
+Fix the code:
+
+```ts
+const selectedDeviceCount = selectedDevices.length;
+```
+
+### Explaining dead or commented-out code
+
+Do not keep old implementations commented out. Git already stores history.
+
+Bad:
+
+```ts
+// const oldRequest = ...
+// We used this before the backend change.
+```
+
+Delete it. If the decision matters long term, record it in an ADR or migration note.
+
+### Comments that contradict code
+
+A comment is not allowed to make incorrect code appear intentional.
+
+For example, if a feature hook still sends a legacy field that the transport layer overrides, do not add:
+
+```ts
+// This is true here, but axios changes it to false later.
+save_to_db: true,
+```
+
+Prefer removing the obsolete field so code and architecture agree.
+
+## JSDoc policy
+
+JSDoc is useful for exported behavior with a non-trivial contract. It is not required for every function.
+
+### Good JSDoc targets
+
+Use JSDoc for:
+
+- exported infrastructure functions with lifecycle guarantees;
+- utilities with non-obvious input/output semantics;
+- functions where callers must respect important constraints;
+- public reusable hooks whose behavior is not clear from the type signature;
+- concurrency/state synchronization functions;
+- functions with meaningful side effects that are easy to miss.
+
+Example:
+
+```ts
+/**
+ * Runs the canonical baseline snapshot once per authenticated session.
+ * Repeated callers reuse the same promise until the session is reset.
+ */
+export const syncAllStateDomainsOnce = () => { ... };
+```
+
+### Poor JSDoc targets
+
+Do not add this:
+
+```ts
+/** Returns the normalized path. */
+const normalizePath = (url: string) => ...;
+```
+
+The name and type already explain it.
+
+Do not generate boilerplate such as `@param` and `@returns` when TypeScript already carries the same information and there is no extra semantic contract.
+
+## TODO and FIXME policy
+
+Unqualified TODOs are not acceptable.
+
+Bad:
+
+```ts
+// TODO: fix this
+```
+
+Bad:
+
+```ts
+// TODO later
+```
+
+A TODO/FIXME must explain:
+
+1. what remains to be changed;
+2. why it cannot be done now;
+3. what condition or tracked work allows its removal.
+
+Preferred form:
+
+```ts
+// TODO(#142): Remove this compatibility branch after legacy API responses are
+// no longer supported by the backend.
+```
+
+If no issue exists, use enough searchable context to make the TODO actionable:
+
+```ts
+// TODO: Remove this legacy payload field after all create-pool requests have
+// migrated to the transport-owned state-sync contract.
+```
+
+Use `FIXME` only when the current implementation is known to be incorrect or unsafe, not as a stronger synonym for TODO.
+
+## File-level comments
+
+Do not add a file header that merely repeats the filename.
+
+Bad:
+
+```ts
+// This file handles authentication.
+```
+
+A file-level comment is justified only when the module has a non-obvious contract that applies to most of its contents.
+
+For example, `axiosInstance.ts` may justify a short policy comment around the persistence transport boundary because many helper functions exist solely to enforce that policy.
+
+## React-specific guidance
+
+### Components
+
+Do not comment JSX layout that is visually obvious.
+
+Bad:
+
+```tsx
+{/* Header */}
+<AppBar>...</AppBar>
+```
+
+A comment can be useful when conditional rendering is based on a non-obvious lifecycle or browser constraint.
+
+### Effects
+
+A `useEffect` should ideally be understandable from extracted function names and dependencies. Comment the effect when the synchronization reason is not obvious.
+
+Good example concept:
+
+```ts
+// Re-check the persisted idle timestamp when the tab becomes visible because
+// background timer throttling must not let an expired session become active.
+```
+
+### Refs
+
+Comment a ref when it is being used to enforce lifecycle correctness rather than simply store a DOM node.
+
+Examples include preventing duplicate timeout execution, storing the latest callback without re-registering listeners, or guarding concurrent work.
+
+### React Query
+
+Document unusual query options only when they differ intentionally from project defaults for a domain reason.
+
+Weak:
+
+```ts
+// Poll every 2 seconds.
+refetchInterval: 2000,
+```
+
+Better:
+
+```ts
+// CPU is a live dashboard metric; keep the 2s cadence only while the widget is
+// observed. Background-tab polling remains disabled by the global policy.
+refetchInterval: 2000,
+```
+
+For widespread polling rules, prefer the polling documentation over repeating the same comment in every hook.
+
+## API and mutation hooks
+
+Mutation hooks deserve comments when they contain ordering, dependency, or compatibility behavior.
+
+Before adding comments, verify that the hook is not duplicating global responsibilities already owned by:
+
+- `axiosInstance`;
+- the global `MutationCache`;
+- `StateSyncManager`;
+- shared error utilities.
+
+If the hook contains a legacy field that the transport discards or overrides, prefer removing the field over explaining the mismatch.
+
+## Comment placement
+
+Place the comment as close as possible to the code whose intent it protects.
+
+Prefer:
+
+```ts
+// Clear local state first so route access is revoked even if server logout fails.
+clearAuthState();
+await logoutRequest(refreshToken);
+```
+
+Over a distant paragraph at the top of a long file.
+
+For a multi-function module-wide invariant, use one focused block comment near the policy boundary instead of duplicating it at every call site.
+
+## Comment maintenance rule
+
+Comments are part of the code.
+
+When changing the associated behavior:
+
+- update the comment in the same commit;
+- delete comments that are no longer true;
+- do not leave historical descriptions attached to new logic;
+- verify links/issue references still make sense.
+
+An outdated comment is usually more dangerous than no comment.
+
+## Comment review checklist
+
+During review, ask:
+
+- Does this comment explain something the code cannot express clearly?
+- Does it capture a reason, invariant, constraint, side effect, or risk?
+- Can clearer naming/refactoring remove the need for it?
+- Is it accurate for the current code, not a previous version?
+- Is it located next to the behavior it protects?
+- Will it still be useful to a developer returning in six months?
+- Is a repository document or ADR a better home because the information spans multiple files?
+
+If the answer to the usefulness question is no, remove the comment.
+
+## When to use docs or ADRs instead
+
+Use an in-code comment when the information protects a local implementation decision.
+
+Use a documentation page when the information explains a flow across multiple modules.
+
+Use an ADR when the information explains why the system chose one long-lived architecture option over alternatives.
+
+Example:
+
+```text
+Why clear auth state before server logout?
+→ In-code comment + authentication flow doc.
+
+How does authentication work across AuthContext, Axios, tokenStorage and routes?
+→ Core-flow documentation.
+
+Why are access tokens memory-only instead of localStorage?
+→ Security comment + authentication ADR if the decision needs formal history.
+```
+
+## Definition of done for comments
+
+A source-code change is not complete if it introduces non-obvious policy, security behavior, race protection, compatibility logic, or lifecycle ordering without either:
+
+- making the intent obvious through code structure; or
+- adding the minimum useful comment that preserves the reason.
+
+The reverse is also true: a change is not complete if it leaves obsolete comments behind.

--- a/docs/03-development/project-structure.md
+++ b/docs/03-development/project-structure.md
@@ -1,0 +1,288 @@
+# Project Structure
+
+## Purpose
+
+This document explains where responsibilities live in the repository and where to start when changing behavior. It is intended as a navigation guide, not a generated directory listing.
+
+## Top-level structure
+
+```text
+Soho_UI/
+├── docs/                  Engineering and runtime documentation
+├── public/                Static assets served directly by Vite
+├── src/                   Application source code
+├── index.html             Vite HTML entry
+├── package.json           Scripts and dependency declarations
+├── vite.config.ts         Vite configuration
+├── tsconfig*.json         TypeScript configuration
+├── eslint.config.js       ESLint configuration
+└── .prettierrc            Formatting configuration
+```
+
+`repomix-output.xml` is a generated repository snapshot and should not be treated as a source-of-truth implementation file.
+
+## `src/` responsibility map
+
+The source tree currently contains these major areas:
+
+```text
+src/
+├── @types/        Shared TypeScript declarations
+├── assets/        Source-managed visual/static assets
+├── components/    Reusable UI and application-shell components
+├── config/        Declarative UI/configuration structures
+├── constants/     Shared labels, options, limits, and static mappings
+├── contexts/      React context providers for cross-cutting state/actions
+├── hooks/         Feature/data/action hooks and reusable React behavior
+├── lib/           Integration and infrastructure modules
+├── mock/          Legacy/feature mock material where present
+├── mocks/         Mock API setup and fixtures
+├── pages/         Route-level page components
+├── routes/        Router definition and access-control wrappers
+├── schemas/       Validation/data schemas
+├── stores/        Shared client/UI stores
+├── utils/         General-purpose utilities
+├── App.tsx        Application composition below global providers
+├── main.tsx       Browser bootstrap and global provider setup
+├── index.css      Global CSS
+└── rtl-cache.ts   Emotion cache used for RTL styling
+```
+
+## Entry points
+
+### `src/main.tsx`
+
+Start here when changing application-wide provider behavior, React Query defaults, or bootstrap ordering.
+
+Current provider chain:
+
+```text
+StrictMode
+└── AuthProvider
+    └── QueryClientProvider
+        └── CacheProvider (RTL)
+            └── ThemeProvider
+                └── App
+```
+
+Changes here can affect the entire application and should be reviewed as cross-cutting changes.
+
+### `src/App.tsx`
+
+Start here when changing application-global rendering infrastructure such as the MUI theme integration, global toaster, global loader, or router mounting.
+
+This file should remain composition-oriented rather than accumulating feature logic.
+
+## Routing
+
+### `src/routes/Routes.tsx`
+
+This is the route map and the fastest source of truth for route-level feature entry points.
+
+Use it when:
+
+- adding/removing a page route;
+- locating the page component responsible for a URL;
+- checking whether a route is protected;
+- reviewing naming/case of existing paths.
+
+### `src/routes/ProtectedRoute.tsx`
+
+Owns authenticated access gating for the protected application tree.
+
+Do not duplicate route-auth checks in every page. If access policy becomes more complex (roles/permissions), evolve the routing/access-control layer deliberately.
+
+## Pages
+
+`src/pages/` contains route-level composition components.
+
+A page should primarily:
+
+- compose feature components;
+- connect route-level state;
+- invoke feature hooks;
+- coordinate page-specific presentation behavior.
+
+A page should not become the default location for reusable API logic, token handling, or cross-feature infrastructure.
+
+Current route-level pages include:
+
+- Dashboard
+- Disks
+- IntegratedStorage
+- BlockStorage
+- FileSystem
+- Services
+- Users
+- Settings
+- Share (SMB/Samba)
+- ShareNfs
+- WebShare
+- History
+- SnmpService
+- LoginPage
+- NotFoundPage
+
+Some files in `pages/` may be historical or no longer routed. Confirm usage through `Routes.tsx` before assuming a page is active.
+
+## Components
+
+`src/components/` contains reusable UI components and several application-shell concerns.
+
+`MainLayout.tsx` is a special case: it is the protected application shell and currently coordinates navigation, notifications, idle-session handling, theme controls, and system power-action UI.
+
+When changing a component, determine whether it is:
+
+1. purely presentational;
+2. feature-specific but reusable within one domain;
+3. application-shell/global infrastructure.
+
+The wider the category, the more important it is to inspect downstream callers before changing behavior.
+
+## Hooks
+
+`src/hooks/` is a major behavior layer in the application.
+
+Hooks currently cover categories such as:
+
+- server-state queries;
+- create/update/delete mutations;
+- storage/pool/filesystem operations;
+- sharing and user-management operations;
+- system/network/SNMP configuration;
+- session/activity behavior;
+- reusable feature UI state.
+
+### Hook design expectations
+
+A feature hook may own:
+
+- query/mutation configuration;
+- feature-level form/action state;
+- validation needed to prepare a request;
+- query-key invalidation specific to the feature;
+- transformation of API errors into feature-meaningful errors.
+
+A hook should not bypass shared infrastructure such as `axiosInstance` or independently implement token refresh.
+
+### Before changing a mutation hook
+
+Check all of the following:
+
+1. Which endpoint does it call?
+2. Does `axiosInstance` already apply a global policy to that request?
+3. Which React Query keys are invalidated locally?
+4. Which persisted state domains will `StateSyncManager` schedule after success?
+5. Does the payload contain a legacy field that the transport layer now overrides?
+6. Does the hook contain business validation that should be preserved or moved to a shared utility/schema?
+
+This check is especially important because the repository has evolved over time and some hooks may still contain fields retained from older API/persistence behavior.
+
+## Contexts
+
+`src/contexts/` currently includes cross-cutting React contexts such as:
+
+- `AuthContext` — authenticated session state/actions;
+- `ThemeContext` — theme state;
+- `SystemPowerActionsContext` — shared access to guarded reboot/shutdown actions.
+
+Use a context only when React-tree-wide access is part of the responsibility. Do not create a context solely to avoid passing a prop through one or two nearby components.
+
+## Infrastructure and API integration (`src/lib/`)
+
+This directory contains some of the highest-impact code in the frontend.
+
+### Authentication / transport
+
+- `authApi.ts`
+- `authEvents.ts`
+- `axiosInstance.ts`
+- `tokenStorage.ts`
+
+### Storage/integration services
+
+Examples include:
+
+- `diskApi.ts`
+- `diskMaintenance.ts`
+- `diskPartitions.ts`
+- `poolDevices.ts`
+- `shareService.ts`
+- `sambaUserService.ts`
+- `sambaGroupService.ts`
+
+### State persistence coordination
+
+- `stateSyncManager.ts`
+
+Treat `axiosInstance.ts`, `tokenStorage.ts`, and `stateSyncManager.ts` as infrastructure contracts. A seemingly small change may affect all features.
+
+## Stores
+
+`src/stores/` is currently used selectively for shared client/UI state. It is not the owner of remote backend state.
+
+Before creating a new Zustand store, ask:
+
+- Is this actually server state? If yes, React Query is usually the correct owner.
+- Is this transient local state? If yes, component/hook state may be enough.
+- Must multiple distant components share this client-only state? If yes, a store may be justified.
+
+## Constants, config, schemas, and utilities
+
+### `src/constants/`
+
+Use for stable shared mappings/options/labels that are not runtime state. Current examples include CPU/memory metadata, disk-related constants, navigation definitions, service labels, settings constants, and VDEV-related values.
+
+Do not hide mutable business behavior in a file merely because it is named `constants`.
+
+### `src/config/`
+
+Use for declarative configuration that drives behavior/layout. `detailLayouts.ts` is the current example.
+
+### `src/schemas/`
+
+Use for reusable structured validation and schema definitions.
+
+### `src/utils/`
+
+Use for context-free or low-context utility functions. If a utility needs extensive knowledge of one feature's lifecycle, it probably belongs closer to that feature instead.
+
+## Mocks
+
+The application can enable an Axios mock adapter through environment configuration. Mock behavior should remain clearly separated from production transport behavior.
+
+When debugging an unexpected API response, first verify whether mock mode is enabled before assuming the backend returned the data.
+
+## Documentation
+
+`docs/` is part of the maintained codebase.
+
+When changing a documented contract, update the relevant document in the same pull request.
+
+Important current documents:
+
+- project overview;
+- frontend architecture;
+- code commenting guidelines;
+- state synchronization contract;
+- polling audit;
+- notifications/data refresh notes;
+- general settings notes.
+
+## Where to start for common changes
+
+| Change | Start here | Then inspect |
+| --- | --- | --- |
+| Add a route/page | `src/routes/Routes.tsx` | target page, `MainLayout` if shell behavior is involved |
+| Change login/session behavior | `src/contexts/AuthContext.tsx` | `authApi`, `axiosInstance`, `tokenStorage`, `ProtectedRoute`, idle-timeout hook |
+| Change API base/transport behavior | `src/lib/axiosInstance.ts` | all shared interceptors and state-sync contract |
+| Change persistence snapshots | `src/lib/stateSyncManager.ts` | `axiosInstance`, `docs/state-sync-save-to-db.md` |
+| Change polling | relevant query hook | `docs/api-polling-audit.md`, page/component observers |
+| Add a mutation | relevant feature hook | endpoint ownership, query invalidation, state-sync domain mapping |
+| Add global client state | existing owner first | context/store justification |
+| Change theme/RTL | `ThemeContext`, `theme`, `rtl-cache.ts` | global CSS and MUI directional assumptions |
+| Change system power actions | `MainLayout` / `usePowerAction` | `SystemPowerActionsContext`, confirmation/countdown components |
+
+## Keep the map current
+
+This document should evolve when responsibility moves between directories or when a new architectural layer is introduced. It should not be edited for every new component or filename.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,102 @@
+# SOHO UI Documentation
+
+This directory is the source of truth for understanding, maintaining, and extending the SOHO frontend.
+
+The goal is not to document every line of code. The goal is to preserve the knowledge that is expensive to rediscover: system boundaries, architectural decisions, runtime flows, business rules, operational constraints, and non-obvious implementation details.
+
+## How to use these docs
+
+If you return to the project after a long break, read the documents in this order:
+
+1. [`01-overview/project-overview.md`](./01-overview/project-overview.md) — what the application is and what it is responsible for.
+2. [`02-architecture/frontend-architecture.md`](./02-architecture/frontend-architecture.md) — how the frontend is structured at runtime.
+3. [`03-development/project-structure.md`](./03-development/project-structure.md) — where code belongs and where to start when changing a feature.
+4. [`03-development/code-commenting-guidelines.md`](./03-development/code-commenting-guidelines.md) — the project rules for useful in-code comments.
+5. The relevant feature or flow document before modifying behavior that crosses multiple modules.
+
+## Documentation map
+
+### Overview
+
+- [`01-overview/project-overview.md`](./01-overview/project-overview.md)
+
+### Architecture
+
+- [`02-architecture/frontend-architecture.md`](./02-architecture/frontend-architecture.md)
+
+### Development
+
+- [`03-development/project-structure.md`](./03-development/project-structure.md)
+- [`03-development/code-commenting-guidelines.md`](./03-development/code-commenting-guidelines.md)
+
+### Existing runtime notes
+
+The following documents predate this documentation structure and contain important implementation details. They remain valid references until they are reorganized into the final structure:
+
+- [`api-polling-audit.md`](./api-polling-audit.md)
+- [`general-settings.md`](./general-settings.md)
+- [`notifications-and-data-refresh.md`](./notifications-and-data-refresh.md)
+- [`state-sync-save-to-db.md`](./state-sync-save-to-db.md)
+
+## Documentation principles
+
+### Document decisions, not syntax
+
+The code already shows how a local variable is assigned or how a component renders. Documentation should instead answer questions such as:
+
+- Why is this flow designed this way?
+- Which module owns this responsibility?
+- What invariants must remain true when the implementation changes?
+- Which other domains are affected by this mutation?
+- What is the expected lifecycle of this data?
+- Which behavior is intentional even if it looks unusual?
+
+### Keep one source of truth
+
+Do not duplicate detailed behavior in multiple places. A high-level document should link to a detailed flow document instead of restating its full contract.
+
+### Update docs with behavior changes
+
+A change is not complete when it modifies a documented architectural contract, business rule, runtime flow, API convention, or operational procedure without updating the corresponding documentation.
+
+### Prefer diagrams for flows
+
+Use Mermaid diagrams when ordering, ownership, or dependencies are easier to understand visually than as prose.
+
+## Planned structure
+
+The documentation will progressively evolve toward this layout:
+
+```text
+docs/
+├── index.md
+├── 01-overview/
+│   ├── project-overview.md
+│   ├── scope.md
+│   └── glossary.md
+├── 02-architecture/
+│   ├── frontend-architecture.md
+│   ├── runtime-flow.md
+│   ├── data-flow.md
+│   └── decisions/
+├── 03-development/
+│   ├── getting-started.md
+│   ├── project-structure.md
+│   ├── configuration.md
+│   ├── coding-conventions.md
+│   ├── code-commenting-guidelines.md
+│   └── testing.md
+├── 04-core-flows/
+│   ├── authentication.md
+│   ├── routing-and-access-control.md
+│   ├── api-request-lifecycle.md
+│   ├── server-state-and-cache.md
+│   ├── state-sync-save-to-db.md
+│   ├── polling-and-data-refresh.md
+│   └── notifications.md
+├── 05-features/
+├── 06-api/
+└── 07-operations/
+```
+
+This structure is intentionally introduced incrementally. Existing useful documentation should be preserved and migrated only when its new location and ownership are clear.

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -9,6 +9,9 @@ interface ProtectedRouteProps {
 const isTruthyEnv = (value: unknown) =>
   ['1', 'true', 'yes', 'on'].includes(String(value ?? '').trim().toLowerCase());
 
+// Keep the bypass impossible in production even if VITE_AUTH_BYPASS is
+// accidentally present in a production environment. It exists only to unblock
+// explicit local development workflows.
 const SHOULD_BYPASS_AUTH =
   import.meta.env.DEV && isTruthyEnv(import.meta.env.VITE_AUTH_BYPASS);
 


### PR DESCRIPTION
## What changed

- turned the root README into a clear repository landing page and documentation entry point
- added `docs/index.md` with the documentation reading order, principles, and planned structure
- added a project overview describing scope, routes, runtime responsibilities, authentication/session behavior, React Query ownership, and persistence rules
- added a frontend architecture document with Mermaid diagrams and module ownership boundaries
- added a project-structure guide focused on where to start for common maintenance tasks
- added Clean Code-based source-comment guidelines covering architectural, security, lifecycle, concurrency, business-rule, JSDoc, TODO/FIXME, React, and API/mutation comments
- added one high-value security comment to `ProtectedRoute` explaining why the development auth bypass is gated by `import.meta.env.DEV`

## Why

The repository already contained useful implementation notes, but they were not organized as a documentation system. The README was primarily an installation/deployment note, and there was no project-wide standard for preserving non-obvious reasoning inside source files.

This PR establishes a documentation foundation intended to make the project understandable after long periods away from the codebase without turning comments into line-by-line narration.

## Behavior impact

No runtime behavior is intentionally changed by this PR. The only TypeScript change is a comment in `ProtectedRoute.tsx`.

## Validation

- compared `agent/documentation-foundation` against `main`
- branch is ahead of `main` with no divergence
- verified the new documentation index and README directly from the branch
- no build/test run was required because executable code was not changed

## Follow-up audit finding

`src/hooks/useCreatePool.ts` still includes a legacy `save_to_db: true` payload field even though the centralized Axios transport policy forces normal mutations to `save_to_db=false` and `StateSyncManager` owns canonical persistence snapshots. This PR documents the ownership rule but deliberately does not mix that cleanup into the documentation-only change.

A follow-up code-maintenance PR should remove/normalize legacy caller-level persistence fields and continue the focused comment audit across complex hooks and infrastructure code.